### PR TITLE
Fix security findings from audit: core lifecycle, state honesty, shell quoting

### DIFF
--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -5,13 +5,15 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{mpsc, Arc, Mutex, MutexGuard},
     thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tauri::{AppHandle, Emitter, Manager, State};
 
 const MAX_LOGS: usize = 1_000;
+/// Matches the timeout `scripts/stage-core.mjs` already applies to the same `--version` call.
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -144,8 +146,10 @@ impl CoreProfile {
                 .parse::<IpAddr>()
                 .map_err(|_| format!("invalid DNS resolver: {resolver}"))?;
         }
-        validate_range("fragment size", &self.fragment_size, 1_500)?;
-        validate_range("fragment delay", &self.fragment_delay, 10_000)?;
+        // Minimum is per-field: a fragment size of 0 silently disables the fragmentation the UI
+        // still shows as enabled, but a delay of 0 ("no inter-write pause") is legitimate.
+        validate_range("fragment size", &self.fragment_size, 1, 1_500)?;
+        validate_range("fragment delay", &self.fragment_delay, 0, 10_000)?;
         validate_peer("peer", self.peer.as_deref())?;
         validate_peer("WireGuard peer", self.wg_peer.as_deref())?;
         validate_peer("HTTP/2 peer", self.h2_peer.as_deref())?;
