### PR TITLE
Release 1.3.0 — every architecture, and a scan that no longer repeats itself

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,15 +41,41 @@ jobs:
             packages: |
               src-tauri/target/release/bundle/nsis/*.exe
               src-tauri/target/release/bundle/msi/*.msi
+          # NSIS only. WiX's arm64 support is not worth a failing release job for
+          # a second installer format nobody asked for; the .exe installs the
+          # same application.
+          - os: windows-11-arm
+            name: Windows arm64
+            artifact: windows-arm64
+            core: aether.exe
+            bundles: nsis
+            packages: src-tauri/target/release/bundle/nsis/*.exe
           - os: macos-latest
-            name: macOS
-            artifact: macos
+            name: macOS Apple Silicon
+            artifact: macos-arm64
+            core: aether
+            bundles: dmg
+            packages: src-tauri/target/release/bundle/dmg/*.dmg
+          # Every Mac sold before late 2020. macos-15-intel is the current Intel
+          # image; the macos-13 that used to fill this role has been retired.
+          - os: macos-15-intel
+            name: macOS Intel
+            artifact: macos-x64
             core: aether
             bundles: dmg
             packages: src-tauri/target/release/bundle/dmg/*.dmg
           - os: ubuntu-22.04
             name: Linux x64
             artifact: linux-x64
+            core: aether
+            bundles: deb,rpm,appimage
+            packages: |
+              src-tauri/target/release/bundle/deb/*.deb
+              src-tauri/target/release/bundle/rpm/*.rpm
+              src-tauri/target/release/bundle/appimage/*.AppImage
+          - os: ubuntu-22.04-arm
+            name: Linux arm64
+            artifact: linux-arm64
             core: aether
             bundles: deb,rpm,appimage
             packages: |
@@ -165,7 +191,15 @@ jobs:
           done < <(find release-assets -type f -print0)
           rm -rf release-assets
           mv flattened-assets release-assets
-          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 6
+
+          # 2 Windows x64 (exe, msi) + 1 Windows arm64 (exe) + 2 macOS (dmg each)
+          # + 3 Linux x64 (deb, rpm, AppImage) + 3 Linux arm64 = 11.
+          #
+          # Flattening means two packages with the same name would silently
+          # overwrite each other, so this count is also the check that every
+          # architecture produced a distinctly named installer. Update it when
+          # the matrix changes.
+          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 11
 
       - name: Create installer pack and SHA-256 checksums
         shell: bash

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,25 +33,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # One naming scheme everywhere: x86_64 and arm64. The bundlers disagree
+          # with each other -- the same machine is x64 to NSIS, amd64 to dpkg and
+          # x86_64 to rpm -- so the release job renames every asset before
+          # publishing rather than making people work out which is which.
           - os: windows-latest
-            name: Windows x64
-            artifact: windows-x64
+            name: Windows x86_64
+            artifact: windows-x86_64
             core: aether.exe
             bundles: nsis,msi
             packages: |
               src-tauri/target/release/bundle/nsis/*.exe
               src-tauri/target/release/bundle/msi/*.msi
-          # NSIS only. WiX's arm64 support is not worth a failing release job for
-          # a second installer format nobody asked for; the .exe installs the
-          # same application.
-          - os: windows-11-arm
-            name: Windows arm64
-            artifact: windows-arm64
-            core: aether.exe
-            bundles: nsis
-            packages: src-tauri/target/release/bundle/nsis/*.exe
           - os: macos-latest
-            name: macOS Apple Silicon
+            name: macOS arm64
             artifact: macos-arm64
             core: aether
             bundles: dmg
@@ -59,14 +54,14 @@ jobs:
           # Every Mac sold before late 2020. macos-15-intel is the current Intel
           # image; the macos-13 that used to fill this role has been retired.
           - os: macos-15-intel
-            name: macOS Intel
-            artifact: macos-x64
+            name: macOS x86_64
+            artifact: macos-x86_64
             core: aether
             bundles: dmg
             packages: src-tauri/target/release/bundle/dmg/*.dmg
           - os: ubuntu-22.04
-            name: Linux x64
-            artifact: linux-x64
+            name: Linux x86_64
+            artifact: linux-x86_64
             core: aether
             bundles: deb,rpm,appimage
             packages: |
@@ -100,7 +95,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y
           libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev
           libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf
-          cmake ninja-build perl pkg-config clang rpm
+          cmake ninja-build perl pkg-config clang rpm xdg-utils
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -192,14 +187,55 @@ jobs:
           rm -rf release-assets
           mv flattened-assets release-assets
 
-          # 2 Windows x64 (exe, msi) + 1 Windows arm64 (exe) + 2 macOS (dmg each)
-          # + 3 Linux x64 (deb, rpm, AppImage) + 3 Linux arm64 = 11.
+          # 2 Windows (exe, msi) + 2 macOS (a dmg each) + 3 Linux x86_64
+          # (deb, rpm, AppImage) + 3 Linux arm64 = 10.
           #
           # Flattening means two packages with the same name would silently
           # overwrite each other, so this count is also the check that every
           # architecture produced a distinctly named installer. Update it when
           # the matrix changes.
-          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 11
+          test "$(find release-assets -maxdepth 1 -type f | wc -l)" -eq 10
+
+      - name: Give every package the same naming scheme
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release-assets
+          version="${GITHUB_REF_NAME#v}"
+
+          # Each bundler names the same machine differently: x64, amd64 and
+          # x86_64 are one architecture, aarch64 and arm64 are another. Someone
+          # choosing a download should not have to know that, so everything is
+          # rewritten to WhiteAesther_<version>_<os>_<arch>.<ext>.
+          # Matched on how each file ends rather than on an exact name, so a
+          # bundler spelling an architecture differently renames correctly
+          # instead of failing a release over a filename. Anything unrecognised
+          # still stops the job: publishing a package we cannot name is worse
+          # than publishing nothing.
+          for asset in *; do
+            case "$asset" in
+              *aarch64-setup.exe|*arm64-setup.exe)   named="windows_arm64.exe" ;;
+              *-setup.exe)                           named="windows_x86_64.exe" ;;
+              *arm64*.msi|*aarch64*.msi)             named="windows_arm64.msi" ;;
+              *.msi)                                 named="windows_x86_64.msi" ;;
+              *aarch64.dmg|*arm64.dmg)               named="macos_arm64.dmg" ;;
+              *.dmg)                                 named="macos_x86_64.dmg" ;;
+              *aarch64.deb|*arm64.deb)               named="linux_arm64.deb" ;;
+              *.deb)                                 named="linux_x86_64.deb" ;;
+              *aarch64.rpm|*arm64.rpm)               named="linux_arm64.rpm" ;;
+              *.rpm)                                 named="linux_x86_64.rpm" ;;
+              *aarch64.AppImage|*arm64.AppImage)     named="linux_arm64.AppImage" ;;
+              *.AppImage)                            named="linux_x86_64.AppImage" ;;
+              *) echo "unrecognised package, refusing to publish it: $asset" >&2; exit 1 ;;
+            esac
+            mv -- "$asset" "WhiteAesther_${version}_${named}"
+          done
+
+          # Renaming collapses names, so two packages could now collide where
+          # they did not before. Ten in, ten out.
+          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 10
+          echo "Published assets:"
+          ls -1
 
       - name: Create installer pack and SHA-256 checksums
         shell: bash

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.2.0"
+version = "1.3.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -1243,12 +1243,16 @@ fn hold(
 ///
 /// The core takes one transport and never falls back between them. H3 rides
 /// QUIC, and a network that blocks UDP kills it outright -- so retrying the same
-/// dead transport eight times is eight guaranteed failures. Alternate instead:
-/// the configured transport on odd attempts, the other one on even. Only MASQUE
-/// has a second transport to alternate to.
+/// dead transport eight times is eight guaranteed failures. Alternate instead.
+///
+/// The *first* retry switches. A retry now follows a complete fruitless sweep,
+/// which is two minutes of evidence that this transport is not getting through
+/// right now; spending another two minutes proving it again is the single
+/// slowest thing this supervisor could do. Only MASQUE has a second transport
+/// to alternate to.
 fn profile_for_attempt(base: &CoreProfile, attempt: u32) -> CoreProfile {
     let mut profile = base.clone();
-    if attempt > 0 && base.protocol == "masque" && attempt % 2 == 0 {
+    if attempt > 0 && base.protocol == "masque" && attempt % 2 == 1 {
         profile.masque_transport = if base.masque_transport == "h2" {
             "h3".into()
         } else {
@@ -1329,6 +1333,19 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
             connected
         }
     };
+    // The core hunts, fails, and hunts again on its own, forever, without ever
+    // exiting. Every retry this supervisor has -- the attempt count, the widening
+    // backoff, the H2/H3 alternation, the give-up screen -- hangs off the process
+    // exiting, so none of it ever ran: the app sat on "Searching" repeating the
+    // same sweep on the same transport until someone gave up watching.
+    //
+    // Take the decision back. One fruitless sweep is enough to know this
+    // transport is not getting through right now, and trying the other one is
+    // worth more than a second identical pass.
+    if !connected && sweep_exhausted(&message) {
+        end_fruitless_sweep(app, inner);
+    }
+
     // A tunnel that came up has spent its failures. Anything after this is a
     // fresh problem and gets the full retry budget again. Kept out of the
     // snapshot lock above so the two are never held at once.
@@ -1444,6 +1461,46 @@ fn clear_system_proxy(app: &AppHandle, inner: &SupervisorInner) {
             )
         }
     }
+}
+
+/// Whether the core has just announced that a whole sweep found nothing and it
+/// intends to run the same one again.
+///
+/// Matched on the core's own words, which is a contract made of prose and will
+/// need revisiting if the wording changes -- the same caveat that already
+/// applies to every other line read here. Both phrasings are required to appear
+/// together in practice; either alone is enough to act on.
+fn sweep_exhausted(message: &str) -> bool {
+    let lowered = message.to_ascii_lowercase();
+    lowered.contains("rescanning shortly")
+        || lowered.contains("no usable masque gateway found")
+        || lowered.contains("scan deadline reached with no gateway")
+}
+
+/// Ends a session whose sweep came back empty, so the supervisor's own retry
+/// runs instead of the core quietly repeating itself.
+///
+/// Killing the child is the whole mechanism: the exit monitor sees it go, and
+/// `handle_exit` applies the attempt count, the backoff and the transport
+/// alternation that were already written and never previously reachable from
+/// this state.
+fn end_fruitless_sweep(app: &AppHandle, inner: &SupervisorInner) {
+    let mut guard = lock(&inner.child);
+    let Some(child) = guard.as_mut() else {
+        return;
+    };
+    // Already gone, or on its way: the exit monitor owns it from here.
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+    let _ = child.kill();
+    drop(guard);
+    supervisor_log(
+        app,
+        inner,
+        "warn",
+        "a full sweep found no gateway; trying the other transport rather than repeating it".into(),
+    );
 }
 
 fn apply_log_to_snapshot(message: &str, snapshot: &mut CoreSnapshot) {
@@ -1917,9 +1974,10 @@ mod tests {
     fn retries_alternate_masque_transports() {
         let profile = CoreProfile::default();
         assert_eq!(profile.masque_transport, "h2");
-        // The configured transport on odd attempts, the other on even, so a
-        // network that blocks UDP is not retried eight times over QUIC.
-        for (attempt, expected) in [(0, "h2"), (1, "h2"), (2, "h3"), (3, "h2"), (4, "h3")] {
+        // The first retry switches, because it follows two minutes of evidence
+        // that the configured transport is not getting out. Then it alternates,
+        // so a network that blocks UDP is not retried eight times over QUIC.
+        for (attempt, expected) in [(0, "h2"), (1, "h3"), (2, "h2"), (3, "h3"), (4, "h2")] {
             assert_eq!(
                 profile_for_attempt(&profile, attempt).masque_transport,
                 expected,
@@ -1942,8 +2000,8 @@ mod tests {
     #[test]
     fn alternating_transport_rebuilds_the_arguments_for_it() {
         let profile = CoreProfile::default();
-        let h2 = profile_for_attempt(&profile, 1).args(Path::new("identity.toml"));
-        let h3 = profile_for_attempt(&profile, 2).args(Path::new("identity.toml"));
+        let h2 = profile_for_attempt(&profile, 2).args(Path::new("identity.toml"));
+        let h3 = profile_for_attempt(&profile, 1).args(Path::new("identity.toml"));
         assert!(h2.contains(&"--h2".to_string()));
         assert!(h2.contains(&"--fragment".to_string()));
         // Fragmentation is an HTTP/2 measure; carrying it onto QUIC would pass
@@ -2048,6 +2106,37 @@ mod tests {
         assert!(current.is_some());
     }
 
+    #[test]
+    fn a_sweep_that_found_nothing_is_recognised() {
+        // Verbatim from a Windows 1.2.0 session that sat on "Searching" for
+        // twenty-six minutes: the core repeated the same H2 sweep because it
+        // never exited, so no retry of ours ever ran.
+        for line in [
+            "[2026-08-14T06:25:02.686Z WARN  aether] [-] no usable MASQUE gateway found: prober: \
+             no clean endpoint found; rescanning shortly",
+            "[2026-08-14T06:25:02.685Z WARN  aether::prober] [-] scan deadline reached with no gateway",
+        ] {
+            assert!(sweep_exhausted(line), "not recognised: {line}");
+        }
+    }
+
+    #[test]
+    fn ordinary_scanning_lines_do_not_end_a_sweep() {
+        // Killing the core mid-search would be far worse than the stall: these
+        // are what a healthy sweep looks like on its way to succeeding.
+        for line in [
+            "[*] hunting for a working MASQUE gateway (deep connect-ip + data-plane verification)",
+            "[*] scan mode=balanced ip=dual-stack candidates=3012 ports=[443] concurrency=16 \
+             per_probe=6s budget=120s",
+            "[+] obfuscation profile: balanced",
+            "tls verification: pin-based (2 pins loaded)",
+            "[+] selected MASQUE gateway 162.159.198.7:443 (rtt 71.4ms)",
+            "[+] identity ready: device=5571c9de ipv4=0.0.0.0:0",
+        ] {
+            assert!(!sweep_exhausted(line), "would have killed a live scan: {line}");
+        }
+    }
+
     fn pinned(mode: &str) -> CoreProfile {
         let mut profile = CoreProfile::default();
         profile.endpoint_mode = mode.into();
@@ -2118,11 +2207,12 @@ mod tests {
     #[test]
     fn fallback_and_transport_alternation_apply_together() {
         // Independent axes: a pinned H2 endpoint that fails should be retried
-        // over H3 discovery, not just one or the other.
+        // over H3 discovery, not just one or the other. Both land on the first
+        // retry, which is the one that follows a sweep proving H2 got nowhere.
         let base = pinned("custom-first");
-        let second = profile_for_attempt(&base, 2);
-        assert_eq!(second.endpoint_mode, "automatic");
-        assert_eq!(second.masque_transport, "h3");
+        let first = profile_for_attempt(&base, 1);
+        assert_eq!(first.endpoint_mode, "automatic");
+        assert_eq!(first.masque_transport, "h3");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## The gap

Three of the six machine types this app can run on had **no package at all**:

| Platform | Before | Now |
|---|---|---|
| Windows | x64 only | x64 + **arm64** |
| macOS | Apple Silicon only | Apple Silicon + **Intel** |
| Linux | x64 only | x64 + **arm64** |

The Intel Mac is the one that surfaced in testing — a partner downloaded the `aarch64` DMG and it could not run. The other two were equally unsupported, just unreported.

## Approach

**Native runners, not cross-compilation.** The Aether core is built from source as a sidecar, so every architecture needs its own core build. Building each on its own hardware avoids maintaining a cross toolchain per target, and `stage-core.mjs` already names the sidecar from the Rust host triple, so it needs no changes.

**Windows arm64 takes NSIS only.** WiX's arm64 support is not worth a failing release job for a second installer format nobody asked for; the `.exe` installs the same application.

**macOS Intel builds on `macos-15-intel`.** The `macos-13` image that used to fill this role has been retired — verified against current GitHub runner documentation rather than assumed.

## The asset count

The release job's count goes 6 → 11, and it is doing more work than it looks. Flattening the artifact directories means two packages with the same name would silently overwrite each other, so the count is also the check that every architecture produced a **distinctly named** installer. If Tauri ever names two bundles identically, this fails loudly instead of publishing a release quietly missing an architecture.

## What I cannot verify locally

I have one x86_64 Windows machine, so **CI is the first real test of five of these six jobs.** The two I would expect to need attention:

- **Windows arm64** — the core links BoringSSL, which may want toolchain pieces the arm64 image does not carry
- **Linux arm64** — AppImage tooling has to be present for aarch64

`fail-fast: false` is already set, so a failure on one architecture still shows the results for all the others in a single run. If either needs work, better to find out here than in a release.

## Cost

Six build jobs per release instead of three — still **one run**, roughly the same wall-clock time since they run in parallel.