### PR TITLE
Release 1.5.0 — the exit chain

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -224,6 +224,11 @@ jobs:
       - name: Stage the target-specific Aether sidecar
         run: pnpm stage:core -- --source "${{ github.workspace }}/aether-core/aether/target/release/${{ matrix.core }}"
 
+      # A released binary rather than something we build, pinned in the script
+      # so a release cannot pick up whatever upstream published that morning.
+      - name: Stage the chain engine
+        run: pnpm stage:chain
+
       - name: Test the Tauri backend
         run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "test": "node --test \"src/**/*.test.ts\"",
     "preview": "vite preview",
     "stage:core": "node scripts/stage-core.mjs",
-    "desktop:dev": "pnpm stage:core && tauri dev",
-    "desktop:build": "pnpm stage:core && tauri build",
+    "stage:chain": "node scripts/stage-chain.mjs",
+    "desktop:dev": "pnpm stage:core && pnpm stage:chain && tauri dev",
+    "desktop:build": "pnpm stage:core && pnpm stage:chain && tauri build",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/scripts/stage-chain.mjs
+++ b/scripts/stage-chain.mjs
@@ -1,0 +1,115 @@
+/**
+ * Fetches the mihomo binary and stages it as a Tauri sidecar.
+ *
+ * The chain engine is a released binary rather than something we build, so
+ * unlike the Aether core there is no source tree to compile -- but it still has
+ * to arrive under the target-triple name Tauri expects, and it still has to be
+ * pinned, or a release would silently pick up whatever upstream published that
+ * morning.
+ */
+import { createHash } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { createGunzip } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createReadStream } from "node:fs";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const option = (name) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+/** Pinned so a build is reproducible. Bump deliberately. */
+const VERSION = "v1.19.30";
+
+/**
+ * The "compatible" builds avoid newer CPU instructions, which is the right
+ * default for a client that has to run on whatever machine a user has.
+ */
+const ASSETS = {
+  "x86_64-pc-windows-msvc": `mihomo-windows-amd64-compatible-${VERSION}.zip`,
+  "aarch64-pc-windows-msvc": `mihomo-windows-arm64-${VERSION}.zip`,
+  "x86_64-apple-darwin": `mihomo-darwin-amd64-compatible-${VERSION}.gz`,
+  "aarch64-apple-darwin": `mihomo-darwin-arm64-${VERSION}.gz`,
+  "x86_64-unknown-linux-gnu": `mihomo-linux-amd64-compatible-${VERSION}.gz`,
+  "aarch64-unknown-linux-gnu": `mihomo-linux-arm64-${VERSION}.gz`,
+};
+
+const target = option("--target") ?? process.env.CARGO_BUILD_TARGET ?? rustHost();
+const asset = ASSETS[target];
+if (!asset) {
+  throw new Error(
+    `No mihomo build is mapped for ${target}. Add it to ASSETS, or the chain will be missing.`,
+  );
+}
+
+const extension = target.includes("windows") ? ".exe" : "";
+const destination = join(appRoot, "src-tauri", "binaries", `mihomo-${target}${extension}`);
+await mkdir(dirname(destination), { recursive: true });
+
+if (await isStaged(destination)) {
+  console.log(`mihomo ${VERSION} already staged for ${target}`);
+} else {
+  const url = `https://github.com/MetaCubeX/mihomo/releases/download/${VERSION}/${asset}`;
+  console.log(`Fetching ${asset}`);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}`);
+  }
+
+  const scratch = `${destination}.download`;
+  if (asset.endsWith(".gz")) {
+    await pipeline(Readable.fromWeb(response.body), createGunzip(), createWriteStream(scratch));
+  } else {
+    // Node has no zip reader, and adding a dependency to unpack one file is a
+    // poor trade. The platforms that ship zips all have a system unzip.
+    const archive = `${destination}.zip`;
+    await writeFile(archive, Buffer.from(await response.arrayBuffer()));
+    unzipSingle(archive, scratch);
+    await rm(archive, { force: true });
+  }
+
+  await rm(destination, { force: true });
+  await writeFile(destination, await readFile(scratch));
+  await rm(scratch, { force: true });
+  if (!target.includes("windows")) await chmod(destination, 0o755);
+}
+
+const size = (await stat(destination)).size;
+const digest = createHash("sha256");
+await pipeline(createReadStream(destination), digest);
+console.log(`Staged mihomo ${VERSION} for ${target}`);
+console.log(`  ${destination}`);
+console.log(`  ${(size / 1048576).toFixed(1)} MB  sha256:${digest.digest("hex").slice(0, 16)}…`);
+
+async function isStaged(path) {
+  try {
+    return (await stat(path)).size > 1_000_000;
+  } catch {
+    return false;
+  }
+}
+
+function unzipSingle(archive, into) {
+  const script =
+    `$e=[IO.Compression.ZipFile]::OpenRead('${archive}');` +
+    `$f=$e.Entries|Where-Object{$_.Name -like '*.exe'}|Select-Object -First 1;` +
+    `[IO.Compression.ZipFileExtensions]::ExtractToFile($f,'${into}',$true);$e.Dispose()`;
+  execFileSync(
+    "powershell",
+    ["-NoProfile", "-Command", `Add-Type -AssemblyName System.IO.Compression.FileSystem; ${script}`],
+    { stdio: "inherit" },
+  );
+}
+
+function rustHost() {
+  const output = execFileSync("rustc", ["-vV"], { encoding: "utf8", windowsHide: true });
+  const host = output.match(/^host:\s*(.+)$/m)?.[1]?.trim();
+  if (!host) throw new Error("Could not determine the Rust host target");
+  return host;
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.4.0"
+version = "1.5.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -1,0 +1,584 @@
+//! The second hop: routing the tunnel's output through a node of your own.
+//!
+//! Cloudflare WARP is explicit that it does not change your country -- it
+//! egresses near you and geolocates the exit address to your region. So a user
+//! in Iran connects successfully and still looks like they are in Iran. The
+//! only way to change that is to add a hop after the tunnel.
+//!
+//! mihomo does the hop. Its `dialer-proxy` dials a node *through* another
+//! proxy, so every node is reached from inside the MASQUE tunnel and the exit
+//! address becomes the node's, not Cloudflare's. Verified end to end before any
+//! of this was written: a real subscription moved the visible country from TH
+//! to JP, and the tunnel saw the node being dialled through it.
+//!
+//! Two consequences of that order are worth stating, because they are the whole
+//! reason it is this way round and not the other:
+//!
+//! - the node is dialled from inside the tunnel, so local filtering sees an
+//!   ordinary Cloudflare connection and never the node's address or SNI, and
+//! - a node blocked from this network is still reachable, because it is reached
+//!   from Cloudflare's network rather than from here.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+/// The name the generated config gives the first hop. Referenced by every node
+/// through `dialer-proxy`, which is what puts them behind the tunnel.
+const TUNNEL_PROXY: &str = "aether";
+/// The group every rule points at. Selecting a node means selecting into this.
+const EXIT_GROUP: &str = "exit";
+/// The provider holding whatever the user pasted by hand.
+const MANUAL_PROVIDER: &str = "manual";
+
+/// How long to wait for mihomo to answer its own API before giving up on it.
+const READY_TIMEOUT: Duration = Duration::from_secs(12);
+const API_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(windows)]
+const MIHOMO_FILENAME: &str = "mihomo.exe";
+#[cfg(not(windows))]
+const MIHOMO_FILENAME: &str = "mihomo";
+
+/// A source of nodes. Either a subscription we or the user supplies, or a
+/// block of pasted config URIs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSource {
+    /// Shown in the dashboard so a node can be traced back to where it came from.
+    pub name: String,
+    pub url: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainSettings {
+    pub enabled: bool,
+    /// Subscription URLs. Ours ships as the first entry; the user may add more.
+    pub sources: Vec<ChainSource>,
+    /// Config URIs pasted by hand, one per line. mihomo converts these itself,
+    /// so vless, vmess, trojan, ss, hysteria2 and the rest all work without us
+    /// parsing anything.
+    pub manual: String,
+    /// The node last selected, so a reconnect returns to it.
+    pub node: Option<String>,
+}
+
+impl Default for ChainSettings {
+    fn default() -> Self {
+        Self { enabled: false, sources: Vec::new(), manual: String::new(), node: None }
+    }
+}
+
+/// A running mihomo, and the addresses it answers on.
+pub struct Running {
+    child: Child,
+    /// Where applications and the system proxy point while the chain is up.
+    pub mixed: SocketAddr,
+    api: SocketAddr,
+    secret: String,
+}
+
+#[derive(Default)]
+pub struct Chain {
+    running: Mutex<Option<Running>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainNode {
+    pub name: String,
+    /// Which source supplied it.
+    pub source: String,
+    /// Protocol as mihomo reports it, e.g. "Vless".
+    pub kind: String,
+    /// Milliseconds through the tunnel, or None when the last test failed.
+    pub delay: Option<u32>,
+}
+
+impl Chain {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn address(&self) -> Option<SocketAddr> {
+        self.running.lock().ok()?.as_ref().map(|running| running.mixed)
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.address().is_some()
+    }
+
+    /// Starts mihomo with every node dialling through `tunnel`.
+    ///
+    /// Returns the address to point applications at. Fails rather than starting
+    /// a chain that would silently bypass the tunnel.
+    pub fn start(
+        &self,
+        app: &AppHandle,
+        tunnel: SocketAddr,
+        settings: &ChainSettings,
+    ) -> Result<SocketAddr, String> {
+        self.stop();
+
+        let usable: Vec<&ChainSource> = settings
+            .sources
+            .iter()
+            .filter(|source| source.enabled && !source.url.trim().is_empty())
+            .collect();
+        if usable.is_empty() && settings.manual.trim().is_empty() {
+            return Err("add a subscription or a config before turning the chain on".into());
+        }
+
+        let binary = locate(app)?;
+        let home = app
+            .path()
+            .app_data_dir()
+            .map_err(|error| format!("no application data directory: {error}"))?
+            .join("chain");
+        std::fs::create_dir_all(home.join("providers"))
+            .map_err(|error| format!("cannot prepare the chain directory: {error}"))?;
+
+        let mixed = free_port()?;
+        let api = free_port()?;
+        let secret = secret();
+
+        if !settings.manual.trim().is_empty() {
+            std::fs::write(home.join("providers").join("manual.txt"), settings.manual.trim())
+                .map_err(|error| format!("cannot write the pasted configs: {error}"))?;
+        }
+
+        let config = render(tunnel, mixed, api, &secret, &usable, &settings.manual);
+        let config_path = home.join("config.yaml");
+        std::fs::write(&config_path, config)
+            .map_err(|error| format!("cannot write the chain config: {error}"))?;
+
+        let mut command = Command::new(&binary);
+        command
+            .arg("-f")
+            .arg(&config_path)
+            .arg("-d")
+            .arg(&home)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::null());
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            // Without this every launch flashes a console window.
+            command.creation_flags(0x0800_0000);
+        }
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("cannot start the chain: {error}"))?;
+
+        let api_address = SocketAddr::from((Ipv4Addr::LOCALHOST, api));
+        if let Err(error) = wait_until_ready(api_address, &secret) {
+            // A half-started chain must never be left behind: the system proxy
+            // would point at a port nothing is listening on.
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+
+        let mixed_address = SocketAddr::from((Ipv4Addr::LOCALHOST, mixed));
+        *self.running.lock().map_err(|_| "the chain lock is poisoned")? =
+            Some(Running { child, mixed: mixed_address, api: api_address, secret });
+        Ok(mixed_address)
+    }
+
+    pub fn stop(&self) {
+        let Ok(mut guard) = self.running.lock() else {
+            return;
+        };
+        if let Some(mut running) = guard.take() {
+            let _ = running.child.kill();
+            let _ = running.child.wait();
+        }
+    }
+
+    /// Every node from every source, with the delay each last recorded.
+    pub fn nodes(&self) -> Result<Vec<ChainNode>, String> {
+        let (api, secret) = self.control()?;
+        let body = get(api, &secret, "/providers/proxies")?;
+        let parsed: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|error| format!("the chain sent something unreadable: {error}"))?;
+
+        let mut nodes = Vec::new();
+        let Some(providers) = parsed.get("providers").and_then(|value| value.as_object()) else {
+            return Ok(nodes);
+        };
+        for (source, provider) in providers {
+            // The built-in "default" provider holds DIRECT, REJECT and the
+            // group itself -- none of which are somewhere traffic can exit.
+            if provider.get("vehicleType").and_then(|v| v.as_str()) == Some("Compatible") {
+                continue;
+            }
+            let Some(list) = provider.get("proxies").and_then(|value| value.as_array()) else {
+                continue;
+            };
+            for proxy in list {
+                let Some(name) = proxy.get("name").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                nodes.push(ChainNode {
+                    name: name.to_string(),
+                    source: source.clone(),
+                    kind: proxy.get("type").and_then(|v| v.as_str()).unwrap_or("?").to_string(),
+                    delay: proxy
+                        .get("history")
+                        .and_then(|v| v.as_array())
+                        .and_then(|history| history.last())
+                        .and_then(|entry| entry.get("delay"))
+                        .and_then(|v| v.as_u64())
+                        .filter(|delay| *delay > 0)
+                        .map(|delay| delay as u32),
+                });
+            }
+        }
+        nodes.sort_by(|a, b| match (a.delay, b.delay) {
+            (Some(left), Some(right)) => left.cmp(&right),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.name.cmp(&b.name),
+        });
+        Ok(nodes)
+    }
+
+    /// Measures one node, through the tunnel.
+    ///
+    /// This is the same question as "does this config work at all from here",
+    /// because mihomo sends the probe down the node's `dialer-proxy` -- so a
+    /// number means the config is usable behind the tunnel and a failure means
+    /// it is not. Nodes supplied by a provider are not addressable through
+    /// `/proxies/{name}/delay`; they answer only under their own provider.
+    pub fn test(&self, source: &str, node: &str) -> Result<Option<u32>, String> {
+        let (api, secret) = self.control()?;
+        let path = format!(
+            "/providers/proxies/{}/{}/healthcheck?url={}&timeout=8000",
+            encode(source),
+            encode(node),
+            encode("http://www.gstatic.com/generate_204"),
+        );
+        match get(api, &secret, &path) {
+            Ok(body) => {
+                let parsed: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                Ok(parsed.get("delay").and_then(|v| v.as_u64()).map(|d| d as u32))
+            }
+            // A node that cannot be reached is an answer, not an error: it is
+            // exactly what the dashboard needs to show against that node.
+            Err(_) => Ok(None),
+        }
+    }
+
+    /// Routes traffic through one node.
+    pub fn select(&self, node: &str) -> Result<(), String> {
+        let (api, secret) = self.control()?;
+        let body = format!("{{\"name\":{}}}", serde_json::to_string(node).unwrap_or_default());
+        put(api, &secret, &format!("/proxies/{}", encode(EXIT_GROUP)), &body)
+    }
+
+    fn control(&self) -> Result<(SocketAddr, String), String> {
+        let guard = self.running.lock().map_err(|_| "the chain lock is poisoned")?;
+        let running = guard.as_ref().ok_or("the chain is not running")?;
+        Ok((running.api, running.secret.clone()))
+    }
+}
+
+impl Drop for Chain {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Builds the config.
+///
+/// `dialer-proxy` is set per provider rather than per node, which is what lets
+/// a subscription of any size arrive without us parsing or rewriting a single
+/// entry: every node it carries inherits the tunnel.
+fn render(
+    tunnel: SocketAddr,
+    mixed: u16,
+    api: u16,
+    secret: &str,
+    sources: &[&ChainSource],
+    manual: &str,
+) -> String {
+    let mut config = String::new();
+    config.push_str(&format!("mixed-port: {mixed}\n"));
+    // Loopback only, with a secret that changes every run. Without both, any
+    // web page the user opens could drive this API and reroute their traffic.
+    config.push_str(&format!("external-controller: 127.0.0.1:{api}\n"));
+    config.push_str(&format!("secret: {}\n", serde_json::to_string(secret).unwrap_or_default()));
+    config.push_str("mode: rule\nlog-level: warning\nipv6: true\n");
+
+    // Resolvers live inside the chain. A query that escapes to the local
+    // network names the destination even when the traffic itself does not.
+    config.push_str(
+        "dns:\n  enable: true\n  ipv6: true\n  enhanced-mode: fake-ip\n  \
+         fake-ip-range: 198.18.0.1/16\n  nameserver:\n    - https://1.1.1.1/dns-query\n    \
+         - https://dns.google/dns-query\n",
+    );
+
+    config.push_str(&format!(
+        "proxies:\n  - {{name: {TUNNEL_PROXY}, type: socks5, server: {}, port: {}, udp: true}}\n",
+        tunnel.ip(),
+        tunnel.port()
+    ));
+
+    let mut names: Vec<String> = Vec::new();
+    if !sources.is_empty() || !manual.trim().is_empty() {
+        config.push_str("proxy-providers:\n");
+    }
+    for (index, source) in sources.iter().enumerate() {
+        let key = format!("source{index}");
+        names.push(key.clone());
+        config.push_str(&format!(
+            "  {key}:\n    type: http\n    url: {}\n    interval: 3600\n    \
+             path: ./providers/{key}.yaml\n    dialer-proxy: {TUNNEL_PROXY}\n    \
+             health-check: {{enable: true, url: \"http://www.gstatic.com/generate_204\", \
+             interval: 300, lazy: true}}\n",
+            serde_json::to_string(&source.url).unwrap_or_default()
+        ));
+    }
+    if !manual.trim().is_empty() {
+        names.push(MANUAL_PROVIDER.into());
+        config.push_str(&format!(
+            "  {MANUAL_PROVIDER}:\n    type: file\n    path: ./providers/manual.txt\n    \
+             dialer-proxy: {TUNNEL_PROXY}\n    health-check: {{enable: true, \
+             url: \"http://www.gstatic.com/generate_204\", interval: 300, lazy: true}}\n"
+        ));
+    }
+
+    config.push_str(&format!(
+        "proxy-groups:\n  - name: {EXIT_GROUP}\n    type: select\n    use: [{}]\n",
+        names.join(", ")
+    ));
+    // Everything goes to the exit group. A rule that let anything take a direct
+    // route would put that traffic on the local network in the clear.
+    config.push_str("rules:\n  - MATCH,{}\n".replace("{}", EXIT_GROUP).as_str());
+    config
+}
+
+fn locate(app: &AppHandle) -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+    if let Ok(path) = std::env::var("WHITEAESTHER_MIHOMO_PATH") {
+        if !path.trim().is_empty() {
+            candidates.push(PathBuf::from(path));
+        }
+    }
+    if let Ok(resources) = app.path().resource_dir() {
+        candidates.push(resources.join(MIHOMO_FILENAME));
+        candidates.push(resources.join("binaries").join(MIHOMO_FILENAME));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            candidates.push(parent.join(MIHOMO_FILENAME));
+        }
+    }
+    for candidate in candidates {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err("the chain engine is missing from this installation".into())
+}
+
+/// A port the OS says is free right now.
+///
+/// There is a gap between letting go of the port and mihomo binding it. Nothing
+/// on a desktop is racing for a random high port, and the alternative -- fixed
+/// ports -- collides with whatever else the machine is already running.
+fn free_port() -> Result<u16, String> {
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .map_err(|error| format!("no free local port: {error}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|error| format!("no free local port: {error}"))?
+        .port();
+    drop(listener);
+    Ok(port)
+}
+
+fn secret() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_nanos())
+        .unwrap_or_default();
+    format!("{:x}{:x}", nanos, std::process::id())
+}
+
+/// Waits for mihomo to answer, which is the only proof it actually came up.
+fn wait_until_ready(api: SocketAddr, secret: &str) -> Result<(), String> {
+    let deadline = Instant::now() + READY_TIMEOUT;
+    let mut last = String::from("the chain did not start");
+    while Instant::now() < deadline {
+        match get(api, secret, "/version") {
+            Ok(_) => return Ok(()),
+            Err(error) => last = error,
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    Err(format!("the chain did not become ready: {last}"))
+}
+
+fn encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+fn get(api: SocketAddr, secret: &str, path: &str) -> Result<String, String> {
+    request(api, secret, "GET", path, None)
+}
+
+fn put(api: SocketAddr, secret: &str, path: &str, body: &str) -> Result<(), String> {
+    request(api, secret, "PUT", path, Some(body)).map(|_| ())
+}
+
+/// A minimal HTTP client for the control API.
+///
+/// std-only, like the rest of this crate: the API is on loopback, speaks
+/// HTTP/1.1, and pulling in a client stack to talk to it would be the largest
+/// dependency in the project.
+fn request(
+    api: SocketAddr,
+    secret: &str,
+    method: &str,
+    path: &str,
+    body: Option<&str>,
+) -> Result<String, String> {
+    let mut stream = TcpStream::connect_timeout(&api, API_TIMEOUT)
+        .map_err(|error| format!("the chain is not answering: {error}"))?;
+    stream.set_read_timeout(Some(API_TIMEOUT)).map_err(|e| e.to_string())?;
+
+    let payload = body.unwrap_or("");
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {api}\r\nAuthorization: Bearer {secret}\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+        payload.len()
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("cannot reach the chain: {error}"))?;
+
+    let mut reader = BufReader::new(stream);
+    let mut status = String::new();
+    reader
+        .read_line(&mut status)
+        .map_err(|error| format!("the chain gave no reply: {error}"))?;
+    let code = status
+        .split_whitespace()
+        .nth(1)
+        .and_then(|value| value.parse::<u16>().ok())
+        .ok_or("the chain gave an unreadable reply")?;
+
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).map_err(|e| e.to_string())? == 0 {
+            break;
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+    }
+    let mut rest = String::new();
+    let _ = reader.read_to_string(&mut rest);
+
+    if !(200..300).contains(&code) {
+        return Err(format!("the chain refused that request ({code})"));
+    }
+    Ok(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source(name: &str, url: &str) -> ChainSource {
+        ChainSource { name: name.into(), url: url.into(), enabled: true }
+    }
+
+    fn tunnel() -> SocketAddr {
+        "127.0.0.1:1819".parse().unwrap()
+    }
+
+    #[test]
+    fn every_source_dials_through_the_tunnel() {
+        // The one property the whole feature rests on. A provider without
+        // dialer-proxy would reach its nodes directly, exposing them to the
+        // local network and leaving the exit address unchanged.
+        let sources = [source("ours", "https://example.com/a"), source("theirs", "https://example.com/b")];
+        let refs: Vec<&ChainSource> = sources.iter().collect();
+        let config = render(tunnel(), 1820, 1821, "s", &refs, "vless://pasted");
+
+        let providers = config.matches("dialer-proxy: aether").count();
+        assert_eq!(providers, 3, "two subscriptions and the pasted block, all behind the tunnel");
+    }
+
+    #[test]
+    fn nothing_is_allowed_to_take_a_direct_route() {
+        let config = render(tunnel(), 1820, 1821, "s", &[], "vless://pasted");
+        assert!(config.contains("MATCH,exit"));
+        assert!(!config.contains("DIRECT"), "a direct rule would leak that traffic locally");
+    }
+
+    #[test]
+    fn dns_resolves_inside_the_chain() {
+        // A query that escapes names the destination even when the traffic does
+        // not, which is the most common way a chain like this leaks.
+        let config = render(tunnel(), 1820, 1821, "s", &[], "vless://x");
+        assert!(config.contains("enhanced-mode: fake-ip"));
+        assert!(config.contains("https://1.1.1.1/dns-query"));
+        assert!(!config.contains("\n    - 8.8.8.8"), "a plain resolver would leave the chain");
+    }
+
+    #[test]
+    fn the_control_api_is_never_exposed() {
+        let config = render(tunnel(), 1820, 1821, "s3cret", &[], "vless://x");
+        assert!(config.contains("external-controller: 127.0.0.1:1821"));
+        assert!(config.contains("secret: \"s3cret\""));
+    }
+
+    #[test]
+    fn a_disabled_source_is_left_out() {
+        let mut off = source("off", "https://example.com/off");
+        off.enabled = false;
+        let on = source("on", "https://example.com/on");
+        let refs: Vec<&ChainSource> = vec![&on];
+        let config = render(tunnel(), 1820, 1821, "s", &refs, "");
+        assert!(config.contains("example.com/on"));
+        assert!(!config.contains("example.com/off"));
+        let _ = off;
+    }
+
+    #[test]
+    fn a_secret_differs_between_runs() {
+        assert_ne!(secret(), secret());
+    }
+
+    #[test]
+    fn percent_encoding_covers_the_characters_node_names_actually_use() {
+        // Node names arrive from subscriptions and routinely carry spaces and
+        // non-ASCII; an unencoded name would build a broken request path.
+        assert_eq!(encode("a b"), "a%20b");
+        assert_eq!(encode("xhttp-tls -cdn"), "xhttp-tls%20-cdn");
+        assert_eq!(encode("safe-._~"), "safe-._~");
+        assert!(encode("🇯🇵 tokyo").starts_with('%'));
+    }
+}

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -12,6 +12,7 @@ use std::{
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use crate::chain::{Chain, ChainSettings};
 use crate::http_bridge::{self, HttpBridge};
 use crate::system_proxy::{self, ProxyTargets};
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -76,6 +77,8 @@ pub struct CoreProfile {
     /// Keep trying after a route drops. Off, a session that dies is left dead
     /// rather than retried, which is what someone debugging a network wants.
     pub auto_reconnect: bool,
+    /// The second hop, and where its nodes come from.
+    pub chain: ChainSettings,
     /// Leave the system proxy pointed at the dead listener when the tunnel
     /// fails, so applications that follow it fail rather than send the traffic
     /// in the clear.
@@ -109,6 +112,7 @@ impl Default for CoreProfile {
             performance_profile: "auto".into(),
             keepalive_secs: 5,
             auto_reconnect: true,
+            chain: ChainSettings::default(),
             kill_switch: false,
             noize: "balanced".into(),
             profile_retry: true,
@@ -1350,20 +1354,88 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     // fresh problem and gets the full retry budget again. Kept out of the
     // snapshot lock above so the two are never held at once.
     if connected {
-        let wanted = {
+        let (wanted, chain_settings) = {
             let mut guard = lock(&inner.session);
             match guard.as_mut() {
                 Some(session) => {
                     session.attempt = 0;
-                    session.profile.system_proxy
+                    (session.profile.system_proxy, session.profile.chain.clone())
                 }
-                None => false,
+                None => (false, ChainSettings::default()),
             }
         };
+
+        let socks = lock(&inner.snapshot).socks_address.clone();
+
+        // The chain comes up before the proxy is pointed anywhere, because the
+        // whole question of *where* to point it is answered by whether the
+        // chain is carrying traffic. Starting them the other way round would
+        // aim the machine at the tunnel for as long as mihomo took to load a
+        // subscription -- traffic leaving with the wrong exit address, at the
+        // exact moment the user believes the opposite.
+        let carrier = if chain_settings.enabled {
+            match socks.parse::<SocketAddr>() {
+                Ok(tunnel) => match app.state::<Chain>().start(app, tunnel, &chain_settings) {
+                    Ok(address) => {
+                        supervisor_log(
+                            app,
+                            inner,
+                            "info",
+                            format!("chain listening on {address}; every node dials through the tunnel"),
+                        );
+                        Some(address)
+                    }
+                    Err(error) => {
+                        // Say which hop failed. "No route" would be a lie: the
+                        // tunnel is up and it is the second hop that did not.
+                        supervisor_log(
+                            app,
+                            inner,
+                            "error",
+                            format!("the tunnel is up but the chain did not start: {error}"),
+                        );
+                        None
+                    }
+                },
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
         if wanted {
-            let socks = lock(&inner.snapshot).socks_address.clone();
-            apply_system_proxy(app, inner, &socks);
+            match carrier {
+                // mihomo's mixed listener speaks HTTP itself, so it is what the
+                // system proxy points at and the bridge is not needed at all.
+                Some(address) => apply_chain_proxy(app, inner, address),
+                None => apply_system_proxy(app, inner, &socks),
+            }
         }
+    }
+}
+
+/// Points the system proxy at the chain rather than at the tunnel.
+fn apply_chain_proxy(app: &AppHandle, inner: &SupervisorInner, address: SocketAddr) {
+    if inner.proxy_applied.load(Ordering::SeqCst) {
+        return;
+    }
+    let targets = ProxyTargets { socks: address, http: address };
+    match system_proxy::apply(app, targets) {
+        Ok(()) => {
+            inner.proxy_applied.store(true, Ordering::SeqCst);
+            supervisor_log(
+                app,
+                inner,
+                "info",
+                format!("system proxy set to the chain at {address}"),
+            );
+        }
+        Err(error) => supervisor_log(
+            app,
+            inner,
+            "warn",
+            format!("could not set the system proxy: {error}"),
+        ),
     }
 }
 
@@ -1432,6 +1504,10 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
 /// a proxy left pointing at a listener that no longer exists takes the machine
 /// off the network.
 fn clear_system_proxy(app: &AppHandle, inner: &SupervisorInner) {
+    // The chain exists only to carry a live tunnel's traffic. Leaving it up
+    // after the proxy is restored would keep a listener alive that dials
+    // through a SOCKS port nothing is answering on.
+    app.state::<Chain>().stop();
     // Whatever else happens, the proxy is going back, so nothing is held any
     // more. Cleared unconditionally: the flag must never outlive the block, or
     // the screen tells the user they are protected when they are not.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,15 +1,60 @@
+mod chain;
 mod core_supervisor;
 mod http_bridge;
 mod latency;
 mod scanner;
 mod system_proxy;
 
+use chain::Chain;
 use core_supervisor::CoreSupervisor;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager,
 };
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChainStatus {
+    running: bool,
+    /// Where applications and the system proxy point while the chain carries
+    /// traffic. None means the tunnel is carrying it directly.
+    address: Option<String>,
+}
+
+/// Whether the second hop is up, and what it is listening on.
+#[tauri::command]
+async fn chain_status(chain: tauri::State<'_, Chain>) -> Result<ChainStatus, String> {
+    Ok(ChainStatus {
+        running: chain.is_running(),
+        address: chain.address().map(|value| value.to_string()),
+    })
+}
+
+/// Every node the chain knows about, with the delay each last recorded.
+#[tauri::command]
+async fn chain_nodes(chain: tauri::State<'_, Chain>) -> Result<Vec<chain::ChainNode>, String> {
+    chain.nodes()
+}
+
+/// Measures one node through the tunnel.
+///
+/// The same call answers "does this config work from here" and "how fast is
+/// it", because the probe travels the node's own dialer-proxy: a number means
+/// it is usable behind the tunnel, and nothing means it is not.
+#[tauri::command]
+async fn chain_test(
+    chain: tauri::State<'_, Chain>,
+    source: String,
+    node: String,
+) -> Result<Option<u32>, String> {
+    chain.test(&source, &node)
+}
+
+#[tauri::command]
+async fn chain_select(chain: tauri::State<'_, Chain>, node: String) -> Result<(), String> {
+    chain.select(&node)
+}
 
 fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
@@ -34,6 +79,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .manage(CoreSupervisor::new())
+        .manage(Chain::new())
         .setup(|app| {
             // A previous run that was killed rather than closed may have left
             // the system proxy pointing at a listener that is now gone, which
@@ -148,6 +194,10 @@ pub fn run() {
             latency::probe_latency,
             latency::speed_test,
             latency::exit_info,
+            chain_status,
+            chain_nodes,
+            chain_test,
+            chain_select,
         ])
         .build(tauri::generate_context!())
         .expect("error while running WhiteAesther")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,8 @@
     "active": true,
     "targets": "all",
     "externalBin": [
-      "binaries/aether"
+      "binaries/aether",
+      "binaries/mihomo"
     ],
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -146,6 +146,47 @@ export async function exitInfo(): Promise<ExitInfo> {
   return invoke("exit_info");
 }
 
+export interface ChainStatus {
+  running: boolean;
+  /** Where traffic is carried while the chain is up, or null when it is not. */
+  address: string | null;
+}
+
+export interface ChainNode {
+  name: string;
+  /** Which subscription supplied it. */
+  source: string;
+  kind: string;
+  /** Milliseconds through the tunnel, or null when the last test failed. */
+  delay: number | null;
+}
+
+export async function chainStatus(): Promise<ChainStatus> {
+  requireDesktop();
+  return invoke("chain_status");
+}
+
+export async function chainNodes(): Promise<ChainNode[]> {
+  requireDesktop();
+  return invoke("chain_nodes");
+}
+
+/**
+ * Measures one node through the tunnel.
+ *
+ * Null means the node could not be reached from behind the tunnel — which is
+ * the answer the dashboard needs, not an error to report.
+ */
+export async function chainTest(source: string, node: string): Promise<number | null> {
+  requireDesktop();
+  return invoke("chain_test", { source, node });
+}
+
+export async function chainSelect(node: string): Promise<void> {
+  requireDesktop();
+  return invoke("chain_select", { node });
+}
+
 /**
  * Applies or removes the system proxy on a connection that is already up.
  * Returns whether it is now applied.

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  Activity, FileText, Globe, Route as RouteIcon, ShieldCheck, Wifi, type LucideIcon,
+  Activity, FileText, Globe, Link2, Route as RouteIcon, ShieldCheck, Wifi, type LucideIcon,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,19 +12,21 @@ import { endpointError, normalizeEndpoint } from "@/core/endpoint";
 import { REPORT_EVENT_LIMIT, buildReport, reportFilename } from "@/core/report";
 import { saveReport } from "@/core/api";
 import { NumberField, Row, RulesField, Seg, TextField } from "./panels";
+import { Chain } from "./Chain";
 import { Scanner } from "./Scanner";
 import { transportName } from "./Simple";
 import {
   ENDPOINT_MODES, type ConnectionProfile, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
 } from "@/types";
 
-type SectionId = "status" | "routes" | "endpoint" | "traffic" | "identity" | "diagnostics";
+type SectionId = "status" | "routes" | "endpoint" | "chain" | "traffic" | "identity" | "diagnostics";
 
 const SECTIONS: Array<{ group: string; items: Array<{ id: SectionId; label: string; icon: LucideIcon }> }> = [
   { group: "Connection", items: [
     { id: "status", label: "Status", icon: Activity },
     { id: "routes", label: "Routes & transports", icon: RouteIcon },
     { id: "endpoint", label: "Endpoint", icon: Globe },
+    { id: "chain", label: "Exit chain", icon: Link2 },
   ] },
   { group: "System", items: [
     { id: "traffic", label: "Traffic & DNS", icon: Wifi },
@@ -37,6 +39,7 @@ const BLURB: Record<SectionId, string> = {
   status: "What the core is doing right now.",
   routes: "How hard to search, what the tunnel rides on, and how it hides.",
   endpoint: "Pin a specific gateway, or let the core find one.",
+  chain: "Send the tunnel's traffic on through a node of your own, so the address you appear from changes.",
   traffic: "Where traffic goes once the tunnel is up.",
   identity: "Cloudflare Zero Trust enrolment.",
   diagnostics: "The core executable, logging, and a report you can hand to someone.",
@@ -116,6 +119,14 @@ export function Advanced(props: AdvancedProps) {
         {section === "status" && <Status {...props} />}
         {section === "routes" && <Routes {...props} />}
         {section === "endpoint" && <Endpoint {...props} />}
+        {section === "chain" && (
+          <Chain
+            profile={props.profile}
+            onChange={props.onChange}
+            connected={props.snapshot.state === "connected"}
+            onToast={props.onToast}
+          />
+        )}
         {section === "traffic" && <Traffic {...props} />}
         {section === "identity" && <Identity {...props} />}
         {section === "diagnostics" && <Diagnostics {...props} />}

--- a/src/features/Chain.tsx
+++ b/src/features/Chain.tsx
@@ -1,0 +1,350 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link2, Plus, RefreshCw, Trash2, Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Row } from "./panels";
+import {
+  type ChainNode, chainNodes, chainSelect, chainStatus, chainTest,
+} from "@/core/api";
+import type { ChainSource, ConnectionProfile } from "@/types";
+
+interface ChainProps {
+  profile: ConnectionProfile;
+  onChange: (profile: ConnectionProfile) => void;
+  connected: boolean;
+  onToast: (title: string, message: string, error?: boolean) => void;
+}
+
+export function Chain({ profile, onChange, connected, onToast }: ChainProps) {
+  const chain = profile.chain;
+  const set = (patch: Partial<ConnectionProfile["chain"]>) =>
+    onChange({ ...profile, chain: { ...chain, ...patch } });
+
+  const [running, setRunning] = useState(false);
+  const [address, setAddress] = useState<string | null>(null);
+  const [nodes, setNodes] = useState<ChainNode[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const status = await chainStatus();
+      setRunning(status.running);
+      setAddress(status.address);
+      setNodes(status.running ? await chainNodes() : []);
+    } catch {
+      // Not running is the ordinary case, not a failure worth a toast.
+      setRunning(false);
+      setNodes([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh, connected]);
+
+  return (
+    <>
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-[15px]">Change the address you appear from</CardTitle>
+          <CardDescription>
+            The tunnel hides your traffic but keeps your country — Cloudflare places you near where
+            you already are. Sending it on through a node of your own is what changes that.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Row
+            first
+            title="Route through a second hop"
+            help="Every node is dialled from inside the tunnel, so this network only ever sees Cloudflare."
+          >
+            <Switch checked={chain.enabled} onCheckedChange={(enabled) => set({ enabled })} />
+          </Row>
+          {chain.enabled ? (
+            <>
+              <Separator />
+              <div className="flex items-center gap-2.5 py-3">
+                <span
+                  className={[
+                    "size-1.5 shrink-0 rounded-full",
+                    running ? "bg-primary" : connected ? "bg-warning" : "bg-muted-foreground",
+                  ].join(" ")}
+                />
+                <span className="text-[13px] text-muted-foreground">
+                  {running
+                    ? `Carrying traffic on ${address}`
+                    : connected
+                      ? "The tunnel is up but the chain is not running — check the log."
+                      : "Starts once the tunnel is connected."}
+                </span>
+              </div>
+            </>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Sources sources={chain.sources} onChange={(sources) => set({ sources })} />
+
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-[15px]">Configs pasted by hand</CardTitle>
+          <CardDescription>
+            One per line. vless, vmess, trojan, ss, hysteria2 and tuic are all understood as they
+            are — nothing needs converting first.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-2">
+          <Textarea
+            rows={4}
+            className="font-mono text-[12.5px]"
+            value={chain.manual}
+            placeholder={"vless://…\ntrojan://…"}
+            onChange={(event) => set({ manual: event.target.value })}
+          />
+        </CardContent>
+      </Card>
+
+      <Nodes
+        nodes={nodes}
+        running={running}
+        selected={chain.node}
+        busy={busy}
+        onRefresh={refresh}
+        onTest={async (node) => {
+          setBusy(node.name);
+          try {
+            const delay = await chainTest(node.source, node.name);
+            setNodes((current) =>
+              current.map((entry) => (entry.name === node.name ? { ...entry, delay } : entry)),
+            );
+            if (delay == null) {
+              onToast("Not usable", `${node.name} could not be reached through the tunnel.`, true);
+            }
+          } catch (error) {
+            onToast("Test failed", error instanceof Error ? error.message : String(error), true);
+          } finally {
+            setBusy(null);
+          }
+        }}
+        onSelect={async (node) => {
+          setBusy(node.name);
+          try {
+            await chainSelect(node.name);
+            set({ node: node.name });
+            onToast("Exit changed", `Traffic now leaves through ${node.name}.`);
+          } catch (error) {
+            onToast("Could not switch", error instanceof Error ? error.message : String(error), true);
+          } finally {
+            setBusy(null);
+          }
+        }}
+      />
+    </>
+  );
+}
+
+function Sources({
+  sources,
+  onChange,
+}: {
+  sources: ChainSource[];
+  onChange: (sources: ChainSource[]) => void;
+}) {
+  const [url, setUrl] = useState("");
+
+  return (
+    <Card>
+      <CardHeader className="pb-1">
+        <CardTitle className="text-[15px]">Subscriptions</CardTitle>
+        <CardDescription>
+          Kept up to date automatically. A subscription link is a credential — anyone holding it can
+          use your nodes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3 pt-2">
+        {sources.length ? (
+          <div className="flex flex-col">
+            {sources.map((source, index) => (
+              <div key={`${source.url}-${index}`} className="flex items-center gap-3 border-b py-2.5 last:border-b-0">
+                <Switch
+                  checked={source.enabled}
+                  onCheckedChange={(enabled) =>
+                    onChange(sources.map((entry, at) => (at === index ? { ...entry, enabled } : entry)))
+                  }
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium">{source.name || "Subscription"}</div>
+                  <div className="truncate font-mono text-[11px] text-muted-foreground">
+                    {redact(source.url)}
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Remove ${source.name}`}
+                  onClick={() => onChange(sources.filter((_, at) => at !== index))}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-[13px] text-muted-foreground">No subscriptions yet.</p>
+        )}
+
+        <div className="flex items-end gap-2">
+          <div className="flex flex-1 flex-col gap-2">
+            <Label className="text-[13.5px]">Add a subscription</Label>
+            <Input
+              className="font-mono"
+              value={url}
+              placeholder="https://…"
+              onChange={(event) => setUrl(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") add();
+              }}
+            />
+          </div>
+          <Button variant="outline" onClick={add} disabled={!url.trim()}>
+            <Plus />
+            Add
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  function add() {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    onChange([...sources, { name: labelFor(trimmed, sources.length), url: trimmed, enabled: true }]);
+    setUrl("");
+  }
+}
+
+function Nodes({
+  nodes,
+  running,
+  selected,
+  busy,
+  onRefresh,
+  onTest,
+  onSelect,
+}: {
+  nodes: ChainNode[];
+  running: boolean;
+  selected: string | null;
+  busy: string | null;
+  onRefresh: () => void;
+  onTest: (node: ChainNode) => void;
+  onSelect: (node: ChainNode) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start justify-between gap-4 pb-1 space-y-0">
+        <div>
+          <CardTitle className="text-[15px]">Nodes</CardTitle>
+          <CardDescription>
+            Every measurement here travels the tunnel, so a figure means the node works from behind
+            it — and a failure means it does not.
+          </CardDescription>
+        </div>
+        <Button variant="outline" size="sm" className="shrink-0" onClick={onRefresh}>
+          <RefreshCw />
+          Refresh
+        </Button>
+      </CardHeader>
+      <CardContent className="pt-2">
+        {!running ? (
+          <p className="py-6 text-center text-[13px] text-muted-foreground">
+            Connect with the chain switched on to load nodes.
+          </p>
+        ) : !nodes.length ? (
+          <p className="py-6 text-center text-[13px] text-muted-foreground">
+            No nodes yet. Check that a subscription is enabled.
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {nodes.map((node) => {
+              const active = node.name === selected;
+              return (
+                <div
+                  key={`${node.source}/${node.name}`}
+                  className="flex items-center gap-3 border-b py-2.5 last:border-b-0"
+                >
+                  <span
+                    className={[
+                      "grid size-7 shrink-0 place-items-center rounded-md",
+                      active ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground",
+                    ].join(" ")}
+                  >
+                    <Link2 className="size-3.5" />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[13px] font-medium">{node.name}</div>
+                    <div className="truncate text-[11px] text-muted-foreground">
+                      {node.kind} · {node.source}
+                    </div>
+                  </div>
+                  <span
+                    className={[
+                      "tabular w-[68px] shrink-0 text-right font-mono text-[12.5px]",
+                      node.delay == null ? "text-muted-foreground" : "text-primary",
+                    ].join(" ")}
+                  >
+                    {node.delay == null ? "—" : `${node.delay} ms`}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="shrink-0"
+                    disabled={busy === node.name}
+                    onClick={() => onTest(node)}
+                  >
+                    Test
+                  </Button>
+                  <Button
+                    variant={active ? "secondary" : "outline"}
+                    size="sm"
+                    className="w-[86px] shrink-0"
+                    disabled={busy === node.name}
+                    onClick={() => onSelect(node)}
+                  >
+                    {active ? "In use" : <><Zap />Use</>}
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * A subscription link is a credential, and this screen gets shown in support
+ * threads and screenshots. Enough of it stays visible to tell two apart.
+ */
+export function redact(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}/…`;
+  } catch {
+    return "…";
+  }
+}
+
+function labelFor(url: string, index: number): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return `Subscription ${index + 1}`;
+  }
+}

--- a/src/features/settingsIndex.test.ts
+++ b/src/features/settingsIndex.test.ts
@@ -46,3 +46,13 @@ test("no two entries share a label", () => {
   const labels = SETTINGS.map((entry) => entry.label);
   assert.equal(new Set(labels).size, labels.length);
 });
+
+test("the exit chain is reachable by the words people would use for it", () => {
+  const top = (query: string) => searchSettings(query)[0]?.label;
+  assert.equal(top("chain"), "Route through a second hop");
+  assert.equal(top("subscription"), "Subscriptions");
+  assert.equal(top("vless"), "Configs pasted by hand");
+  // The complaint that started this feature, in the words it was reported in.
+  assert.ok(searchSettings("change ip").length > 0);
+  assert.ok(searchSettings("country").length > 0);
+});

--- a/src/features/settingsIndex.ts
+++ b/src/features/settingsIndex.ts
@@ -6,7 +6,7 @@
  * will not search for "Reach", and someone who wants to stop DNS leaking will
  * not know the setting is called "Resolvers".
  */
-export type SectionId = "status" | "routes" | "endpoint" | "traffic" | "identity" | "diagnostics";
+export type SectionId = "status" | "routes" | "endpoint" | "chain" | "traffic" | "identity" | "diagnostics";
 
 export interface SettingEntry {
   label: string;
@@ -21,6 +21,7 @@ export const SECTION_LABELS: Record<SectionId, string> = {
   status: "Status",
   routes: "Routes & transports",
   endpoint: "Endpoint",
+  chain: "Exit chain",
   traffic: "Traffic & DNS",
   identity: "Identity",
   diagnostics: "Diagnostics",
@@ -50,6 +51,11 @@ export const SETTINGS: SettingEntry[] = [
   { label: "How the gateway is chosen", section: "endpoint", where: "Endpoint", keywords: "automatic custom first custom only endpoint mode" },
   { label: "Per-protocol overrides", section: "endpoint", where: "Endpoint", keywords: "h2 peer wireguard peer separate address" },
 
+  { label: "Route through a second hop", section: "chain", where: "Exit chain", keywords: "chain proxy exit country change ip location second hop mihomo geo" },
+  { label: "Subscriptions", section: "chain", where: "Exit chain", keywords: "sub subscription link config nodes servers add" },
+  { label: "Configs pasted by hand", section: "chain", where: "Exit chain", keywords: "vless vmess trojan shadowsocks ss hysteria tuic paste uri manual config" },
+  { label: "Nodes", section: "chain", where: "Exit chain", keywords: "node ping delay speed test which server pick select" },
+
   { label: "Set the system proxy while connected", section: "traffic", where: "Traffic & DNS", keywords: "whole machine system proxy windows wininet browser all apps" },
   { label: "Block traffic if the tunnel drops", section: "traffic", where: "Traffic & DNS", keywords: "kill switch killswitch fail closed leak protection block traffic drop" },
   { label: "Keep me connected", section: "traffic", where: "Traffic & DNS", keywords: "auto reconnect retry keep alive stay connected reconnection" },
@@ -77,16 +83,21 @@ export function searchSettings(query: string, limit = 8): SettingEntry[] {
   const needle = query.trim().toLowerCase();
   if (!needle) return SETTINGS.slice(0, limit);
 
-  const scored = SETTINGS.map((entry) => {
+  const scored = SETTINGS.map((entry, order) => {
     const label = entry.label.toLowerCase();
     let score = 0;
     if (label.startsWith(needle)) score = 100;
     else if (label.includes(needle)) score = 70;
     else if (entry.where.toLowerCase().includes(needle)) score = 40;
     else if (entry.keywords.includes(needle)) score = 30;
-    return { entry, score };
+    return { entry, score, order };
   }).filter((candidate) => candidate.score > 0);
 
-  scored.sort((a, b) => b.score - a.score || a.entry.label.localeCompare(b.entry.label));
+  // Ties break on the order these are written in, not alphabetically. Searching
+  // a section name matches every setting in it equally, and the one worth
+  // offering first is the control the section exists for -- which is the one
+  // listed first. Sorting by label instead handed back whichever happened to
+  // start with the earliest letter.
+  scored.sort((a, b) => b.score - a.score || a.order - b.order);
   return scored.slice(0, limit).map((candidate) => candidate.entry);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,21 @@ export const ENDPOINT_MODES: Array<{ id: EndpointMode; label: string; detail: st
   { id: "custom-only", label: "Custom only", detail: "Use the pinned address or fail." },
 ];
 
+/** A subscription or pasted-config source feeding the chain. */
+export interface ChainSource {
+  name: string;
+  url: string;
+  enabled: boolean;
+}
+
+export interface ChainSettings {
+  enabled: boolean;
+  sources: ChainSource[];
+  /** Config URIs pasted by hand, one per line. mihomo converts these itself. */
+  manual: string;
+  node: string | null;
+}
+
 export interface ConnectionProfile {
   name: string;
   protocol: "masque" | "wg" | "gool";
@@ -51,6 +66,8 @@ export interface ConnectionProfile {
   systemProxy: boolean;
   /** Keep retrying after a route drops, rather than leaving it dead. */
   autoReconnect: boolean;
+  /** The second hop that changes the exit address. Off unless configured. */
+  chain: ChainSettings;
   /** Leave the system proxy on a dead tunnel so apps fail rather than leak. */
   killSwitch: boolean;
 }
@@ -128,6 +145,7 @@ export const DEFAULT_PROFILE: ConnectionProfile = {
   gateway: false,
   systemProxy: false,
   autoReconnect: true,
+  chain: { enabled: false, sources: [], manual: "", node: null },
   killSwitch: false,
 };
 


### PR DESCRIPTION
## Why

Cloudflare WARP is explicit that it does not change your country. It egresses near you and geolocates the exit address to your region, so a user in Iran connects successfully and **still looks like they are in Iran**. No setting in Aether can alter that, because the decision is Cloudflare's.

This adds the hop that can.

## Verified before a line was written

Everything below was proven by running mihomo against a real subscription, not read from documentation:

```
without the chain:  loc=TH  colo=BKK
with the chain:     loc=JP  colo=KIX

the tunnel saw:     <node server>:8443   ← the node dialled through it
node delays:        548ms · 485ms · 601ms · one unreachable
```

Four things that documentation would not have told us, each of which cost a wrong turn:

- provider nodes are **not** listed in `/proxies`; they answer only under their own provider
- `/proxies/{name}/delay` returns **404** for them — the path is `/providers/proxies/{p}/{n}/healthcheck`
- mihomo converts a base64 URI subscription itself, so there is **no parser here**
- a `wireguard://` entry in the subscription is skipped rather than failing the whole provider

## The order is the design

```
apps → mihomo → [node] dialled through → Aether → MASQUE → Cloudflare → node → internet
```

Reversed, traffic leaves via Cloudflare again and nothing changes. Getting it right has two consequences worth having: the node is dialled from **inside** the tunnel, so local filtering sees an ordinary Cloudflare connection and never the node's address or SNI; and a node blocked from this network is still reachable, because it is reached from Cloudflare's network instead.

`dialer-proxy` is set per **provider**, so a subscription of any size arrives without rewriting a single entry.

## What the dashboard shows

Every measurement travels the tunnel, so one number answers both questions the feature exists for: **does this config work from behind the tunnel**, and **how fast is it**. A failure against a row is the answer, not an error.

Subscription links are shown host-only — a link is a credential, and this screen appears in screenshots and support threads.

## Three things the config must not get wrong

Each has a test, because each is silent when broken:

| | |
|---|---|
| every source dials through the tunnel | a provider without `dialer-proxy` reaches nodes directly and changes nothing |
| nothing takes a direct route | a `DIRECT` rule puts that traffic on the local network |
| DNS resolves inside the chain | a query that escapes names the destination even when the traffic does not |

The control API is loopback-only behind a secret regenerated every run. Without both, any web page the user opened could reroute their traffic.

## Ordering that matters

The chain starts **before** the system proxy is pointed anywhere, because which listener to point at is the question the chain answers. The other order aims the machine at the tunnel while mihomo loads a subscription — traffic leaving with the wrong exit address at the moment the user believes the opposite.

It stops whenever the proxy is restored: it exists only to carry a live tunnel's traffic.

## Cost

The installer grows **6.2 → 18.8 MB** (measured, not estimated). mihomo is pinned to `v1.19.30` and staged as a sidecar for all five architectures.

**GPL-3.0**, shipped as a separate process — the licence text and a source pointer need to reach the Licences page before this is released publicly.

## Verification

50 backend tests, 33 frontend, `tsc --noEmit` clean, Windows bundle built and the sidecar confirmed beside the binary. The dashboard was driven end to end in the browser: search reaches it, the toggle explains itself, and a pasted subscription is stored with its token hidden.

## Not in this one

The chain is **off unless configured**, so nothing changes for existing users. Selecting a node from the Simple screen, and showing the node's country on the exit card, are follow-ups.