### PR TITLE
Release 1.2.0

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -7,7 +7,9 @@ name: build, test and release
 on:
   pull_request:
   push:
-    branches: [main]
+    # Tags only. A merge to main is the same tree a pull request just built and
+    # passed, so building it again bought nothing and cost a full three-platform
+    # run on every merge.
     tags: ["v*"]
   workflow_dispatch:
 
@@ -140,10 +142,10 @@ jobs:
   release:
     name: Publish GitHub release
     needs: package
-    if: >-
-      (github.event_name == 'push' &&
-        (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))) ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    # A version tag is now the only thing that publishes. workflow_dispatch still
+    # builds and uploads artifacts, so a manual check of the packages does not
+    # have to create a release to get them.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -175,7 +177,7 @@ jobs:
             | sort -z \
             | xargs -0 sha256sum > SHA256SUMS
 
-      - name: Publish tagged or continuous release
+      - name: Publish the tagged release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -183,39 +185,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            tag="${GITHUB_REF_NAME}"
-            if gh release view "$tag" >/dev/null 2>&1; then
-              gh release upload "$tag" release-assets/* --clobber
-            else
-              gh release create "$tag" release-assets/* \
-                --verify-tag \
-                --generate-notes \
-                --title "WhiteAesther $tag"
-            fi
-            exit 0
-          fi
-
-          tag="continuous"
-          title="WhiteAesther continuous build"
-          notes="Automated packages from commit ${GITHUB_SHA}. This prerelease is replaced after every successful main build."
-
-          if gh api "repos/${GH_REPO}/git/ref/tags/${tag}" >/dev/null 2>&1; then
-            gh api --method PATCH "repos/${GH_REPO}/git/refs/tags/${tag}" \
-              -f sha="${GITHUB_SHA}" \
-              -F force=true >/dev/null
-          else
-            gh api --method POST "repos/${GH_REPO}/git/refs" \
-              -f ref="refs/tags/${tag}" \
-              -f sha="${GITHUB_SHA}" >/dev/null
-          fi
-
+          tag="${GITHUB_REF_NAME}"
           if gh release view "$tag" >/dev/null 2>&1; then
-            gh release edit "$tag" --title "$title" --notes "$notes" --prerelease
             gh release upload "$tag" release-assets/* --clobber
           else
             gh release create "$tag" release-assets/* \
-              --title "$title" \
-              --notes "$notes" \
-              --prerelease
+              --verify-tag \
+              --generate-notes \
+              --title "WhiteAesther $tag"
           fi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.1.1"
+version = "1.2.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## What ships

**The Simple screen, rebuilt around a live connection.** A measured round-trip series replaces the single figure parsed from the engine's `rtt 84.5ms` at connect; failed probes stay in the series as gaps so a bad minute looks bad. A speed test downloads through the tunnel. The connect orb is the Android client's, so the two read as one product. The app carries its own icon, with version, engine build, licence and source in the footer — AGPL-3.0 obliges us to say where the source for a build lives, and the desktop client previously did not.

**A kill switch that heals itself.** Traffic is held when the tunnel dies and the search continues on a slow loop until a route returns, with a banner and a tray entry as ways out. Its first cut ended the session, which blocked the machine and then waited to be noticed — verified fixed by killing the engine and watching it recover unattended.

**Two switches that were previously fixed behaviour:** whether a dropped session is retried at all, and whether traffic fails closed.

**The footer version now comes from `package.json`.** Released builds were always right because CI sets it; every local build fell back to a hardcoded `1.0.0` and stated a version it was not.

## One release, one build

Building a release cost two full three-platform runs — one when the merge landed on `main`, one when the tag was pushed, from the same tree.

The `main` push trigger is gone. A pull request already builds and tests that tree before it merges, and a version tag is now the only thing that publishes. `workflow_dispatch` still builds and uploads artifacts, so packages can be checked by hand without creating a release.

That retires the `continuous` prerelease, whose assets were from 8 August and which was replaced on every merge whether anyone wanted it or not.

## Verification

- 39 backend tests, 25 frontend tests, `tsc --noEmit` clean
- Windows bundle built and installed; kill switch recovery confirmed by killing the engine process
- Workflow parsed and asserted: `push` fires on tags only, `pull_request` still validates, release job gated on `refs/tags/v`

## Known and not fixed here

The moderate Dependabot alert is `glib` 0.18.5, pulled only by the GTK/WebKitGTK stack, so it affects the Linux build alone — Windows and macOS never compile it. The fix is 0.20.0, which `cargo update` cannot reach because tauri's GTK dependencies pin the 0.18 line. It needs an upstream release, not a change here.