### PR TITLE
Release 1.1.1 — system proxy, endpoint scanner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   # The fork adds the reporting modes the endpoint scanner needs. Pinned to a
   # tag rather than a branch so a release is reproducible.
-  AETHER_REVISION: v1.5.0-whiteaesther.2
+  AETHER_REVISION: v1.5.0-whiteaesther.3
 
 jobs:
   package:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.1.0"
+version = "1.1.1"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -12,7 +12,8 @@ use std::{
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
-use crate::system_proxy;
+use crate::http_bridge::{self, HttpBridge};
+use crate::system_proxy::{self, ProxyTargets};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 const MAX_LOGS: usize = 1_000;
@@ -384,6 +385,9 @@ struct SupervisorInner {
     /// A reporting run of the core -- a scan or an endpoint test. Separate from
     /// `child` because it is short-lived and independently cancellable.
     scan_child: Mutex<Option<Child>>,
+    /// The local HTTP proxy the system proxy points at. Only alive while the
+    /// system proxy is applied, and dropped with it.
+    bridge: Mutex<Option<HttpBridge>>,
 }
 
 impl SupervisorInner {
@@ -408,6 +412,7 @@ impl CoreSupervisor {
                 generation: AtomicU64::new(0),
                 proxy_applied: AtomicBool::new(false),
                 scan_child: Mutex::new(None),
+                bridge: Mutex::new(None),
             }),
         }
     }
@@ -685,6 +690,43 @@ pub async fn stop_core(
         Ok(lock(&inner.snapshot).clone())
     })
     .await
+}
+
+/// Applies or removes the system proxy while a connection is already up.
+///
+/// Without this, choosing "whole machine" after connecting only changed a field
+/// in the profile: the proxy was applied on the log line that reports the
+/// listener, which had already gone by. The screen offers the choice while
+/// connected, so it has to mean something then.
+#[tauri::command]
+pub fn set_system_proxy(
+    app: AppHandle,
+    supervisor: State<'_, CoreSupervisor>,
+    enabled: bool,
+) -> Result<bool, String> {
+    let inner = &supervisor.inner;
+
+    // Remember it for the rest of the session, so a reconnect keeps the choice.
+    if let Some(session) = lock(&inner.session).as_mut() {
+        session.profile.system_proxy = enabled;
+    }
+
+    if !enabled {
+        clear_system_proxy(&app, inner);
+        return Ok(false);
+    }
+
+    let (state, socks) = {
+        let snapshot = lock(&inner.snapshot);
+        (snapshot.state.clone(), snapshot.socks_address.clone())
+    };
+    // Before the listener exists there is nothing to point at; the connect path
+    // applies it when the core reports itself up.
+    if state != "connected" {
+        return Ok(false);
+    }
+    apply_system_proxy(&app, inner, &socks);
+    Ok(inner.proxy_applied.load(Ordering::SeqCst))
 }
 
 #[tauri::command]
@@ -1173,7 +1215,8 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     }
 }
 
-/// Points the OS at the listener once, on the first log line that says it is up.
+/// Points the OS at the tunnel. Idempotent, so the log-line path and the
+/// change-while-connected path can both call it.
 fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
     if inner.proxy_applied.load(Ordering::SeqCst) {
         return;
@@ -1187,19 +1230,47 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
         );
         return;
     };
-    match system_proxy::apply(app, address) {
+
+    // Windows follows an HTTP proxy and effectively ignores a SOCKS one, so the
+    // bridge is what its settings are pointed at. It costs a listener on
+    // loopback and is torn down with the proxy.
+    let bridge = match http_bridge::start(address) {
+        Ok(bridge) => bridge,
+        Err(error) => {
+            supervisor_log(
+                app,
+                inner,
+                "warn",
+                format!("could not start the local HTTP proxy: {error}"),
+            );
+            return;
+        }
+    };
+    let targets = ProxyTargets { socks: address, http: bridge.address() };
+    *lock(&inner.bridge) = Some(bridge);
+
+    match system_proxy::apply(app, targets) {
         Ok(()) => {
             inner.proxy_applied.store(true, Ordering::SeqCst);
-            supervisor_log(app, inner, "info", format!("system proxy set to {address}"));
+            supervisor_log(
+                app,
+                inner,
+                "info",
+                format!("system proxy set to {} via {}", targets.socks, targets.http),
+            );
         }
         // Worth saying and worth continuing: the tunnel is up either way, and
         // the SOCKS listener can still be used directly.
-        Err(error) => supervisor_log(
-            app,
-            inner,
-            "warn",
-            format!("could not set the system proxy: {error}"),
-        ),
+        Err(error) => {
+            // Nothing is pointed at the bridge, so it has no reason to stay up.
+            lock(&inner.bridge).take();
+            supervisor_log(
+                app,
+                inner,
+                "warn",
+                format!("could not set the system proxy: {error}"),
+            )
+        }
     }
 }
 
