### PR TITLE
Release 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.0.0"
+version = "1.1.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump only — no code changes. `package.json`, `tauri.conf.json`,
`Cargo.toml` and `Cargo.lock` all move to 1.1.0 together, so the installer
name, the window title and the crate cannot disagree.

Additive since 1.0.0: profiles saved by 1.0.0 load and migrate, and no setting
was removed.

## What 1.1.0 contains

- **Endpoint scanner** — ranks reachable gateways by round-trip time without
  connecting, sweeps the other transport when one finds nothing, cancellable
- **Endpoint pinning** — automatic, custom-first with an announced fallback, or
  custom-only
- **System proxy** — set while connected, restored on disconnect, recovered on
  next launch if the app was killed
- **Retry and cross-transport failover** — widening delay to eight attempts,
  alternating MASQUE H2 and H3
- **Diagnostics report** — reviewable, addresses redacted by default, no Zero
  Trust credentials
- **Two-mode interface** on Tailwind and shadcn/ui, dark by default
- **Three interface defects fixed** that made the window stall: synchronous
  commands blocking the main thread, a status event per log line, and a Tauri
  listener rebuilt on every keystroke
- **Security audit fixes** from #4, reconciled with the above
- **AGPL-3.0 declared**, with third-party notices

The core is built from `WhiteDNS/Aether` at `v1.5.0-whiteaesther.2`, which adds
the reporting modes the scanner needs.

## After merge

Tagging `v1.1.0` triggers the release workflow: all three platforms, installer
pack and SHA-256 sums.

## Not verified

The system proxy has never been executed against a live machine — the apply path
and the kill-then-relaunch recovery both need a manual pass. No scan has returned
real gateways from the development machine either; the plumbing is tested, the
network behaviour is not.