@@ -508,8 +512,15 @@ fn spawn_log_reader<R: Read + Send + 'static>(
     stream: &'static str,
 ) {
     thread::spawn(move || {
-        for line in BufReader::new(reader).lines().map_while(Result::ok) {
-            record_log(&app, &inner, stream, line);
+        for line in BufReader::new(reader).lines() {
+            match line {
+                Ok(line) => record_log(&app, &inner, stream, line),
+                // Skip an undecodable line, do not end the stream. map_while(Result::ok) stopped
+                // the whole reader on the first non-UTF-8 byte, which silently froze every piece
+                // of state this stream feeds — including the only path out of "connected".
+                Err(error) if error.kind() == std::io::ErrorKind::InvalidData => continue,
+                Err(_) => break,
+            }
         }
     });
 }
@@ -538,6 +549,11 @@ fn spawn_exit_monitor(app: AppHandle, inner: Arc<SupervisorInner>) {
         let Some(exit) = exit else { continue };
         let mut snapshot = lock(&inner.snapshot);
         snapshot.pid = None;
+        // Match stop_inner and clear the route fields too. Leaving them set showed a live
+        // transport, edge IP and latency next to a dead core.
+        snapshot.transport = None;
+        snapshot.endpoint = None;
+        snapshot.latency_ms = None;
         match exit {
             Ok(status) if status.success() => snapshot.state = "stopped".into(),
             Ok(status) => {
@@ -571,8 +587,14 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     let _ = app.emit("core-log", &event);
 
     let mut snapshot = lock(&inner.snapshot);
-    apply_log_to_snapshot(&event.message, &mut snapshot);
-    emit_snapshot(app, &snapshot);
+    // Once the core is gone, buffered lines still draining from the pipe must not resurrect a
+    // live-looking state. pid is already the terminal marker — both stop_inner and the exit
+    // monitor clear it — so one guard here covers the stop path and the crash path together.
+    // Lines still reach the Diagnostics stream above; they just stop driving security state.
+    if snapshot.pid.is_some() {
+        apply_log_to_snapshot(&event.message, &mut snapshot);
+        emit_snapshot(app, &snapshot);
+    }
 }
 
 fn apply_log_to_snapshot(message: &str, snapshot: &mut CoreSnapshot) {
@@ -595,22 +617,37 @@ fn apply_log_to_snapshot(message: &str, snapshot: &mut CoreSnapshot) {
     if let Some(latency) = parse_latency_ms(message) {
         snapshot.latency_ms = Some(latency);
     }
-    if message.contains("socks5 server listening on") || message.contains("socks5 listening on") {
-        snapshot.state = "connected".into();
-        if let Some(address) = message.split("listening on ").nth(1) {
-            snapshot.socks_address = address
-                .split_whitespace()
-                .next()
-                .unwrap_or(address)
-                .to_string();
+    // Three guards so a bind FAILURE cannot read as a success: no failure wording on the line;
+    // the address comes from the gate we actually matched (a bare "listening on " picked up a
+    // different listener earlier in the line); and it must parse, as parse_endpoint already requires.
+    // Errs toward not-connected, which is the safe direction for this indicator.
+    // ponytail: matching prose is the wrong contract. Ceiling is the core emitting structured
+    // events, or probing the SOCKS port here before believing it is up.
+    const LISTEN_GATES: [&str; 2] = ["socks5 server listening on ", "socks5 listening on "];
+    const FAILURE_MARKERS: [&str; 7] = [
+        "failed", "could not", "cannot", "unable to", "refused", "already in use", "error",
+    ];
+    let lowered = message.to_ascii_lowercase();
+    if !FAILURE_MARKERS.iter().any(|marker| lowered.contains(marker)) {
+        for gate in LISTEN_GATES {
+            let Some(rest) = message.split(gate).nth(1) else {
+                continue;
+            };
+            if let Some(candidate) = rest.split_whitespace().next() {
+                if candidate.parse::<SocketAddr>().is_ok() {
+                    snapshot.socks_address = candidate.to_string();
+                    snapshot.state = "connected".into();
+                }
+            }
+            break;
         }
     }
     if message.contains("reconnecting") {
         snapshot.state = "reconnecting".into();
     }
-    if (message.contains(" ERROR ") || message.starts_with("ERROR"))
-        && !message.contains("reconnecting")
-    {
+    // An error and a reconnect are orthogonal: excluding "reconnecting" here hid the most
+    // common phrasing for a failed retry ("... FAILED, reconnecting") from every UI surface.
+    if message.contains(" ERROR ") || message.starts_with("ERROR") {
         snapshot.last_error = Some(strip_logger_prefix(message));
     }
 }
@@ -711,9 +748,12 @@ fn resolve_core_path(app: &AppHandle, requested: Option<&str>) -> Result<PathBuf
         if !candidate.is_file() {
             continue;
         }
-        let canonical = candidate
-            .canonicalize()
-            .map_err(|error| format!("cannot resolve core path: {error}"))?;
+        // Skip a candidate we cannot resolve rather than abandoning the search: `?` here let one
+        // unusable entry (a path unlinked between is_file and canonicalize) deny core discovery
+        // entirely, even though a perfectly good sidecar sat later in the list.
+        let Ok(canonical) = candidate.canonicalize() else {
+            continue;
+        };
         let filename = canonical
             .file_stem()
             .and_then(|value| value.to_str())
@@ -727,18 +767,48 @@ fn resolve_core_path(app: &AppHandle, requested: Option<&str>) -> Result<PathBuf
 }
 
 fn core_version(path: &Path) -> Result<String, String> {
-    let output = Command::new(path)
+    // The deadline has to cover the READ, not just the child's exit. `.output()` waited for EOF
+    // on the pipes, so a core that forked a grandchild inheriting stdout hung here forever — and
+    // this runs from probe_core on every launch, on the thread that dispatches Tauri commands.
+    // Waiting on try_wait alone would not help: the direct child exits immediately in exactly
+    // that case and the read is what blocks. So read on a worker and bound the wait.
+    let mut command = Command::new(path);
+    command
         .arg("--version")
         .stdin(Stdio::null())
-        .output()
+        .stdout(Stdio::piped())
+        // Never read, so never wait on it; piping without draining risks the child blocking.
+        .stderr(Stdio::null())
+        .env_remove("RUST_LOG");
+    hide_console_window(&mut command);
+    let mut child = command
+        .spawn()
         .map_err(|error| format!("cannot run Aether core: {error}"))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Aether version check failed with {}",
-            output.status
-        ));
+
+    let stdout = child.stdout.take().expect("stdout is piped above");
+    let (sender, receiver) = mpsc::channel();
+    // ponytail: on timeout this thread stays blocked on a pipe nobody will close. Bounded by the
+    // number of probes and it holds one buffer; revisit only if probing turns into a hot path.
+    thread::spawn(move || {
+        let mut buffer = Vec::new();
+        // Cap the read so a chatty or hostile binary cannot balloon memory.
+        let _ = stdout.take(64 * 1024).read_to_end(&mut buffer);
+        let _ = sender.send(buffer);
+    });
+
+    let Ok(buffer) = receiver.recv_timeout(VERSION_PROBE_TIMEOUT) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err("Aether version check timed out".into());
+    };
+    let status = child
+        .wait()
+        .map_err(|error| format!("cannot run Aether core: {error}"))?;
+    if !status.success() {
+        return Err(format!("Aether version check failed with {status}"));
     }
-    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    let version = String::from_utf8_lossy(&buffer).trim().to_string();
     if !version.to_ascii_lowercase().starts_with("aether ") {
         return Err("the selected executable is not an Aether core".into());
     }
@@ -770,7 +840,7 @@ fn validate_peer(label: &str, value: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
-fn validate_range(label: &str, value: &str, maximum: u64) -> Result<(), String> {
+fn validate_range(label: &str, value: &str, minimum: u64, maximum: u64) -> Result<(), String> {
     let values: Vec<&str> = value.split('-').collect();
     if values.is_empty() || values.len() > 2 {
         return Err(format!("{label} must be a number or range"));
@@ -780,6 +850,9 @@ fn validate_range(label: &str, value: &str, maximum: u64) -> Result<(), String> 
         let number = item
             .parse::<u64>()
             .map_err(|_| format!("{label} must contain only positive numbers"))?;
+        if number < minimum {
+            return Err(format!("{label} must be at least {minimum}"));
+        }
         if number > maximum {
             return Err(format!("{label} must not exceed {maximum}"));
         }
@@ -849,9 +922,12 @@ fn log_level(message: &str) -> &'static str {
 }
 
 fn strip_logger_prefix(message: &str) -> String {
+    // splitn, not split().last(): the intent is to drop the "timestamp LEVEL target - " prefix,
+    // but " - " also occurs inside prose, and taking the last segment threw away everything
+    // before the final separator ("gateway rejected - retrying without encryption" -> "done").
     message
-        .split(" - ")
-        .last()
+        .splitn(2, " - ")
+        .nth(1)
         .unwrap_or(message)
         .trim()
         .to_string()
@@ -924,5 +1000,73 @@ mod tests {
         profile = CoreProfile::default();
         profile.fragment_size = "32-16".into();
         assert!(profile.validate().is_err());
+    }
+
+    #[test]
+    fn a_failed_listener_is_never_reported_as_connected() {
+        for line in [
+            "failed to bind: socks5 server listening on 127.0.0.1:1819 already in use",
+            "2026-01-01 ERROR core - could not start socks5 server listening on 127.0.0.1:1819",
+            "WARN peer sent banner: \"socks5 server listening on 0.0.0.0:9\"",
+        ] {
+            let mut snapshot = CoreSnapshot::default();
+            apply_log_to_snapshot(line, &mut snapshot);
+            assert_ne!(snapshot.state, "connected", "line must not connect: {line}");
+        }
+    }
+
+    #[test]
+    fn socks_address_is_only_taken_from_a_valid_gated_address() {
+        // Garbage after the gate leaves the configured value untouched.
+        let mut snapshot = CoreSnapshot::default();
+        let configured = snapshot.socks_address.clone();
+        apply_log_to_snapshot("socks5 server listening on not-an-address", &mut snapshot);
+        assert_eq!(snapshot.socks_address, configured);
+
+        // A different listener earlier in the line must not be mistaken for the SOCKS one.
+        let mut snapshot = CoreSnapshot::default();
+        apply_log_to_snapshot(
+            "http proxy listening on 198.51.100.9:8080; socks5 server listening on 127.0.0.1:1819",
+            &mut snapshot,
+        );
+        assert_eq!(snapshot.socks_address, "127.0.0.1:1819");
+        assert_eq!(snapshot.state, "connected");
+    }
+
+    #[test]
+    fn an_error_is_recorded_even_when_the_line_mentions_reconnecting() {
+        let mut snapshot = CoreSnapshot::default();
+        apply_log_to_snapshot(
+            "2026-01-01 ERROR aether - TLS certificate verification FAILED, reconnecting",
+            &mut snapshot,
+        );
+        assert_eq!(snapshot.state, "reconnecting");
+        assert_eq!(
+            snapshot.last_error.as_deref(),
+            Some("TLS certificate verification FAILED, reconnecting")
+        );
+    }
+
+    #[test]
+    fn logger_prefix_strip_keeps_everything_after_the_first_separator() {
+        assert_eq!(
+            strip_logger_prefix("ERROR gateway rejected - retrying without encryption - done"),
+            "retrying without encryption - done"
+        );
+    }
+
+    #[test]
+    fn a_zero_fragment_size_is_rejected_but_a_zero_delay_is_allowed() {
+        let mut profile = CoreProfile::default();
+        profile.fragment_size = "0".into();
+        assert!(profile.validate().is_err());
+
+        profile = CoreProfile::default();
+        profile.fragment_size = "0-0".into();
+        assert!(profile.validate().is_err());
+
+        profile = CoreProfile::default();
+        profile.fragment_delay = "0".into();
+        profile.validate().unwrap();
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,15 @@ pub fn run() {
             core_supervisor::save_profile,
             core_supervisor::load_profile,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running WhiteAesther");
+        .build(tauri::generate_context!())
+        .expect("error while running WhiteAesther")
+        // prevent_close() above means WindowEvent::Destroyed never fires, so it was never a
+        // cleanup path — Cmd+Q, Dock Quit and logout all exited here instead, orphaning a live
+        // core (std::process::Child does not kill on drop). shutdown() is idempotent.
+        // ponytail: cannot cover SIGKILL/OOM — that needs a pid file reaped at next launch.
+        .run(|app, event| {
+            if let tauri::RunEvent::Exit = event {
+                app.state::<CoreSupervisor>().shutdown();
+            }
+        });
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,17 +64,22 @@ function App() {
         return;
       }
       try {
-        const [info, saved, current, history] = await Promise.all([runtimeInfo(), loadProfile(), getCoreStatus(), getCoreLogs()]);
-        if (disposed) return;
-        setRuntime(`${info.os} · ${info.arch}`);
-        setProfile(saved);
-        setSnapshot(current);
-        setLogs(history);
-        setProbe(await probeCore(saved));
+        // Subscribe first, then settle the rest independently: with Promise.all, one rejection
+        // (loadProfile throws on any stored profile that fails validation) skipped subscribeCore
+        // too, leaving the app blind to a running core for the whole session.
         unsubscribe = await subscribeCore(
           (next) => { if (!disposed) setSnapshot(next); },
           (entry) => { if (!disposed) setLogs((currentLogs) => [...currentLogs.slice(-999), entry]); },
         );
+        if (disposed) return;
+        const [info, saved, current, history] = await Promise.allSettled([runtimeInfo(), loadProfile(), getCoreStatus(), getCoreLogs()]);
+        if (disposed) return;
+        if (info.status === "fulfilled") setRuntime(`${info.value.os} · ${info.value.arch}`);
+        if (saved.status === "fulfilled") setProfile(saved.value);
+        if (current.status === "fulfilled") setSnapshot(current.value);
+        if (history.status === "fulfilled") setLogs(history.value);
+        if (saved.status === "rejected") showError(saved.reason);
+        setProbe(await probeCore(saved.status === "fulfilled" ? saved.value : DEFAULT_PROFILE));
       } catch (error) {
         showError(error);
       }
@@ -261,7 +266,7 @@ function Routing({ profile, onChange }: ProfileProps) {
 }
 
 function Identity({ profile, onChange }: ProfileProps) {
-  return <><PageIntro badge="CORE TODAY" title="Zero Trust identity" copy="Enrollment settings are sent to Aether; secrets remain memory-only until OS-vault integration lands." /><div className="two-col"><article className="card"><div className="section-head"><div><span className="label">ORGANIZATION</span><h3>Cloudflare Zero Trust</h3></div></div><div className="form-grid two"><TextField label="Team" value={profile.team??""} placeholder="team name" onChange={(value)=>onChange({...profile,team:value||null})}/><TextField label="Email" value={profile.accessEmail??""} placeholder="you@example.com" onChange={(value)=>onChange({...profile,accessEmail:value||null})}/><TextField label="Access client ID" value={profile.accessClientId??""} onChange={(value)=>onChange({...profile,accessClientId:value||null})}/><TextField label="Access client secret" type="password" value={profile.accessClientSecret??""} onChange={(value)=>onChange({...profile,accessClientSecret:value||null})}/><TextField label="Existing token" type="password" value={profile.accessToken??""} onChange={(value)=>onChange({...profile,accessToken:value||null})}/></div></article><article className="card"><div className="section-head"><div><span className="label">GATEWAY</span><h3>Organization filtering</h3></div><Switch checked={profile.gateway} onCheckedChange={(checked)=>onChange({...profile,gateway:checked})}/></div><p className="warning">Gateway adds a hop and permits organization filtering and logging for web traffic.</p><ToggleField label="Send web traffic to Gateway" copy="Applies the enrolled organization policy." checked={profile.gateway} onChange={(checked)=>onChange({...profile,gateway:checked})}/><SettingRow name="Secret persistence" value="Disabled"/></article></div></>;
+  return <><PageIntro badge="CORE TODAY" title="Zero Trust identity" copy="Enrollment settings are sent to Aether. The client secret and token stay in memory only; the team, client ID and email are saved with the profile on this device." /><div className="two-col"><article className="card"><div className="section-head"><div><span className="label">ORGANIZATION</span><h3>Cloudflare Zero Trust</h3></div></div><div className="form-grid two"><TextField label="Team" value={profile.team??""} placeholder="team name" onChange={(value)=>onChange({...profile,team:value||null})}/><TextField label="Email" value={profile.accessEmail??""} placeholder="you@example.com" onChange={(value)=>onChange({...profile,accessEmail:value||null})}/><TextField label="Access client ID" value={profile.accessClientId??""} onChange={(value)=>onChange({...profile,accessClientId:value||null})}/><TextField label="Access client secret" type="password" value={profile.accessClientSecret??""} onChange={(value)=>onChange({...profile,accessClientSecret:value||null})}/><TextField label="Existing token" type="password" value={profile.accessToken??""} onChange={(value)=>onChange({...profile,accessToken:value||null})}/></div></article><article className="card"><div className="section-head"><div><span className="label">GATEWAY</span><h3>Organization filtering</h3></div><Switch checked={profile.gateway} onCheckedChange={(checked)=>onChange({...profile,gateway:checked})}/></div><p className="warning">Gateway adds a hop and permits organization filtering and logging for web traffic.</p><ToggleField label="Send web traffic to Gateway" copy="Applies the enrolled organization policy." checked={profile.gateway} onChange={(checked)=>onChange({...profile,gateway:checked})}/><SettingRow name="Client secret & token" value="Never stored"/><SettingRow name="Team, client ID, email" value="Stored on this device"/></article></div></>;
 }
 
 function Diagnostics({ snapshot, logs }: { snapshot: CoreSnapshot; logs: CoreLogEvent[] }) {

--- a/src/core/command.ts
+++ b/src/core/command.ts
@@ -11,7 +11,7 @@ export function buildCoreCommand(profile: ConnectionProfile): string {
     "--validate-secs", String(profile.validateSecs),
     "--startup-secs", String(profile.startupSecs),
     "--reconnect-secs", String(profile.reconnectSecs),
-    "--dns", profile.dns.join(","),
+    "--dns", quote(profile.dns.join(",")),
     "--noize", profile.noize,
     "--keepalive", String(profile.keepaliveSecs),
     "--log-level", profile.logLevel,
@@ -38,5 +38,8 @@ function option(name: string, value: string | null): string {
 }
 
 function quote(value: string): string {
-  return /^[A-Za-z0-9._,:/@+\-=]+$/.test(value) ? value : JSON.stringify(value);
+  // Single quotes, not JSON.stringify: its double quotes still expand $(...) and backticks, and
+  // this string is offered to the user as the command to run. Also restores real newlines, which
+  // JSON.stringify turned into a literal \n.
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }


### PR DESCRIPTION
Fixes five findings from a security audit of the desktop shell.

**Nothing here was remotely exploitable and nothing reached HIGH or CRITICAL.** These are correctness defects and broken safety-of-the-user-facing-claim issues. That framing matters for this product: the default profile is `"Adaptive · Iran"`, so "the UI says I'm protected" and "I quit the app so my device is clean" are claims users act on.

## What's fixed

### Quitting the app left the tunnel running — MEDIUM
`CloseRequested` calls `prevent_close()`, so `WindowEvent::Destroyed` never fired and was never a working cleanup path. ⌘Q, Dock Quit and logout all reached `RunEvent::Exit`, where `cleanup_before_exit()` knows nothing about managed state — so the `Child` was dropped without being killed (`std::process::Child` does not kill on drop). The core kept its SOCKS listener bound and its tunnel established, with nothing reaping it on relaunch; the next Connect then failed to bind.

Reproduced before the fix: parent exits, child reparents to PID 1, listener still bound, relaunch gets `AddrInUse`.

Cleanup now runs on `RunEvent::Exit`, which covers every exit path on every platform. It cannot cover SIGKILL/OOM — that needs a pid file reaped at startup, and is marked in-code rather than silently left.

### Connection state was asserted from unverified log text — LOW-MEDIUM
State came from an unanchored substring match on the child's stdout with zero corroboration. Lines reporting the listener *failing* set state to `connected`:

| Input line | Old result |
|---|---|
| `failed to bind: socks5 server listening on 127.0.0.1:1819 already in use` | `connected` |
| `ERROR core - could not start socks5 server listening on ...` | `connected` + `last_error` |
| `http proxy listening on 198.51.100.9:8080; socks5 server listening on 127.0.0.1:1819` | displayed the **HTTP** address |

Six fixes: reject failure wording before treating a line as success; extract from the gate phrase actually matched (a bare `"listening on "` picked up a different listener earlier in the line); require the address to parse as a `SocketAddr` (the bar `parse_endpoint` already applied 30 lines away); gate mutation on `pid.is_some()` so buffered lines can't resurrect a dead core; replace `map_while(Result::ok)` with skip-on-error (it ended the whole reader on the first non-UTF-8 byte, freezing the only path out of `connected`); and decouple error capture from `"reconnecting"`, which hid the most common phrasing of a failed retry.

Active probing of the SOCKS port is **not** added — that's the real root-cause fix and the remaining gap is marked in-code.

### "Copy command" could put shell injection on the clipboard — LOW
`quote()` used `JSON.stringify`, which emits **double** quotes — inside which `$(...)` and backticks still expand — and `--dns` bypassed quoting entirely. A route rule pasted from a shared config could place a live command substitution on the clipboard, in a string the UI badges "WHAT WILL RUN". Now POSIX single-quoted, with `--dns` routed through it.

Same change fixes a fidelity bug: `JSON.stringify` turned newlines into a literal `\n`, so the copied command could not reproduce a multi-line rule list at all.

### UI overstated the protection in force — LOW
`validate_range` had no lower bound, so a fragment size of `0` zeroed the only anti-DPI parameter on the default profile while the switch still read ON. The minimum is now **per-field** — size ≥ 1, delay ≥ 0, because a zero delay is legitimate and a blanket check would have broken it. Also: "Secret persistence: Disabled" was inaccurate (secret and token are never stored, but team/client ID/email are); labels now say what is actually stored.

### Robustness defects that disabled monitoring — LOW
- `core_version` used `.output()`, which waits for EOF, so a core forking a grandchild that inherits stdout hung **forever** — on the command-dispatch thread, from a probe that runs at every launch. Now bounded at 10s, matching the timeout `stage-core.mjs` already applies to the same call. The deadline had to cover the *read*, not just the child's exit, since the direct child exits immediately in exactly that case.
- Startup used `Promise.all`, so one rejection (`loadProfile` throws on any stored profile failing validation) also skipped `subscribeCore`, leaving the app blind to a running core for the whole session. Now subscribes first, then settles the rest independently.
- `resolve_core_path` propagated a `canonicalize` failure with `?`, letting one unusable candidate deny core discovery entirely; it now skips.
- `spawn_exit_monitor` left transport/endpoint/latency populated, showing a live route beside a dead core; now cleared, matching `stop_inner`.

## Verification

| Check | Result |
|---|---|
| `cargo test --locked` | 8 passed, 0 failed |
| `cargo test --release --locked` (as CI runs it) | 8 passed, 0 failed |
| Warnings in `whiteaesther` | none |
| `pnpm check` (`tsc --noEmit`) | exit 0 |
| `pnpm build` | clean |

5 tests added covering the failed-listener, address-validation, error-capture, prefix-stripping and fragment-bound cases. Before the change, a harness built from this source failed 9 of 15 equivalent assertions; all 15 pass now. The `core_version` timeout was tested against a real daemonizing child, with the old `.output()` confirmed to block past 6s. The generated command was executed by real `sh` — payloads arrive as inert literal argv.

## Deliberately not in this PR

- **Signing / build provenance / updater**, **stale `continuous` release assets**, **unprotected `v*` tags**, **mutable action tags** — all CI, release-pipeline or GitHub-settings changes. They're outward-facing and change what gets published, so they're a maintainer decision rather than something to slip into a code PR.
- **LAN-bind guardrail on `socks_address`** — needs a new `allowLan` field across Rust, types and UI.
- **`--config` missing from the displayed command** — best fixed by having the backend return the argv it will run, removing the second builder entirely rather than patching the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjSPFn6rMb4SUkZUfivewk
