### PR TITLE
Stop building every commit twice

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,9 +1,13 @@
 name: build, test and release
 
+# A push to a branch with an open pull request matches `pull_request` and `push`
+# both, so every commit on every branch was built twice — three platforms each,
+# around thirteen minutes a job. `pull_request` covers branches; `push` is left
+# with the two refs that actually publish something.
 on:
   pull_request:
   push:
-    branches: ["**"]
+    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
 


### PR DESCRIPTION
Releasing 1.1.0 built the same tree **four times** — runs #23 and #24 on the
release branch, #25 on main, #26 on the tag. Roughly two hours of runner time for
one set of installers.

Half of it is a plain defect: a push to a branch with an open PR matches
`pull_request` **and** `push: branches: ["**"]`, so every commit on every branch
built twice. That has been happening on every PR in this repo, not just releases.

`push` now covers only the refs that publish something:

```yaml
push:
  branches: [main]     # was ["**"]
  tags: ["v*"]
```

No coverage is lost — `pull_request` already builds branches. A branch with no PR
open no longer builds, which is the normal arrangement.

## What this does not fix

A release still builds twice: once when the merge lands on `main` (replacing the
`continuous` prerelease) and once when the tag is pushed (cutting the versioned
release). Same tree, two runs, two different outputs.

Removing that pair needs a decision rather than a patch — either drop the
continuous prerelease, or have the tag job promote the artifacts `main` already
built instead of rebuilding them. Left alone here.