@@ -1212,6 +1283,9 @@ fn clear_system_proxy(app: &AppHandle, inner: &SupervisorInner) {
     if !inner.proxy_applied.swap(false, Ordering::SeqCst) {
         return;
     }
+    // Dropped before the settings change, so nothing can be sent to a bridge
+    // that is about to stop answering.
+    lock(&inner.bridge).take();
     match system_proxy::revert(app) {
         Ok(()) => supervisor_log(app, inner, "info", "system proxy restored".into()),
         Err(error) => {

--- a/src-tauri/src/http_bridge.rs
+++ b/src-tauri/src/http_bridge.rs
@@ -1,0 +1,342 @@
+//! A local HTTP proxy that forwards to the core's SOCKS5 listener.
+//!
+//! Windows needs this. WinINET can be told about a SOCKS proxy with
+//! `socks=host:port`, but its SOCKS support is version 4, and Chrome and Edge
+//! ignore that key from system settings altogether — so pointing the system
+//! proxy at Aether's SOCKS5 listener sets a value almost nothing obeys. What
+//! Windows applications do follow is an HTTP proxy, which is what this serves,
+//! translating each request into a SOCKS5 connection.
+//!
+//! Deliberately std-only and thread-per-connection: this crate supervises a
+//! child process and has no async runtime, and a desktop client's own traffic
+//! does not justify adding one.
+
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Long enough for a slow tunnel to answer, short enough that a wedged peer
+/// does not hold a thread forever.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+/// A request line plus headers. Anything larger is not a proxy request.
+const MAX_HEADER_BYTES: usize = 32 * 1024;
+
+pub struct HttpBridge {
+    address: SocketAddr,
+    stop: Arc<AtomicBool>,
+}
+
+impl HttpBridge {
+    /// Where to point the system proxy.
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::SeqCst);
+        // Unblock the accept loop, which is parked in accept() rather than
+        // polling a flag it cannot see.
+        let _ = TcpStream::connect(self.address);
+    }
+}
+
+impl Drop for HttpBridge {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Binds on loopback and forwards everything to `socks`.
+///
+/// Port 0 lets the OS choose, so two instances cannot collide and nothing has
+/// to be configured.
+pub fn start(socks: SocketAddr) -> io::Result<HttpBridge> {
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))?;
+    let address = listener.local_addr()?;
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let accept_stop = stop.clone();
+    thread::Builder::new()
+        .name("whiteaesther-http-bridge".into())
+        .spawn(move || {
+            for client in listener.incoming() {
+                if accept_stop.load(Ordering::SeqCst) {
+                    return;
+                }
+                let Ok(client) = client else { continue };
+                thread::spawn(move || {
+                    // A failed exchange closes that connection and nothing else.
+                    let _ = serve(client, socks);
+                });
+            }
+        })?;
+
+    Ok(HttpBridge { address, stop })
+}
+
+fn serve(mut client: TcpStream, socks: SocketAddr) -> io::Result<()> {
+    client.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    let mut reader = BufReader::new(client.try_clone()?);
+
+    let mut request_line = String::new();
+    if read_line(&mut reader, &mut request_line)? == 0 {
+        return Ok(());
+    }
+    let mut parts = request_line.split_whitespace();
+    let (method, target) = match (parts.next(), parts.next()) {
+        (Some(method), Some(target)) => (method.to_string(), target.to_string()),
+        _ => return respond(&mut client, 400, "Bad Request"),
+    };
+
+    let mut headers = Vec::new();
+    let mut total = request_line.len();
+    loop {
+        let mut line = String::new();
+        if read_line(&mut reader, &mut line)? == 0 {
+            break;
+        }
+        total += line.len();
+        if total > MAX_HEADER_BYTES {
+            return respond(&mut client, 431, "Request Header Fields Too Large");
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        headers.push(line);
+    }
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        // https, and anything else tunnelled. The overwhelming majority.
+        let Some((host, port)) = split_authority(&target, 443) else {
+            return respond(&mut client, 400, "Bad Request");
+        };
+        let upstream = match socks5_connect(socks, &host, port) {
+            Ok(upstream) => upstream,
+            Err(_) => return respond(&mut client, 502, "Bad Gateway"),
+        };
+        client.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")?;
+        client.set_read_timeout(None)?;
+        splice(client, upstream);
+        return Ok(());
+    }
+
+    // Plain http, which arrives as an absolute URI the origin server would not
+    // understand, so the request line is rewritten on the way through.
+    let Some((host, port, path)) = split_absolute_uri(&target) else {
+        return respond(&mut client, 400, "Bad Request");
+    };
+    let mut upstream = match socks5_connect(socks, &host, port) {
+        Ok(upstream) => upstream,
+        Err(_) => return respond(&mut client, 502, "Bad Gateway"),
+    };
+
+    let mut head = format!("{method} {path} HTTP/1.1\r\n");
+    for header in &headers {
+        // Hop-by-hop: meaningful to this proxy, not to the origin server.
+        let lowered = header.to_ascii_lowercase();
+        if lowered.starts_with("proxy-connection:") || lowered.starts_with("proxy-authorization:") {
+            continue;
+        }
+        head.push_str(header);
+    }
+    head.push_str("\r\n");
+    upstream.write_all(head.as_bytes())?;
+
+    // Whatever the client had already buffered is body, and belongs upstream.
+    let buffered = reader.buffer().to_vec();
+    if !buffered.is_empty() {
+        upstream.write_all(&buffered)?;
+    }
+    client.set_read_timeout(None)?;
+    splice(client, upstream);
+    Ok(())
+}
+
+fn read_line(reader: &mut BufReader<TcpStream>, into: &mut String) -> io::Result<usize> {
+    match reader.read_line(into) {
+        Ok(read) => Ok(read),
+        // A client that opens a connection and says nothing is not an error
+        // worth reporting; it is a port scan or a warm-up probe.
+        Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(0),
+        Err(error) => Err(error),
+    }
+}
+
+fn respond(client: &mut TcpStream, code: u16, reason: &str) -> io::Result<()> {
+    write!(client, "HTTP/1.1 {code} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+}
+
+/// `host:port`, with IPv6 in brackets.
+fn split_authority(target: &str, default_port: u16) -> Option<(String, u16)> {
+    if let Some(rest) = target.strip_prefix('[') {
+        let (host, tail) = rest.split_once(']')?;
+        let port = match tail.strip_prefix(':') {
+            Some(port) => port.parse().ok()?,
+            None => default_port,
+        };
+        return Some((host.to_string(), port));
+    }
+    match target.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => Some((host.to_string(), port.parse().ok()?)),
+        _ => Some((target.to_string(), default_port)),
+    }
+}
+
+/// `http://host[:port]/path` into its parts, with the path in origin form.
+fn split_absolute_uri(target: &str) -> Option<(String, u16, String)> {
+    let rest = target
+        .strip_prefix("http://")
+        .or_else(|| target.strip_prefix("HTTP://"))?;
+    let (authority, path) = match rest.find('/') {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, "/"),
+    };
+    let (host, port) = split_authority(authority, 80)?;
+    Some((host, port, path.to_string()))
+}
+
+/// Opens a SOCKS5 connection to `host:port` through `socks`.
+///
+/// The name is passed through as a domain rather than resolved here, so DNS
+/// happens inside the tunnel instead of leaking to the local resolver.
+fn socks5_connect(socks: SocketAddr, host: &str, port: u16) -> io::Result<TcpStream> {
+    let mut upstream = TcpStream::connect_timeout(&socks, HANDSHAKE_TIMEOUT)?;
+    upstream.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+    upstream.set_nodelay(true)?;
+
+    // Greeting: SOCKS5, one method, "no authentication".
+    upstream.write_all(&[0x05, 0x01, 0x00])?;
+    let mut greeting = [0_u8; 2];
+    upstream.read_exact(&mut greeting)?;
+    if greeting != [0x05, 0x00] {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "the SOCKS5 listener refused an unauthenticated connection",
+        ));
+    }
+
+    let host_bytes = host.as_bytes();
+    if host_bytes.len() > 255 {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "host is too long"));
+    }
+    let mut request = Vec::with_capacity(host_bytes.len() + 7);
+    request.extend_from_slice(&[0x05, 0x01, 0x00, 0x03]);
+    request.push(host_bytes.len() as u8);
+    request.extend_from_slice(host_bytes);
+    request.extend_from_slice(&port.to_be_bytes());
+    upstream.write_all(&request)?;
+
+    let mut reply = [0_u8; 4];
+    upstream.read_exact(&mut reply)?;
+    if reply[1] != 0x00 {
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            format!("the tunnel refused the connection (SOCKS5 reply {})", reply[1]),
+        ));
+    }
+    // The bound address varies by type and has to be consumed before the stream
+    // carries payload.
+    match reply[3] {
+        0x01 => drain(&mut upstream, 4 + 2)?,
+        0x03 => {
+            let mut length = [0_u8; 1];
+            upstream.read_exact(&mut length)?;
+            drain(&mut upstream, length[0] as usize + 2)?;
+        }
+        0x04 => drain(&mut upstream, 16 + 2)?,
+        other => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown SOCKS5 address type {other}"),
+            ))
+        }
+    }
+
+    upstream.set_read_timeout(None)?;
+    Ok(upstream)
+}
+
+fn drain(stream: &mut TcpStream, count: usize) -> io::Result<()> {
+    let mut scratch = vec![0_u8; count];
+    stream.read_exact(&mut scratch)
+}
+
+/// Copies in both directions until either side closes.
+fn splice(client: TcpStream, upstream: TcpStream) {
+    let Ok(client_reader) = client.try_clone() else { return };
+    let Ok(upstream_reader) = upstream.try_clone() else { return };
+
+    let outbound = thread::spawn(move || {
+        let mut from = client_reader;
+        let mut to = upstream;
+        let _ = io::copy(&mut from, &mut to);
+        // Half-close so the far end sees EOF rather than waiting on a request
+        // that will never arrive.
+        let _ = to.shutdown(Shutdown::Write);
+    });
+
+    let mut from = upstream_reader;
+    let mut to = client;
+    let _ = io::copy(&mut from, &mut to);
+    let _ = to.shutdown(Shutdown::Write);
+    let _ = outbound.join();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authority_splits_host_and_port() {
+        assert_eq!(split_authority("example.com:443", 80), Some(("example.com".into(), 443)));
+        assert_eq!(split_authority("example.com", 80), Some(("example.com".into(), 80)));
+        assert_eq!(split_authority("[2606:4700::1]:8443", 80), Some(("2606:4700::1".into(), 8443)));
+        // Bracketed without a port still has colons in the host, which a naive
+        // rsplit would take for a port separator.
+        assert_eq!(split_authority("[2606:4700::1]", 443), Some(("2606:4700::1".into(), 443)));
+    }
+
+    #[test]
+    fn absolute_uris_become_origin_form() {
+        assert_eq!(
+            split_absolute_uri("http://example.com/a/b?c=d"),
+            Some(("example.com".into(), 80, "/a/b?c=d".into())),
+        );
+        assert_eq!(
+            split_absolute_uri("http://example.com:8080/"),
+            Some(("example.com".into(), 8080, "/".into())),
+        );
+        // No path at all still has to reach the origin as "/".
+        assert_eq!(split_absolute_uri("http://example.com"), Some(("example.com".into(), 80, "/".into())));
+        // https never arrives this way; it comes through CONNECT.
+        assert_eq!(split_absolute_uri("https://example.com/"), None);
+    }
+
+    #[test]
+    fn the_bridge_binds_and_reports_a_loopback_address() {
+        let socks = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let bridge = start(socks).expect("bridge should bind");
+        assert!(bridge.address().ip().is_loopback());
+        assert_ne!(bridge.address().port(), 0, "port 0 must be resolved to a real one");
+        bridge.stop();
+    }
+
+    #[test]
+    fn a_request_for_a_dead_tunnel_is_refused_not_hung() {
+        // Nothing is listening on the SOCKS port, which is what a client sees
+        // if the core dies while the system proxy still points here.
+        let socks = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let bridge = start(socks).expect("bridge should bind");
+        let mut client = TcpStream::connect(bridge.address()).expect("bridge should accept");
+        client
+            .write_all(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+            .unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 502"), "got: {response}");
+        bridge.stop();
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod core_supervisor;
+mod http_bridge;
 mod scanner;
 mod system_proxy;
 
@@ -126,6 +127,7 @@ pub fn run() {
             core_supervisor::save_profile,
             core_supervisor::load_profile,
             core_supervisor::save_report,
+            core_supervisor::set_system_proxy,
             scanner::scan_endpoints,
             scanner::test_endpoint,
             scanner::cancel_scan,

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -61,12 +61,18 @@ pub async fn test_endpoint(
     supervisor.require_idle("Disconnect before testing an endpoint")?;
     let inner: CoreSupervisor = (*supervisor).clone();
     tauri::async_runtime::spawn_blocking(move || {
+        // The transport the profile is set to, not a fixed one. A gateway can
+        // answer over TCP and be unusable over QUIC -- on a network that
+        // interferes with UDP, every H3 endpoint fails while H2 succeeds -- so
+        // testing the wrong transport reports an endpoint as good that the next
+        // connect cannot use.
+        let transport = transport_of(&profile);
         let value = run_report(
             &app,
             &inner,
             &profile,
             &["--test-endpoint".into(), endpoint],
-            "h2",
+            transport,
         )?;
         candidate_from(&value).ok_or_else(|| "the core gave an unreadable answer".to_string())
     })
@@ -79,13 +85,21 @@ pub fn cancel_scan(supervisor: State<'_, CoreSupervisor>) -> bool {
     supervisor.cancel_scan()
 }
 
+/// Which MASQUE transport the profile is set to.
+///
+/// The scan and the endpoint test both need this: probing over the wrong one
+/// answers a question the user did not ask.
+fn transport_of(profile: &CoreProfile) -> &'static str {
+    if profile.masque_transport == "h2" { "h2" } else { "h3" }
+}
+
 fn scan_blocking(
     app: &AppHandle,
     supervisor: &CoreSupervisor,
     profile: &CoreProfile,
     limit: u32,
 ) -> Result<ScanOutcome, String> {
-    let configured = if profile.masque_transport == "h2" { "h2" } else { "h3" };
+    let configured = transport_of(profile);
     let args = vec!["--scan-only".to_string(), "--scan-limit".into(), limit.to_string()];
 
     let first = run_report(app, supervisor, profile, &args, configured)?;
@@ -119,6 +133,9 @@ fn run_report(
 
     let mut command = Command::new(&core_path);
     command
+        // MASQUE regardless of the profile's protocol: the core's reporting
+        // modes wrap scan_embedded, which has no WireGuard or WARP-in-WARP
+        // path. The panel says so rather than quietly scanning the wrong thing.
         .arg("--masque")
         .args(["--scan", &profile.scan_mode])
         .args(["--ip", &profile.ip_family])

--- a/src-tauri/src/system_proxy.rs
+++ b/src-tauri/src/system_proxy.rs
@@ -48,6 +48,18 @@ pub struct MacProxyService {
     pub port: u16,
 }
 
+/// Where each platform should be pointed.
+///
+/// macOS and GNOME speak SOCKS5 and are given the core's listener directly.
+/// Windows is given the local HTTP bridge instead: WinINET's SOCKS is version 4
+/// and Chrome and Edge ignore the `socks=` key entirely, so pointing it at a
+/// SOCKS5 listener sets a value almost nothing obeys.
+#[derive(Debug, Clone, Copy)]
+pub struct ProxyTargets {
+    pub socks: SocketAddr,
+    pub http: SocketAddr,
+}
+
 fn backup_path(app: &AppHandle) -> Result<PathBuf, String> {
     app.path()
         .app_config_dir()
@@ -64,7 +76,7 @@ pub fn is_applied(app: &AppHandle) -> bool {
 /// Re-applying while already applied deliberately does not touch the backup --
 /// capturing our own settings as "the previous value" is how a tool like this
 /// makes a proxy permanent.
-pub fn apply(app: &AppHandle, socks: SocketAddr) -> Result<(), String> {
+pub fn apply(app: &AppHandle, targets: ProxyTargets) -> Result<(), String> {
     let path = backup_path(app)?;
     if !path.exists() {
         let current = platform::read()?;
@@ -79,7 +91,7 @@ pub fn apply(app: &AppHandle, socks: SocketAddr) -> Result<(), String> {
         std::fs::write(&path, bytes)
             .map_err(|error| format!("cannot save the current proxy settings: {error}"))?;
     }
-    platform::apply(socks)
+    platform::apply(targets)
 }
 
 /// Puts the settings back and forgets the backup.
@@ -115,7 +127,6 @@ pub fn recover(app: &AppHandle) -> Result<bool, String> {
 #[cfg(target_os = "windows")]
 mod platform {
     use super::ProxyBackup;
-    use std::net::SocketAddr;
     use winreg::enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
     use winreg::RegKey;
 
@@ -136,9 +147,14 @@ mod platform {
         })
     }
 
-    pub fn apply(socks: SocketAddr) -> Result<(), String> {
+    pub fn apply(targets: super::ProxyTargets) -> Result<(), String> {
         let key = settings_key(KEY_READ | KEY_WRITE)?;
-        write(&key, 1_u32, &super::windows_proxy_server(socks), "<local>")?;
+        write(
+            &key,
+            1_u32,
+            &super::windows_proxy_server(targets.http),
+            super::WINDOWS_BYPASS,
+        )?;
         notify();
         Ok(())
     }
@@ -191,7 +207,6 @@ mod platform {
 #[cfg(target_os = "macos")]
 mod platform {
     use super::{MacProxyService, ProxyBackup};
-    use std::net::SocketAddr;
     use std::process::Command;
 
     pub fn read() -> Result<ProxyBackup, String> {
@@ -206,10 +221,10 @@ mod platform {
         Ok(ProxyBackup::Macos { services })
     }
 
-    pub fn apply(socks: SocketAddr) -> Result<(), String> {
+    pub fn apply(targets: super::ProxyTargets) -> Result<(), String> {
         for name in list_services()? {
-            let port = socks.port().to_string();
-            let host = socks.ip().to_string();
+            let port = targets.socks.port().to_string();
+            let host = targets.socks.ip().to_string();
             networksetup(&["-setsocksfirewallproxy", &name, &host, &port])?;
             networksetup(&["-setsocksfirewallproxystate", &name, "on"])?;
         }
@@ -263,7 +278,6 @@ mod platform {
 #[cfg(all(unix, not(target_os = "macos")))]
 mod platform {
     use super::ProxyBackup;
-    use std::net::SocketAddr;
     use std::process::Command;
 
     const SCHEMA: &str = "org.gnome.system.proxy";
@@ -278,9 +292,9 @@ mod platform {
         })
     }
 
-    pub fn apply(socks: SocketAddr) -> Result<(), String> {
-        gsettings(&["set", &socks_schema(), "host", &socks.ip().to_string()])?;
-        gsettings(&["set", &socks_schema(), "port", &socks.port().to_string()])?;
+    pub fn apply(targets: super::ProxyTargets) -> Result<(), String> {
+        gsettings(&["set", &socks_schema(), "host", &targets.socks.ip().to_string()])?;
+        gsettings(&["set", &socks_schema(), "port", &targets.socks.port().to_string()])?;
         gsettings(&["set", SCHEMA, "mode", "manual"])?;
         Ok(())
     }
@@ -314,11 +328,20 @@ mod platform {
     }
 }
 
-/// WinINET's proxy list format. SOCKS is named rather than given as a bare
-/// `host:port`, which would be read as an HTTP proxy.
+/// Loopback and private ranges never go through the tunnel: sending them there
+/// breaks local development servers and printers for no benefit.
 #[cfg(any(target_os = "windows", test))]
-fn windows_proxy_server(socks: SocketAddr) -> String {
-    format!("socks={socks}")
+const WINDOWS_BYPASS: &str = "<local>;localhost;127.*;10.*;172.16.*;172.17.*;172.18.*;172.19.*;172.20.*;172.21.*;172.22.*;172.23.*;172.24.*;172.25.*;172.26.*;172.27.*;172.28.*;172.29.*;172.30.*;172.31.*;192.168.*";
+
+/// WinINET's proxy list, naming the HTTP bridge for both schemes.
+///
+/// Not `socks=`: that key means SOCKS4 to WinINET, and Chrome and Edge skip it
+/// altogether. Naming http and https explicitly, rather than a bare
+/// `host:port`, leaves ftp and everything else direct instead of sending it to
+/// a proxy that only speaks HTTP.
+#[cfg(any(target_os = "windows", test))]
+fn windows_proxy_server(http: SocketAddr) -> String {
+    format!("http={http};https={http}")
 }
 
 /// `networksetup -listallnetworkservices` prints an explanatory first line, and
@@ -365,9 +388,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn windows_names_the_protocol_so_socks_is_not_read_as_http() {
-        let socks: SocketAddr = "127.0.0.1:1819".parse().unwrap();
-        assert_eq!(windows_proxy_server(socks), "socks=127.0.0.1:1819");
+    fn windows_is_pointed_at_the_http_bridge_not_at_socks() {
+        // "socks=" is the syntactically correct way to declare a SOCKS proxy and
+        // very nearly useless: WinINET reads it as SOCKS4, and Chrome and Edge
+        // ignore it. Naming both schemes against the bridge is what applications
+        // actually follow.
+        let bridge: SocketAddr = "127.0.0.1:52310".parse().unwrap();
+        let value = windows_proxy_server(bridge);
+        assert_eq!(value, "http=127.0.0.1:52310;https=127.0.0.1:52310");
+        assert!(!value.contains("socks="), "SOCKS must not be advertised to WinINET");
+    }
+
+    #[test]
+    fn the_windows_bypass_keeps_local_traffic_off_the_tunnel() {
+        for expected in ["<local>", "localhost", "127.*", "192.168.*", "10.*"] {
+            assert!(WINDOWS_BYPASS.contains(expected), "missing bypass: {expected}");
+        }
+        assert!(!WINDOWS_BYPASS.contains(" "), "WinINET splits this list on semicolons only");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import { Simple } from "@/features/Simple";
 import { type CarryMode, carryFromProfile } from "@/features/carry";
 import {
   getCoreLogs, getCoreStatus, isDesktopRuntime, loadProfile, probeCore, runtimeInfo,
-  saveProfile as persistProfile, startCore, stopCore, subscribeCore, subscribeTrayActions,
+  saveProfile as persistProfile, setSystemProxy, startCore, stopCore, subscribeCore,
+  subscribeTrayActions,
 } from "@/core/api";
 import { withNormalizedEndpoint } from "@/core/endpoint";
 import {
@@ -158,10 +159,23 @@ export default function App() {
   }, [desktop, profile, effective, notify, showError]);
 
   const carry: CarryMode = carryFromProfile(profile.systemProxy);
-  const setCarry = useCallback((next: CarryMode) => {
-    if (next === "tun") return;
-    setProfile((current) => ({ ...current, systemProxy: next === "system" }));
-  }, []);
+  const setCarry = useCallback(
+    (next: CarryMode) => {
+      if (next === "tun") return;
+      const wantsSystem = next === "system";
+      setProfile((current) => ({ ...current, systemProxy: wantsSystem }));
+      // The screen offers this choice while connected, so it has to take effect
+      // then, rather than only at the next connect.
+      if (!desktop || !ACTIVE.has(snapshot.state)) return;
+      void setSystemProxy(wantsSystem)
+        .then((applied) => {
+          if (wantsSystem && applied) notify("Whole machine", "Your system proxy now points at the tunnel.");
+          else if (!wantsSystem) notify("This app only", "Your system proxy has been put back.");
+        })
+        .catch(showError);
+    },
+    [desktop, snapshot.state, notify, showError],
+  );
 
   const retryStealth = useCallback(async () => {
     const next: ConnectionProfile = { ...profile, scanMode: "stealth" };

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -105,3 +105,12 @@ export async function cancelScan(): Promise<boolean> {
   requireDesktop();
   return invoke("cancel_scan");
 }
+
+/**
+ * Applies or removes the system proxy on a connection that is already up.
+ * Returns whether it is now applied.
+ */
+export async function setSystemProxy(enabled: boolean): Promise<boolean> {
+  requireDesktop();
+  return invoke("set_system_proxy", { enabled });
+}

--- a/src/features/Scanner.tsx
+++ b/src/features/Scanner.tsx
@@ -37,6 +37,10 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
   }, []);
 
   const busy = phase === "scanning" || phase === "testing";
+  // The core's reporting modes wrap a MASQUE-only probe, so the picker under
+  // Routes has no effect here. Saying so beats letting someone select WireGuard
+  // and conclude the scanner is broken.
+  const masqueOnly = profile.protocol !== "masque";
   const connected = snapshot.state !== "idle" && snapshot.state !== "stopped" && snapshot.state !== "error";
   const pinned = normalizeEndpoint(profile.peer ?? "");
 
@@ -104,7 +108,8 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
         <div className="flex flex-col gap-1.5">
           <CardTitle className="text-[15px]">Find a gateway</CardTitle>
           <CardDescription>
-            Tests real gateways and ranks them by round-trip time. Nothing is connected until you pick one.
+            Tests real MASQUE gateways over {label(profile.masqueTransport)} and ranks them by round-trip
+            time. Nothing is connected until you pick one.
           </CardDescription>
         </div>
         <div className="flex shrink-0 gap-2">
@@ -132,6 +137,17 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
       </CardHeader>
 
       <CardContent className="pt-0">
+        {masqueOnly ? (
+          <p className="py-2 text-[13px] text-muted-foreground">
+            Your protocol is set to{" "}
+            <span className="font-medium text-foreground">
+              {profile.protocol === "wg" ? "WireGuard" : "WARP in WARP"}
+            </span>
+            . This searches for MASQUE gateways only, so anything found here applies when you switch back to
+            MASQUE — it will not change how {profile.protocol === "wg" ? "WireGuard" : "WARP in WARP"} connects.
+          </p>
+        ) : null}
+
         {connected ? (
           <p className="py-2 text-[13px] text-muted-foreground">
             Disconnect first — scanning while connected competes with the tunnel for the same gateways and

--- a/src/features/Scanner.tsx
+++ b/src/features/Scanner.tsx
@@ -4,9 +4,17 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { cancelScan, scanEndpoints, testEndpoint, type ScanCandidate } from "@/core/api";
 import { normalizeEndpoint } from "@/core/endpoint";
+import { byNetwork, summarise } from "./grouping";
 import type { ConnectionProfile, CoreSnapshot } from "@/types";
 
 type Phase = "idle" | "scanning" | "testing" | "cancelling";
+
+/**
+ * The core's own ceiling. Asking for fewer hides whole ranges: results are
+ * ranked by round-trip time, so the nearest network fills the list and the
+ * alternatives you would want when it is throttled never appear.
+ */
+const SCAN_LIMIT = 16;
 
 interface ScannerProps {
   profile: ConnectionProfile;
@@ -37,7 +45,7 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
     setError(null);
     setNote(null);
     try {
-      const outcome = await scanEndpoints(profile, 8);
+      const outcome = await scanEndpoints(profile, SCAN_LIMIT);
       if (!live.current) return;
       setCandidates(outcome.candidates);
       if (outcome.candidates.length === 0) {
@@ -46,7 +54,7 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
         setNote(
           outcome.fellBack
             ? `Nothing over ${label(profile.masqueTransport)}; these answered over ${label(outcome.transport)}.`
-            : `${outcome.candidates.length} gateway${outcome.candidates.length === 1 ? "" : "s"} answered.`,
+            : summarise(outcome.candidates),
         );
       }
     } catch (raw) {
@@ -142,37 +150,51 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
         {note && !error ? <p className="py-2 text-[13px] text-muted-foreground">{note}</p> : null}
 
         {candidates.length > 0 ? (
-          <div className="mt-1 flex flex-col overflow-hidden rounded-md border">
-            {candidates.map((candidate, index) => {
-              const chosen = pinned === candidate.peer;
-              return (
-                <button
-                  key={candidate.peer}
-                  type="button"
-                  onClick={() => {
-                    onPick(candidate.peer);
-                    onToast("Endpoint pinned", `${candidate.peer} — set Endpoint mode to use it.`);
-                  }}
-                  className={[
-                    "flex items-center justify-between gap-3 border-b px-3.5 py-2.5 text-left transition-colors last:border-b-0",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                    chosen ? "bg-primary/10" : "hover:bg-accent",
-                  ].join(" ")}
-                >
-                  <div className="flex min-w-0 items-center gap-3">
-                    <span className="tabular w-4 shrink-0 font-mono text-[11px] text-muted-foreground">
-                      {index + 1}
-                    </span>
-                    <span className="truncate font-mono text-[13px]">{candidate.peer}</span>
-                    {chosen ? <CheckCircle2 className="size-4 shrink-0 text-primary" /> : null}
-                  </div>
-                  <div className="flex shrink-0 items-center gap-2.5">
-                    <Latency ms={candidate.rttMs} best={candidates[0].rttMs} />
-                    <span className="tabular w-16 text-right font-mono text-[13px]">{candidate.rttMs} ms</span>
-                  </div>
-                </button>
-              );
-            })}
+          <div className="mt-1 flex flex-col gap-2.5">
+            {byNetwork(candidates).map(({ network, members }) => (
+              <div key={network} className="overflow-hidden rounded-md border">
+                <div className="flex items-baseline justify-between gap-3 border-b bg-muted/40 px-3.5 py-2">
+                  <span className="font-mono text-[12px] font-medium">{network}</span>
+                  <span className="text-[11.5px] text-muted-foreground">
+                    {members.length} gateway{members.length === 1 ? "" : "s"} · best{" "}
+                    <span className="tabular font-mono">{members[0].rttMs} ms</span>
+                  </span>
+                </div>
+                {members.map((candidate) => {
+                  const chosen = pinned === candidate.peer;
+                  const rank = candidates.indexOf(candidate) + 1;
+                  return (
+                    <button
+                      key={candidate.peer}
+                      type="button"
+                      onClick={() => {
+                        onPick(candidate.peer);
+                        onToast("Endpoint pinned", `${candidate.peer} — set Endpoint mode to use it.`);
+                      }}
+                      className={[
+                        "flex w-full items-center justify-between gap-3 border-b px-3.5 py-2.5 text-left transition-colors last:border-b-0",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                        chosen ? "bg-primary/10" : "hover:bg-accent",
+                      ].join(" ")}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span className="tabular w-5 shrink-0 font-mono text-[11px] text-muted-foreground">
+                          {rank}
+                        </span>
+                        <span className="truncate font-mono text-[13px]">{candidate.peer}</span>
+                        {chosen ? <CheckCircle2 className="size-4 shrink-0 text-primary" /> : null}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2.5">
+                        <Latency ms={candidate.rttMs} best={candidates[0].rttMs} />
+                        <span className="tabular w-16 text-right font-mono text-[13px]">
+                          {candidate.rttMs} ms
+                        </span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
           </div>
         ) : null}
       </CardContent>

--- a/src/features/grouping.test.ts
+++ b/src/features/grouping.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { ScanCandidate } from "../core/api.ts";
+import { byNetwork, networkOf, summarise } from "./grouping.ts";
+
+function candidate(peer: string, rttMs: number): ScanCandidate {
+  return { peer, rttMs };
+}
+
+test("an IPv4 gateway is grouped by its /24", () => {
+  assert.equal(networkOf("162.159.198.127:443"), "162.159.198.0/24");
+  assert.equal(networkOf("188.114.96.3:8443"), "188.114.96.0/24");
+  // The port must not leak into the network label.
+  assert.ok(!networkOf("162.159.198.2:443").includes("443"));
+});
+
+test("an IPv6 gateway is grouped by its /48", () => {
+  // Bracketed with a port, which is how the core reports a v6 gateway.
+  assert.equal(networkOf("[2606:4700:102:abcd::1]:443"), "2606:4700:102::/48");
+  assert.equal(networkOf("[2606:4700:d0:1::9]:443"), "2606:4700:d0::/48");
+});
+
+test("networks are ordered by their fastest gateway, not by size", () => {
+  const groups = byNetwork([
+    candidate("188.114.96.1:443", 90),
+    candidate("162.159.198.2:443", 200),
+    candidate("162.159.198.9:443", 205),
+    candidate("162.159.198.7:443", 210),
+  ]);
+  assert.deepEqual(
+    groups.map((group) => group.network),
+    ["188.114.96.0/24", "162.159.198.0/24"],
+    "a single fast gateway must outrank a slower crowd",
+  );
+  assert.equal(groups[0].members.length, 1);
+  assert.equal(groups[1].members.length, 3);
+});
+
+test("nothing is dropped by grouping", () => {
+  const candidates = [
+    candidate("162.159.198.2:443", 200),
+    candidate("188.114.96.1:443", 90),
+    candidate("[2606:4700:102::1]:443", 150),
+  ];
+  const total = byNetwork(candidates).reduce((count, group) => count + group.members.length, 0);
+  assert.equal(total, candidates.length);
+});
+
+test("the summary says whether there is any real choice", () => {
+  // One network answering is the case worth naming: it means no alternative if
+  // that range gets throttled.
+  assert.match(summarise([candidate("162.159.198.2:443", 200)]), /1 gateway answered, all on one network/);
+  assert.match(
+    summarise([candidate("162.159.198.2:443", 200), candidate("162.159.198.9:443", 210)]),
+    /2 gateways answered, all on one network/,
+  );
+  assert.match(
+    summarise([candidate("162.159.198.2:443", 200), candidate("188.114.96.1:443", 90)]),
+    /2 gateways answered across 2 networks/,
+  );
+});

--- a/src/features/grouping.ts
+++ b/src/features/grouping.ts
@@ -1,0 +1,38 @@
+import type { ScanCandidate } from "@/core/api";
+
+export function summarise(candidates: ScanCandidate[]): string {
+  const networks = byNetwork(candidates).length;
+  const gateways = `${candidates.length} gateway${candidates.length === 1 ? "" : "s"}`;
+  if (networks === 1) return `${gateways} answered, all on one network.`;
+  return `${gateways} answered across ${networks} networks.`;
+}
+
+/// Gateways grouped by the network they sit in, best first.
+///
+/// A flat list sorted by latency is dominated by whichever range is nearest,
+/// which reads as "the scanner only finds one place". Grouping shows which
+/// networks answer at all -- the thing worth knowing when the usual one is
+/// being throttled.
+export function byNetwork(candidates: ScanCandidate[]) {
+  const groups = new Map<string, ScanCandidate[]>();
+  for (const candidate of candidates) {
+    const network = networkOf(candidate.peer);
+    const existing = groups.get(network);
+    if (existing) existing.push(candidate);
+    else groups.set(network, [candidate]);
+  }
+  return [...groups.entries()]
+    .map(([network, members]) => ({ network, members }))
+    .sort((a, b) => a.members[0].rttMs - b.members[0].rttMs);
+}
+
+/// The /24 for IPv4, the /48 for IPv6 — the granularity Cloudflare allocates
+/// these gateways in, so it matches the ranges actually being sampled.
+export function networkOf(peer: string): string {
+  if (peer.startsWith("[")) {
+    const address = peer.slice(1, peer.indexOf("]"));
+    return `${address.split(":").slice(0, 3).join(":")}::/48`;
+  }
+  const octets = peer.split(":")[0].split(".");
+  return octets.length === 4 ? `${octets.slice(0, 3).join(".")}.0/24` : peer;
+}


### PR DESCRIPTION
Everything since 1.1.0, plus the version bump. All four version declarations
move together so the installer name, window title and crate cannot disagree.

## "Whole machine" now works

Two defects, either of which alone stopped it on Windows.

The proxy was applied only on the log line reporting the listener coming up, so
choosing "whole machine" *after* connecting set a field and did nothing — while
the screen offers that choice in the connected state. There is now a command for
it, and the choice survives a reconnect.

The value written was `socks=127.0.0.1:1819`. That is the correct way to declare
a SOCKS proxy to WinINET and nearly useless: WinINET reads it as SOCKS4, and
Chrome and Edge ignore the key. Aether serves SOCKS5 only, so nothing followed
it. The client now runs a small HTTP proxy on loopback and points Windows there,
translating each request into a SOCKS5 connection through the core. Host names go
to SOCKS5 as names, so DNS stays inside the tunnel. macOS and GNOME speak SOCKS5
and are still handed the core's listener directly.

Confirmed working on Windows by the user.

## Endpoint scanner

The core front-loads eight fixed seed gateways, and a scan asked for eight
results, so on any network where the seeds answer the list filled with them and
no sampled address was ever reached — every search depth returned the same
handful. Scanning now spreads the seeds through the sampled addresses; connecting
still tries them first. Turbo also returned exactly one result however many were
asked for.

Results now ask for the core's full sixteen and are grouped by network — /24 for
IPv4, /48 for IPv6 — ordered by each network's fastest member, because a flat
list ranked by latency is dominated by whichever range is nearest and reads as
"the scanner only finds one place".

"Test pinned" probed over H2 regardless of the profile, so on a network that
interferes with QUIC an address could be reported good and then fail on the next
connect over H3. It now uses the configured transport.

The panel also says what it does: the reporting modes are MASQUE-only, so the
protocol picker has no effect there, and selecting WireGuard and watching MASQUE
gateways come back read as a bug.

Core pinned to `v1.5.0-whiteaesther.3`, which carries the seed fix.

## Known limitation, investigated and parked

On some networks the scanner finds only one range. The cause is not the address
list: `tls::install_verification` pins the leaf certificate's SPKI hash against
two entries in `MASQUE_PINS`, and most of Cloudflare's fleet presents something
else — including the endpoint Cloudflare's own API assigns. Measured with 224
real handshakes across 14 ranges on both transports. Widening or removing the pin
is a security decision on a circumvention tool and was left alone.