### PR TITLE
Release 1.5.1 — the exit chain, and the routes the app was describing wrong

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -174,8 +174,26 @@ jobs:
 
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
+        # Twice in a row this sat here for over half an hour on x86_64 while
+        # every other architecture -- including the arm runner on the same image
+        # -- finished, and a release waited on an apt mirror that had stopped
+        # answering. apt retries without a deadline by default, so the job never
+        # failed and never finished, which is the worst of both.
+        #
+        # Bound the wait and make the failure loud: ten minutes is far longer
+        # than this step has ever legitimately needed, and a re-run of one job
+        # costs minutes where a hang costs the whole cycle.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          # needrestart asks which services to restart, on a terminal nobody is
+          # watching. "a" answers it.
+          NEEDRESTART_MODE: a
         run: >-
-          sudo apt-get update && sudo apt-get install -y
+          sudo -E apt-get update
+          -o Acquire::Retries=3 -o Acquire::http::Timeout=20 &&
+          sudo -E apt-get install -y
+          -o Acquire::Retries=3 -o Acquire::http::Timeout=20
           libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev
           libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf
           cmake ninja-build perl pkg-config clang rpm xdg-utils

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3419,6 +3419,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4243,13 +4259,14 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "windows-sys 0.61.2",
  "winreg",
 ]
@@ -4459,6 +4476,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4490,11 +4516,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4528,6 +4571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4538,6 +4587,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4552,10 +4607,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4570,6 +4637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,6 +4653,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4594,6 +4673,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4604,6 +4689,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.5.0"
+version = "1.5.1"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,10 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
+# A second copy knows nothing about the first: it reports "Not connected" over a
+# live tunnel, and its startup recovery reverts the system proxy the first one
+# applied -- taking the running session off the network from the outside.
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -61,6 +61,14 @@ pub struct ChainSource {
 #[serde(rename_all = "camelCase")]
 pub struct ChainSettings {
     pub enabled: bool,
+    /// Dial the nodes from inside the MASQUE tunnel.
+    ///
+    /// On by default, and worth keeping: it is what hides the node's address
+    /// and SNI from the local network. But it makes the chain impossible
+    /// whenever the tunnel cannot connect -- and on a network that resets
+    /// MASQUE, that is always -- so it can be turned off to reach the nodes
+    /// directly instead of reaching nothing at all.
+    pub through_tunnel: bool,
     /// Subscription URLs. Ours ships as the first entry; the user may add more.
     pub sources: Vec<ChainSource>,
     /// Config URIs pasted by hand, one per line. mihomo converts these itself,
@@ -73,7 +81,13 @@ pub struct ChainSettings {
 
 impl Default for ChainSettings {
     fn default() -> Self {
-        Self { enabled: false, sources: Vec::new(), manual: String::new(), node: None }
+        Self {
+            enabled: false,
+            through_tunnel: true,
+            sources: Vec::new(),
+            manual: String::new(),
+            node: None,
+        }
     }
 }
 
@@ -123,7 +137,7 @@ impl Chain {
     pub fn start(
         &self,
         app: &AppHandle,
-        tunnel: SocketAddr,
+        tunnel: Option<SocketAddr>,
         settings: &ChainSettings,
     ) -> Result<SocketAddr, String> {
         self.stop();
@@ -135,6 +149,9 @@ impl Chain {
             .collect();
         if usable.is_empty() && settings.manual.trim().is_empty() {
             return Err("add a subscription or a config before turning the chain on".into());
+        }
+        if settings.through_tunnel && tunnel.is_none() {
+            return Err("connect first, or turn off \"dial nodes through the tunnel\"".into());
         }
 
         let binary = locate(app)?;
@@ -305,7 +322,7 @@ impl Drop for Chain {
 /// a subscription of any size arrive without us parsing or rewriting a single
 /// entry: every node it carries inherits the tunnel.
 fn render(
-    tunnel: SocketAddr,
+    tunnel: Option<SocketAddr>,
     mixed: u16,
     api: u16,
     secret: &str,
@@ -328,11 +345,19 @@ fn render(
          - https://dns.google/dns-query\n",
     );
 
-    config.push_str(&format!(
-        "proxies:\n  - {{name: {TUNNEL_PROXY}, type: socks5, server: {}, port: {}, udp: true}}\n",
-        tunnel.ip(),
-        tunnel.port()
-    ));
+    // Declared only when there is a tunnel to declare. A socks5 proxy pointing
+    // at a port nothing is listening on would fail every node it fronted.
+    let through = match tunnel {
+        Some(address) => {
+            config.push_str(&format!(
+                "proxies:\n  - {{name: {TUNNEL_PROXY}, type: socks5, server: {}, port: {}, udp: true}}\n",
+                address.ip(),
+                address.port()
+            ));
+            format!("\n    dialer-proxy: {TUNNEL_PROXY}")
+        }
+        None => String::new(),
+    };
 
     let mut names: Vec<String> = Vec::new();
     if !sources.is_empty() || !manual.trim().is_empty() {
@@ -343,7 +368,7 @@ fn render(
         names.push(key.clone());
         config.push_str(&format!(
             "  {key}:\n    type: http\n    url: {}\n    interval: 3600\n    \
-             path: ./providers/{key}.yaml\n    dialer-proxy: {TUNNEL_PROXY}\n    \
+             path: ./providers/{key}.yaml{through}\n    \
              health-check: {{enable: true, url: \"http://www.gstatic.com/generate_204\", \
              interval: 300, lazy: true}}\n",
             serde_json::to_string(&source.url).unwrap_or_default()
@@ -352,8 +377,8 @@ fn render(
     if !manual.trim().is_empty() {
         names.push(MANUAL_PROVIDER.into());
         config.push_str(&format!(
-            "  {MANUAL_PROVIDER}:\n    type: file\n    path: ./providers/manual.txt\n    \
-             dialer-proxy: {TUNNEL_PROXY}\n    health-check: {{enable: true, \
+            "  {MANUAL_PROVIDER}:\n    type: file\n    path: ./providers/manual.txt{through}\n    \
+             health-check: {{enable: true, \
              url: \"http://www.gstatic.com/generate_204\", interval: 300, lazy: true}}\n"
         ));
     }
@@ -514,8 +539,8 @@ mod tests {
         ChainSource { name: name.into(), url: url.into(), enabled: true }
     }
 
-    fn tunnel() -> SocketAddr {
-        "127.0.0.1:1819".parse().unwrap()
+    fn tunnel() -> Option<SocketAddr> {
+        Some("127.0.0.1:1819".parse().unwrap())
     }
 
     #[test]
@@ -565,6 +590,22 @@ mod tests {
         assert!(config.contains("example.com/on"));
         assert!(!config.contains("example.com/off"));
         let _ = off;
+    }
+
+    #[test]
+    fn without_a_tunnel_the_nodes_are_reached_directly() {
+        // The whole point of the fallback: on a network that resets MASQUE the
+        // tunnel never comes up, and a config that still insisted on dialling
+        // through it would leave the user with nothing working at all.
+        let config = render(None, 1820, 1821, "s", &[], "vless://x");
+        assert!(!config.contains("dialer-proxy"), "nothing to dial through");
+        assert!(
+            !config.contains("type: socks5"),
+            "a socks5 proxy pointing at a dead port would fail every node it fronted",
+        );
+        // Everything else must still hold: no direct rule, DNS inside the chain.
+        assert!(config.contains("MATCH,exit"));
+        assert!(config.contains("enhanced-mode: fake-ip"));
     }
 
     #[test]

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -29,6 +29,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
+use crate::core_supervisor::CoreSupervisor;
+
 /// The name the generated config gives the first hop. Referenced by every node
 /// through `dialer-proxy`, which is what puts them behind the tunnel.
 const TUNNEL_PROXY: &str = "aether";
@@ -163,7 +165,12 @@ impl Chain {
         std::fs::create_dir_all(home.join("providers"))
             .map_err(|error| format!("cannot prepare the chain directory: {error}"))?;
 
-        let mixed = free_port()?;
+        // The mixed port is an address a person types into a browser, so it has
+        // to be the same one tomorrow. An ephemeral port meant every launch
+        // moved it, and anything configured against the last run quietly went
+        // out past the hop with the old exit address.
+        let mixed = preferred_port(tunnel.map_or(DEFAULT_MIXED_PORT, next_port))?;
+        // The API stays ephemeral: only this process ever speaks to it.
         let api = free_port()?;
         let secret = secret();
 
@@ -196,6 +203,36 @@ impl Chain {
         let mut child = command
             .spawn()
             .map_err(|error| format!("cannot start the chain: {error}"))?;
+
+        // Piped and never read is a process that blocks on its own logging once
+        // the pipe fills. It also threw away the only account of what the chain
+        // was doing: mihomo marks every node dead when the tunnel underneath
+        // slows down, and none of that reached anyone.
+        for (reader, name) in [
+            (child.stdout.take().map(|out| Box::new(out) as Box<dyn Read + Send>), "chain"),
+            (child.stderr.take().map(|err| Box::new(err) as Box<dyn Read + Send>), "chain"),
+        ] {
+            let Some(reader) = reader else {
+                continue;
+            };
+            let app = app.clone();
+            std::thread::spawn(move || {
+                for line in BufReader::new(reader).lines().map_while(Result::ok) {
+                    let line = line.trim();
+                    if line.is_empty() {
+                        continue;
+                    }
+                    let level = if line.contains("level=error") {
+                        "error"
+                    } else if line.contains("level=warning") {
+                        "warn"
+                    } else {
+                        "info"
+                    };
+                    app.state::<CoreSupervisor>().record(name, level, line.to_string());
+                }
+            });
+        }
 
         let api_address = SocketAddr::from((Ipv4Addr::LOCALHOST, api));
         if let Err(error) = wait_until_ready(api_address, &secret) {
@@ -335,7 +372,10 @@ fn render(
     // web page the user opens could drive this API and reroute their traffic.
     config.push_str(&format!("external-controller: 127.0.0.1:{api}\n"));
     config.push_str(&format!("secret: {}\n", serde_json::to_string(secret).unwrap_or_default()));
-    config.push_str("mode: rule\nlog-level: warning\nipv6: true\n");
+    // info, not warning: a node list where every entry reads dead is explained
+    // by the health-check lines, and those are info. They cost a few lines a
+    // minute and now go to the app log rather than an undrained pipe.
+    config.push_str("mode: rule\nlog-level: info\nipv6: true\n");
 
     // Resolvers live inside the chain. A query that escapes to the local
     // network names the destination even when the traffic itself does not.
@@ -422,6 +462,28 @@ fn locate(app: &AppHandle) -> Result<PathBuf, String> {
 /// There is a gap between letting go of the port and mihomo binding it. Nothing
 /// on a desktop is racing for a random high port, and the alternative -- fixed
 /// ports -- collides with whatever else the machine is already running.
+/// The mixed port used when there is no tunnel to derive one from.
+const DEFAULT_MIXED_PORT: u16 = 1820;
+
+/// One above the tunnel's own port, so the two read as a pair.
+fn next_port(tunnel: SocketAddr) -> u16 {
+    tunnel.port().checked_add(1).unwrap_or(DEFAULT_MIXED_PORT)
+}
+
+/// Takes `want` when it is free, and any free port when it is not.
+///
+/// Falling back rather than failing matters: something else holding one port is
+/// a reason to move, not a reason to leave the user without a second hop.
+fn preferred_port(want: u16) -> Result<u16, String> {
+    match TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, want))) {
+        Ok(listener) => {
+            drop(listener);
+            Ok(want)
+        }
+        Err(_) => free_port(),
+    }
+}
+
 fn free_port() -> Result<u16, String> {
     let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
         .map_err(|error| format!("no free local port: {error}"))?;
@@ -697,5 +759,21 @@ mod tests {
         let wire = format!("{:x}\r\n", MAX_BODY + 1);
         let mut reader = BufReader::new(wire.as_bytes());
         assert!(read_chunked(&mut reader).is_err());
+    }
+
+    #[test]
+    fn the_mixed_port_sits_next_to_the_tunnel() {
+        // A person configures this one in a browser, so it has to be derivable
+        // and the same on the next launch rather than whatever was free.
+        assert_eq!(next_port("127.0.0.1:1819".parse().unwrap()), 1820);
+        assert_eq!(next_port("127.0.0.1:65535".parse().unwrap()), DEFAULT_MIXED_PORT);
+    }
+
+    #[test]
+    fn a_taken_port_moves_rather_than_failing() {
+        let held = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
+        let taken = held.local_addr().unwrap().port();
+        let chosen = preferred_port(taken).unwrap();
+        assert_ne!(chosen, taken);
     }
 }

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -513,6 +513,14 @@ fn request(
         .and_then(|value| value.parse::<u16>().ok())
         .ok_or("the chain gave an unreadable reply")?;
 
+    // Go sets Content-Length only for a reply small enough to buffer, and
+    // frames the rest in chunks. That is why this went unnoticed for so long:
+    // /version is 35 bytes and arrives whole, so the readiness check passed and
+    // the chain reported itself up, while the node list -- the one reply that is
+    // always large -- reached the JSON parser with its chunk header still on the
+    // front. "expected value at line 1 column 1" reads like the chain crashed,
+    // not like a reply we never finished reading.
+    let mut chunked = false;
     loop {
         let mut line = String::new();
         if reader.read_line(&mut line).map_err(|e| e.to_string())? == 0 {
@@ -521,15 +529,66 @@ fn request(
         if line == "\r\n" || line == "\n" {
             break;
         }
+        let lowered = line.to_ascii_lowercase();
+        if let Some(value) = lowered.strip_prefix("transfer-encoding:") {
+            chunked = value.contains("chunked");
+        }
     }
-    let mut rest = String::new();
-    let _ = reader.read_to_string(&mut rest);
+    let rest = if chunked {
+        read_chunked(&mut reader)?
+    } else {
+        let mut body = String::new();
+        let _ = reader.read_to_string(&mut body);
+        body
+    };
 
     if !(200..300).contains(&code) {
         return Err(format!("the chain refused that request ({code})"));
     }
     Ok(rest)
 }
+
+/// Reassembles a chunked body.
+///
+/// Only what reading one requires: sizes are hex, may carry a `;extension`
+/// this ignores, and a zero-length chunk ends the body. Trailers after it are
+/// left unread, because the connection is closing anyway.
+fn read_chunked<R: BufRead>(reader: &mut R) -> Result<String, String> {
+    let mut body = Vec::new();
+    loop {
+        let mut header = String::new();
+        if reader.read_line(&mut header).map_err(|e| e.to_string())? == 0 {
+            break;
+        }
+        let size = header.trim().split(';').next().unwrap_or_default();
+        if size.is_empty() {
+            continue;
+        }
+        let size = usize::from_str_radix(size, 16)
+            .map_err(|_| "the chain framed its reply in a way we cannot read".to_string())?;
+        if size == 0 {
+            break;
+        }
+        // The length is the peer's word, not ours, and this reply is a node
+        // list rather than a download.
+        if body.len() + size > MAX_BODY {
+            return Err("the chain sent more than we are willing to hold".into());
+        }
+        let mut chunk = vec![0u8; size];
+        reader
+            .read_exact(&mut chunk)
+            .map_err(|error| format!("the chain stopped mid-reply: {error}"))?;
+        body.extend_from_slice(&chunk);
+        // The line break that closes the chunk.
+        let mut terminator = String::new();
+        let _ = reader.read_line(&mut terminator);
+    }
+    String::from_utf8(body).map_err(|_| "the chain sent something that is not text".into())
+}
+
+/// Eight megabytes: far beyond any node list, far below anything that matters
+/// to a desktop.
+const MAX_BODY: usize = 8 * 1024 * 1024;
 
 #[cfg(test)]
 mod tests {
@@ -621,5 +680,22 @@ mod tests {
         assert_eq!(encode("xhttp-tls -cdn"), "xhttp-tls%20-cdn");
         assert_eq!(encode("safe-._~"), "safe-._~");
         assert!(encode("🇯🇵 tokyo").starts_with('%'));
+    }
+
+    #[test]
+    fn a_chunked_reply_is_reassembled() {
+        // The shape mihomo actually sends a node list in: a hex size, the
+        // bytes, then a zero chunk. Before this was read, that size line went
+        // to the JSON parser and every node list looked like a crash.
+        let wire = "5\r\nhello\r\n2\r\n!!\r\n0\r\n\r\n";
+        let mut reader = BufReader::new(wire.as_bytes());
+        assert_eq!(read_chunked(&mut reader).unwrap(), "hello!!");
+    }
+
+    #[test]
+    fn a_chunk_larger_than_we_will_hold_is_refused() {
+        let wire = format!("{:x}\r\n", MAX_BODY + 1);
+        let mut reader = BufReader::new(wire.as_bytes());
+        assert!(read_chunked(&mut reader).is_err());
     }
 }

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -459,6 +459,15 @@ impl CoreSupervisor {
         (snapshot.state == "connected").then(|| snapshot.socks_address.clone())
     }
 
+    /// Records a line from something the app runs alongside the core.
+    ///
+    /// The chain uses this for mihomo's output. Anything with a piped stream
+    /// must have it drained by somebody, or the process blocks on its own
+    /// logging once the pipe fills -- and its diagnosis is lost either way.
+    pub fn record(&self, stream: &str, level: &str, message: String) {
+        push_log(&self.inner, stream, level, message);
+    }
+
     /// Refuses when a connection is live: a scan competes with it for the same
     /// gateways and would report worse numbers than the network really offers.
     pub fn require_idle(&self, message: &str) -> Result<(), String> {
@@ -718,6 +727,7 @@ fn launch(
         spawn_log_reader(app.clone(), inner.clone(), stderr, "stderr");
     }
     spawn_exit_monitor(app.clone(), inner.clone(), generation);
+    spawn_route_watch(app.clone(), inner.clone(), generation);
 
     Ok(())
 }
@@ -1014,6 +1024,129 @@ fn spawn_log_reader<R: Read + Send + 'static>(
             }
         }
     });
+}
+
+/// How long a round trip has to take before the route counts as unusable.
+///
+/// A good edge answers in about a tenth of a second from here; a degraded one
+/// was measured at three to ten. Two seconds is far outside ordinary variance
+/// and still well inside "the page has not loaded yet".
+const BAD_ROUTE_MS: f64 = 2_000.0;
+
+/// Consecutive bad samples before acting, at [`ROUTE_WATCH`] apart.
+///
+/// Three rather than one: a single slow probe is a hiccup, and reconnecting on
+/// every hiccup would be worse than the problem.
+const BAD_ROUTE_STREAK: u32 = 3;
+const ROUTE_WATCH: Duration = Duration::from_secs(10);
+
+/// Watches the route a live tunnel is actually giving, and re-scans when it is
+/// no longer worth having.
+///
+/// The engine caches the gateway that last worked and reuses it on the next
+/// connect, checking only that it still answers a handshake -- not that it is
+/// still fast. A Cloudflare edge that degrades therefore stays pinned for good,
+/// because every successful connect writes it back to the cache. Measured on
+/// one machine, one minute apart: the cached edge took 3 to 10 seconds to first
+/// byte and then timed out, while a freshly scanned one took 0.11 seconds.
+///
+/// Nothing in the app noticed, because a handshake through a congested tunnel is
+/// still quick -- so the status chart read healthy while no page would load.
+fn spawn_route_watch(app: AppHandle, inner: Arc<SupervisorInner>, generation: u64) {
+    thread::spawn(move || {
+        let mut streak = 0u32;
+        loop {
+            thread::sleep(ROUTE_WATCH);
+            if !inner.is_current(generation) {
+                return;
+            }
+            let (state, socks) = {
+                let snapshot = lock(&inner.snapshot);
+                (snapshot.state.clone(), snapshot.socks_address.clone())
+            };
+            // Only a live tunnel has a route to judge. Connecting and retrying
+            // are already someone else's problem.
+            if state != "connected" {
+                streak = 0;
+                continue;
+            }
+            let Ok(address) = socks.parse::<SocketAddr>() else {
+                return;
+            };
+            match crate::latency::round_trip_ms(address) {
+                Some(ms) if ms < BAD_ROUTE_MS => streak = 0,
+                _ => streak += 1,
+            }
+            if streak < BAD_ROUTE_STREAK {
+                continue;
+            }
+            if !inner.is_current(generation) {
+                return;
+            }
+            rescan_bad_route(&app, &inner, generation);
+            return;
+        }
+    });
+}
+
+/// Reconnects without the cached gateway, keeping everything else as it was.
+///
+/// The transport is deliberately left alone. Alternating H2 and H3 is the answer
+/// to a transport that cannot get through at all; here it plainly can, and the
+/// edge behind it is what went bad -- moving a working transport to one this
+/// network may block would trade a slow tunnel for no tunnel.
+///
+/// The retry budget is untouched for the same reason: this is not a failed
+/// attempt, it is a good connection being replaced with a better one.
+fn rescan_bad_route(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u64) {
+    let profile = {
+        let mut guard = lock(&inner.session);
+        let Some(session) = guard.as_mut() else {
+            return;
+        };
+        if session.generation != generation {
+            return;
+        }
+        // For the rest of this session. A cache that has already served one bad
+        // gateway has not earned another chance before the next launch.
+        session.profile.quick_reconnect = false;
+        session.attempt = 0;
+        session.profile.clone()
+    };
+
+    supervisor_log(
+        inner,
+        "warn",
+        format!(
+            "this gateway has been slower than {}ms for {} checks in a row; searching for a \n             better one rather than staying on it",
+            BAD_ROUTE_MS as u64, BAD_ROUTE_STREAK
+        ),
+    );
+
+    // Same shape as an explicit reconnect: invalidate, stop, start. Bumping the
+    // generation first stops the old child's monitors from treating the kill
+    // below as a crash and racing this with a retry of their own.
+    let next = inner.generation.fetch_add(1, Ordering::SeqCst) + 1;
+    app.state::<Chain>().stop();
+    if let Some(child) = lock(&inner.child).take().as_mut() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    // The proxy is re-applied when the new tunnel reports itself up; leaving it
+    // pointed at the old one would strand traffic in the gap.
+    clear_system_proxy(app, inner);
+
+    *lock(&inner.session) = Some(Session { generation: next, profile: profile.clone(), attempt: 0 });
+    {
+        let mut snapshot = lock(&inner.snapshot);
+        snapshot.state = "reconnecting".into();
+        snapshot.pid = None;
+        snapshot.status_message = Some("Finding a faster gateway".into());
+        mark_snapshot_dirty(inner);
+    }
+    if let Err(error) = launch(app, inner, &profile, 0, next) {
+        handle_exit(app, inner, next, error);
+    }
 }
 
 fn spawn_exit_monitor(app: AppHandle, inner: Arc<SupervisorInner>, generation: u64) {

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::{
     collections::VecDeque,
-    io::{BufRead, BufReader, Read},
+    io::{BufRead, BufReader, Read, Write},
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
@@ -408,6 +408,16 @@ struct SupervisorInner {
     /// The local HTTP proxy the system proxy points at. Only alive while the
     /// system proxy is applied, and dropped with it.
     bridge: Mutex<Option<HttpBridge>>,
+    /// Log lines waiting to be handed to the window.
+    ///
+    /// The thread reading the core's stdout is the only thing draining a 64KB
+    /// pipe: if it stops to emit an IPC message per line, a busy window becomes
+    /// backpressure and the core blocks mid-scan on its own logging. Nothing on
+    /// the reading side may wait on the interface, so lines land here and a
+    /// separate pump delivers them.
+    pending: Mutex<Vec<CoreLogEvent>>,
+    /// Set when the snapshot has changed since the pump last sent it.
+    snapshot_dirty: AtomicBool,
 }
 
 impl SupervisorInner {
@@ -433,6 +443,8 @@ impl CoreSupervisor {
                 proxy_applied: AtomicBool::new(false),
                 scan_child: Mutex::new(None),
                 bridge: Mutex::new(None),
+                pending: Mutex::new(Vec::new()),
+                snapshot_dirty: AtomicBool::new(false),
             }),
         }
     }
@@ -695,9 +707,9 @@ fn launch(
             max_attempts: MAX_ATTEMPTS,
             blocking: false,
         };
-        emit_snapshot(app, &snapshot);
+        mark_snapshot_dirty(inner);
     }
-    supervisor_log(app, inner, "info", session_summary(profile, attempt));
+    supervisor_log(inner, "info", session_summary(profile, attempt));
 
     if let Some(stdout) = stdout {
         spawn_log_reader(app.clone(), inner.clone(), stdout, "stdout");
@@ -758,6 +770,72 @@ pub fn set_system_proxy(
     }
     apply_system_proxy(&app, inner, &socks);
     Ok(inner.proxy_applied.load(Ordering::SeqCst))
+}
+
+/// Turns the chain on or off on a connection that is already up.
+///
+/// Without this the switch only took effect at the next connect, which is the
+/// same fault the system proxy toggle had: the screen offers the choice while
+/// connected, so it has to mean something then. Changing a subscription goes
+/// through here too, because mihomo reads its sources at startup and would
+/// otherwise keep serving the old list.
+#[tauri::command]
+pub async fn set_chain(
+    app: AppHandle,
+    supervisor: State<'_, CoreSupervisor>,
+    chain: State<'_, Chain>,
+    settings: ChainSettings,
+) -> Result<bool, String> {
+    let inner = &supervisor.inner;
+
+    // Remember it for the rest of the session, so a reconnect keeps the choice.
+    if let Some(session) = lock(&inner.session).as_mut() {
+        session.profile.chain = settings.clone();
+    }
+
+    let socks = supervisor.connected_socks();
+    let tunnel = match socks.as_deref() {
+        Some(address) => Some(
+            address
+                .parse::<SocketAddr>()
+                .map_err(|_| format!("the proxy address {address} cannot be parsed"))?,
+        ),
+        None => None,
+    };
+    // Without a tunnel the chain can still carry traffic straight to the nodes.
+    // Refusing outright is what left this unusable on a network that resets
+    // MASQUE: the tunnel never came up, so the chain never ran, so nothing the
+    // user configured did anything at all.
+    if tunnel.is_none() && (!settings.enabled || settings.through_tunnel) {
+        chain.stop();
+        return Ok(false);
+    }
+
+    let started = if settings.enabled {
+        let address = chain.start(&app, tunnel, &settings)?;
+        supervisor_log(
+            inner,
+            "info",
+            format!("chain listening on {address}; every node dials through the tunnel"),
+        );
+        Some(address)
+    } else {
+        chain.stop();
+        None
+    };
+
+    // The proxy has to follow whichever listener is now carrying traffic.
+    // Leaving it pointed at the old one would send everything around the change
+    // the user just made.
+    if inner.proxy_applied.load(Ordering::SeqCst) {
+        clear_system_proxy(&app, inner);
+        match (started, socks.as_deref()) {
+            (Some(address), _) => apply_chain_proxy(&app, inner, address),
+            (None, Some(address)) => apply_system_proxy(&app, inner, address),
+            (None, None) => {}
+        }
+    }
+    Ok(started.is_some())
 }
 
 #[tauri::command]
@@ -1053,14 +1131,14 @@ fn give_up(
         snapshot.status_message = None;
         snapshot.attempt = 0;
         snapshot.last_error = Some(summary);
-        emit_snapshot(app, &snapshot);
+        mark_snapshot_dirty(inner);
     }
     supervisor_log(
-        app,
         inner,
         "error",
         format!("gave up after {MAX_ATTEMPTS} attempts: {reason}"),
     );
+    app.state::<Chain>().stop();
 
     // The kill switch only bites here, on the failure path. An explicit stop and
     // a quit both restore unconditionally, so the machine can always be put back
@@ -1068,7 +1146,6 @@ fn give_up(
     // caught by the recovery pass at the next launch.
     if profile.kill_switch && inner.proxy_applied.load(Ordering::SeqCst) {
         supervisor_log(
-            app,
             inner,
             "warn",
             "the tunnel is down and the system proxy has been left pointing at it, so traffic \
@@ -1103,6 +1180,18 @@ fn handle_exit(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u64, r
         ExitDecision::Retry { attempt, profile } => (attempt, profile),
     };
 
+    // The tunnel this proxy points at is gone, and the bridge in front of it
+    // answers nothing. Left applied through the backoff and the next attempt,
+    // it takes the whole machine off the network for as long as the retry runs
+    // -- the browser fails, and the failure reads as "the app broke everything"
+    // rather than "one attempt did not come up".
+    //
+    // The kill switch is the one case where holding it is the point, and that
+    // path is `hold` below; an ordinary retry has to leave the machine usable.
+    if !base_profile.kill_switch {
+        clear_system_proxy(app, inner);
+    }
+
     let profile = profile_for_attempt(&base_profile, attempt);
     let delay = retry_delay(attempt);
     // A pinned address that quietly stops being used is the one substitution a
@@ -1131,11 +1220,10 @@ fn handle_exit(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u64, r
                 delay.as_secs()
             )
         });
-        emit_snapshot(app, &snapshot);
+        mark_snapshot_dirty(inner);
     }
     if fell_back {
         supervisor_log(
-            app,
             inner,
             "warn",
             format!(
@@ -1145,7 +1233,6 @@ fn handle_exit(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u64, r
         );
     }
     supervisor_log(
-        app,
         inner,
         "warn",
         format!(
@@ -1211,10 +1298,9 @@ fn hold(
             "{reason}. Traffic is being held rather than sent in the clear — the search continues \
              in the background, or disconnect to put your system proxy back."
         ));
-        emit_snapshot(app, &snapshot);
+        mark_snapshot_dirty(inner);
     }
     supervisor_log(
-        app,
         inner,
         "warn",
         format!("{reason}; holding traffic and retrying every {}s", HOLD_RETRY.as_secs()),
@@ -1282,7 +1368,7 @@ fn retry_delay(attempt: u32) -> Duration {
     Duration::from_secs((BASE_RETRY_SECS << shift).min(MAX_RETRY_SECS))
 }
 
-fn push_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, level: &str, message: String) {
+fn push_log(inner: &SupervisorInner, stream: &str, level: &str, message: String) {
     let event = CoreLogEvent {
         timestamp: now_millis(),
         stream: stream.into(),
@@ -1296,7 +1382,11 @@ fn push_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, level: &str,
         }
         logs.push_back(event.clone());
     }
-    let _ = app.emit("core-log", &event);
+    // Buffered, not emitted. The pump below delivers these in batches.
+    let mut pending = lock(&inner.pending);
+    if pending.len() < MAX_LOGS {
+        pending.push(event);
+    }
 }
 
 /// What the supervisor itself did, as opposed to what the core printed.
@@ -1304,13 +1394,13 @@ fn push_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, level: &str,
 /// Retries, give-ups and the configuration a session ran with leave no trace in
 /// the core's own output, so without these a diagnostics report cannot answer
 /// the question it was collected for.
-fn supervisor_log(app: &AppHandle, inner: &SupervisorInner, level: &str, message: String) {
-    push_log(app, inner, "supervisor", level, message);
+fn supervisor_log(inner: &SupervisorInner, level: &str, message: String) {
+    push_log(inner, "supervisor", level, message);
 }
 
 fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: String) {
     let message = message.trim().to_string();
-    push_log(app, inner, stream, log_level(&message), message.clone());
+    push_log(inner, stream, log_level(&message), message.clone());
 
     let connected = {
         let mut snapshot = lock(&inner.snapshot);
@@ -1332,7 +1422,7 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
             // Most log lines change nothing. Emitting regardless meant two IPC
             // messages and a full re-render for every line the core printed.
             if *snapshot != before {
-                emit_snapshot(app, &snapshot);
+                mark_snapshot_dirty(inner);
             }
             connected
         }
@@ -1347,7 +1437,7 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     // transport is not getting through right now, and trying the other one is
     // worth more than a second identical pass.
     if !connected && sweep_exhausted(&message) {
-        end_fruitless_sweep(app, inner);
+        end_fruitless_sweep(inner);
     }
 
     // A tunnel that came up has spent its failures. Anything after this is a
@@ -1373,12 +1463,17 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
         // aim the machine at the tunnel for as long as mihomo took to load a
         // subscription -- traffic leaving with the wrong exit address, at the
         // exact moment the user believes the opposite.
-        let carrier = if chain_settings.enabled {
+        // `connected` is true for every line the core prints once the tunnel is
+        // up, not just the one that brought it up -- so this ran again on each
+        // of them, and every run tore down a working chain to build another.
+        // The log showed two starts a second apart, on different ports, leaving
+        // the screen watching a listener that had already been replaced.
+        let chain = app.state::<Chain>();
+        let carrier = if chain_settings.enabled && !chain.is_running() {
             match socks.parse::<SocketAddr>() {
-                Ok(tunnel) => match app.state::<Chain>().start(app, tunnel, &chain_settings) {
+                Ok(tunnel) => match chain.start(app, Some(tunnel), &chain_settings) {
                     Ok(address) => {
                         supervisor_log(
-                            app,
                             inner,
                             "info",
                             format!("chain listening on {address}; every node dials through the tunnel"),
@@ -1389,7 +1484,6 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
                         // Say which hop failed. "No route" would be a lie: the
                         // tunnel is up and it is the second hop that did not.
                         supervisor_log(
-                            app,
                             inner,
                             "error",
                             format!("the tunnel is up but the chain did not start: {error}"),
@@ -1404,7 +1498,7 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
         };
 
         if wanted {
-            match carrier {
+            match carrier.or_else(|| chain.address()) {
                 // mihomo's mixed listener speaks HTTP itself, so it is what the
                 // system proxy points at and the bridge is not needed at all.
                 Some(address) => apply_chain_proxy(app, inner, address),
@@ -1424,14 +1518,12 @@ fn apply_chain_proxy(app: &AppHandle, inner: &SupervisorInner, address: SocketAd
         Ok(()) => {
             inner.proxy_applied.store(true, Ordering::SeqCst);
             supervisor_log(
-                app,
                 inner,
                 "info",
                 format!("system proxy set to the chain at {address}"),
             );
         }
         Err(error) => supervisor_log(
-            app,
             inner,
             "warn",
             format!("could not set the system proxy: {error}"),
@@ -1447,7 +1539,6 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
     }
     let Ok(address) = socks.parse::<SocketAddr>() else {
         supervisor_log(
-            app,
             inner,
             "warn",
             format!("cannot use {socks} as a system proxy address"),
@@ -1462,7 +1553,6 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
         Ok(bridge) => bridge,
         Err(error) => {
             supervisor_log(
-                app,
                 inner,
                 "warn",
                 format!("could not start the local HTTP proxy: {error}"),
@@ -1477,7 +1567,6 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
         Ok(()) => {
             inner.proxy_applied.store(true, Ordering::SeqCst);
             supervisor_log(
-                app,
                 inner,
                 "info",
                 format!("system proxy set to {} via {}", targets.socks, targets.http),
@@ -1489,7 +1578,6 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
             // Nothing is pointed at the bridge, so it has no reason to stay up.
             lock(&inner.bridge).take();
             supervisor_log(
-                app,
                 inner,
                 "warn",
                 format!("could not set the system proxy: {error}"),
@@ -1504,10 +1592,6 @@ fn apply_system_proxy(app: &AppHandle, inner: &SupervisorInner, socks: &str) {
 /// a proxy left pointing at a listener that no longer exists takes the machine
 /// off the network.
 fn clear_system_proxy(app: &AppHandle, inner: &SupervisorInner) {
-    // The chain exists only to carry a live tunnel's traffic. Leaving it up
-    // after the proxy is restored would keep a listener alive that dials
-    // through a SOCKS port nothing is answering on.
-    app.state::<Chain>().stop();
     // Whatever else happens, the proxy is going back, so nothing is held any
     // more. Cleared unconditionally: the flag must never outlive the block, or
     // the screen tells the user they are protected when they are not.
@@ -1515,7 +1599,7 @@ fn clear_system_proxy(app: &AppHandle, inner: &SupervisorInner) {
         let mut snapshot = lock(&inner.snapshot);
         if snapshot.blocking {
             snapshot.blocking = false;
-            emit_snapshot(app, &snapshot);
+            mark_snapshot_dirty(inner);
         }
     }
     if !inner.proxy_applied.swap(false, Ordering::SeqCst) {
@@ -1525,12 +1609,11 @@ fn clear_system_proxy(app: &AppHandle, inner: &SupervisorInner) {
     // that is about to stop answering.
     lock(&inner.bridge).take();
     match system_proxy::revert(app) {
-        Ok(()) => supervisor_log(app, inner, "info", "system proxy restored".into()),
+        Ok(()) => supervisor_log(inner, "info", "system proxy restored".into()),
         Err(error) => {
             // Leave the flag cleared but say so loudly: the backup file stays on
             // disk, so the next launch will try again.
             supervisor_log(
-                app,
                 inner,
                 "error",
                 format!("could not restore the system proxy: {error}"),
@@ -1560,7 +1643,7 @@ fn sweep_exhausted(message: &str) -> bool {
 /// `handle_exit` applies the attempt count, the backoff and the transport
 /// alternation that were already written and never previously reachable from
 /// this state.
-fn end_fruitless_sweep(app: &AppHandle, inner: &SupervisorInner) {
+fn end_fruitless_sweep(inner: &SupervisorInner) {
     let mut guard = lock(&inner.child);
     let Some(child) = guard.as_mut() else {
         return;
@@ -1572,7 +1655,6 @@ fn end_fruitless_sweep(app: &AppHandle, inner: &SupervisorInner) {
     let _ = child.kill();
     drop(guard);
     supervisor_log(
-        app,
         inner,
         "warn",
         "a full sweep found no gateway; trying the other transport rather than repeating it".into(),
@@ -1675,6 +1757,9 @@ fn parse_latency_ms(message: &str) -> Option<f64> {
 }
 
 fn stop_inner(inner: &SupervisorInner, app: &AppHandle) -> Result<(), String> {
+    // The chain exists only to carry a live tunnel's traffic; without one it
+    // would sit there dialling a SOCKS port nothing is answering on.
+    app.state::<Chain>().stop();
     // Invalidate first. A retry sleeping out its backoff has no child to kill,
     // and would otherwise launch a process after the user asked it to stop.
     inner.generation.fetch_add(1, Ordering::SeqCst);
@@ -1698,7 +1783,7 @@ fn stop_inner(inner: &SupervisorInner, app: &AppHandle) -> Result<(), String> {
     snapshot.last_error = None;
     snapshot.status_message = None;
     snapshot.attempt = 0;
-    emit_snapshot(app, &snapshot);
+    mark_snapshot_dirty(inner);
     Ok(())
 }
 
@@ -1960,8 +2045,82 @@ fn strip_logger_prefix(message: &str) -> String {
         .to_string()
 }
 
-fn emit_snapshot(app: &AppHandle, snapshot: &CoreSnapshot) {
-    let _ = app.emit("core-status", snapshot);
+/// Marks the snapshot as changed. The pump sends the latest one.
+///
+/// Coalescing matters as much as batching: a scan can change state several
+/// times a second, and the window only ever needs the newest.
+fn mark_snapshot_dirty(inner: &SupervisorInner) {
+    inner.snapshot_dirty.store(true, Ordering::SeqCst);
+}
+
+/// Delivers buffered logs and snapshot changes to the window on a timer.
+///
+/// One thread for the life of the app. Emitting from the reader thread is what
+/// let a slow window throttle the core -- this keeps the two apart, so the core
+/// runs at full speed whether or not anything is listening.
+pub fn start_pump(app: AppHandle, supervisor: &CoreSupervisor) {
+    let inner = supervisor.inner.clone();
+    let log_path = session_log_path(&app);
+    thread::spawn(move || loop {
+        thread::sleep(Duration::from_millis(120));
+
+        let batch: Vec<CoreLogEvent> = {
+            let mut pending = lock(&inner.pending);
+            if pending.is_empty() {
+                Vec::new()
+            } else {
+                std::mem::take(&mut *pending)
+            }
+        };
+        if !batch.is_empty() {
+            if let Some(path) = log_path.as_deref() {
+                append_session_log(path, &batch);
+            }
+            let _ = app.emit("core-logs", &batch);
+        }
+        if inner.snapshot_dirty.swap(false, Ordering::SeqCst) {
+            let snapshot = lock(&inner.snapshot).clone();
+            let _ = app.emit("core-status", &snapshot);
+        }
+    });
+}
+
+/// Where this run's log is kept on disk.
+///
+/// The in-memory buffer holds the last {MAX_LOGS} lines and dies with the
+/// process, which is exactly the wrong shape for the failures worth reporting:
+/// a crash, a freeze, or a scan that took ten minutes and scrolled the evidence
+/// away. Written from the pump, so the thread reading the core still never
+/// waits on anything.
+fn session_log_path(app: &AppHandle) -> Option<PathBuf> {
+    let dir = app.path().app_log_dir().ok()?;
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join("core.log");
+    // One rotation, so the file that survives a crash is still there after the
+    // restart that follows it -- and the pair stays bounded.
+    if std::fs::metadata(&path).is_ok_and(|meta| meta.len() > MAX_LOG_BYTES) {
+        let _ = std::fs::rename(&path, dir.join("core.previous.log"));
+    }
+    Some(path)
+}
+
+/// Two megabytes: a few thousand lines, which covers a long scan and several
+/// retries without letting an app left running for weeks fill a disk.
+const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
+
+fn append_session_log(path: &Path, batch: &[CoreLogEvent]) {
+    let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let mut text = String::new();
+    for event in batch {
+        text.push_str(&format!(
+            "{} [{}/{}] {}
+",
+            event.timestamp, event.stream, event.level, event.message
+        ));
+    }
+    let _ = file.write_all(text.as_bytes());
 }
 
 fn now_millis() -> u64 {
@@ -2422,5 +2581,60 @@ mod tests {
         profile = CoreProfile::default();
         profile.fragment_delay = "0".into();
         profile.validate().unwrap();
+    }
+}
+
+/// A headless stand-in for [`launch`], for pinning down "works in a terminal,
+/// not in the app". Run it with the app closed:
+///
+///     cargo test spawn_like_the_app -- --ignored --nocapture
+///
+/// It builds the child exactly as `launch` does -- same arguments, working
+/// directory, environment, piped stdio and creation flags -- and prints each
+/// line with the milliseconds since spawn, so the point where the two diverge
+/// is visible rather than inferred.
+#[cfg(test)]
+mod spawn_repro {
+    use super::*;
+
+    #[test]
+    #[ignore = "spawns the real core and talks to the network"]
+    fn spawn_like_the_app() {
+        let config_dir = PathBuf::from(std::env::var("WHITEAESTHER_CONFIG_DIR").expect(
+            "set WHITEAESTHER_CONFIG_DIR to the app config directory",
+        ));
+        let core_path = PathBuf::from(
+            std::env::var("WHITEAESTHER_CORE_PATH").expect("set WHITEAESTHER_CORE_PATH"),
+        );
+        let identity_path = config_dir.join("identity").join("aether.toml");
+        let profile = CoreProfile::default();
+
+        let mut command = Command::new(&core_path);
+        command
+            .args(profile.args(&identity_path))
+            .current_dir(&config_dir)
+            .env_remove("RUST_LOG")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        hide_console_window(&mut command);
+
+        let started = Instant::now();
+        let mut child = command.spawn().expect("spawn");
+        let stdout = child.stdout.take().expect("stdout");
+        let stderr = child.stderr.take().expect("stderr");
+        for (reader, name) in [
+            (Box::new(stdout) as Box<dyn Read + Send>, "out"),
+            (Box::new(stderr) as Box<dyn Read + Send>, "err"),
+        ] {
+            thread::spawn(move || {
+                for line in BufReader::new(reader).lines().map_while(Result::ok) {
+                    println!("[{:>6}ms {name}] {line}", started.elapsed().as_millis());
+                }
+            });
+        }
+        thread::sleep(Duration::from_secs(45));
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }

--- a/src-tauri/src/latency.rs
+++ b/src-tauri/src/latency.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 use serde::Serialize;
 use tauri::State;
 
+use crate::chain::Chain;
 use crate::core_supervisor::CoreSupervisor;
 use crate::http_bridge::socks5_connect;
 
@@ -26,7 +27,10 @@ use crate::http_bridge::socks5_connect;
 /// A routing rule that sends this address direct would measure the direct path
 /// instead; that is a deliberate choice by whoever wrote the rule.
 const TARGET_HOST: &str = "1.1.1.1";
-const TARGET_PORT: u16 = 443;
+/// Port 80, because the probe now asks for a byte back and needs a server that
+/// will answer in the clear. There is no TLS client in this crate, and nothing
+/// here is secret -- it is a fixed request to a public resolver's web front.
+const TARGET_PORT: u16 = 80;
 
 /// Short on purpose. A probe that has not answered in this long has told us
 /// what we needed to know, and holding the thread longer only delays the next
@@ -54,19 +58,38 @@ pub async fn probe_latency(supervisor: State<'_, CoreSupervisor>) -> Result<Opti
         .map_err(|error| format!("the latency probe did not finish: {error}"))
 }
 
+/// One round trip through the tunnel, for anything that needs to judge the
+/// route rather than display it.
+pub(crate) fn round_trip_ms(socks: SocketAddr) -> Option<f64> {
+    measure(socks)
+}
+
+/// Times a request and its first byte back, not just the handshake.
+///
+/// Timing the SOCKS5 CONNECT alone was measuring the wrong thing: opening a
+/// connection through a congested tunnel stays fast, because the engine answers
+/// as soon as the far end accepts. A gateway that had degraded to five seconds
+/// a page still charted at thirty milliseconds, so the screen said the route was
+/// healthy while nothing would load. Waiting for a byte to come back is the
+/// cheapest measurement that moves when the experience does.
 fn measure(socks: SocketAddr) -> Option<f64> {
     let started = Instant::now();
-    match socks5_connect(socks, TARGET_HOST, TARGET_PORT, PROBE_TIMEOUT) {
-        Ok(stream) => {
-            let elapsed = started.elapsed();
-            // Closing before the timer would count teardown in the figure.
-            drop(stream);
-            Some(elapsed.as_secs_f64() * 1000.0)
-        }
-        // A refused or timed-out probe is a real answer about the route, but it
-        // is not a number, and a gap in the chart says it better than a zero.
-        Err(_) => None,
+    let mut stream = socks5_connect(socks, TARGET_HOST, TARGET_PORT, PROBE_TIMEOUT).ok()?;
+    stream.set_read_timeout(Some(PROBE_TIMEOUT)).ok()?;
+    stream.set_write_timeout(Some(PROBE_TIMEOUT)).ok()?;
+    // HEAD, so the answer is a header and nothing is downloaded to time.
+    let request = format!(
+        "HEAD / HTTP/1.1\r\nHost: {TARGET_HOST}\r\nUser-Agent: WhiteAesther\r\n\n         Connection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).ok()?;
+    let mut first = [0u8; 1];
+    // A closed connection with nothing on it is a failed probe, not a fast one.
+    if stream.read(&mut first).ok()? == 0 {
+        return None;
     }
+    let elapsed = started.elapsed();
+    drop(stream);
+    Some(elapsed.as_secs_f64() * 1000.0)
 }
 
 /// How fast the tunnel actually carries bulk traffic.
@@ -167,29 +190,51 @@ pub struct ExitInfo {
     pub country: String,
     /// The datacentre the traffic left from, as a three-letter airport code.
     pub colo: String,
-    /// Whether Cloudflare sees this connection as WARP at all. False here means
-    /// the request went out around the tunnel, not through it.
+    /// Whether Cloudflare sees this connection as WARP at all.
+    ///
+    /// Only meaningful when `chained` is false. Through a second hop it is
+    /// always off, because the last leg is the node's own connection and not a
+    /// WARP one -- which is the point of the hop, not a fault.
     pub warp: bool,
     /// Whether an organisation's Zero Trust gateway is applying policy.
     pub gateway: bool,
+    /// Whether this was read through the second hop rather than the tunnel.
+    pub chained: bool,
 }
 
-/// Reads the exit address and country from inside the tunnel.
+/// Reads the exit address and country from wherever traffic actually leaves.
+///
+/// Follows the chain when there is one. Reading the tunnel regardless was the
+/// bug this replaces: with a second hop carrying traffic, the card reported
+/// Cloudflare's address while every application was leaving through the node --
+/// the card contradicting the browser on the one question it exists to answer.
 #[tauri::command]
-pub async fn exit_info(supervisor: State<'_, CoreSupervisor>) -> Result<ExitInfo, String> {
-    let socks = supervisor
-        .connected_socks()
-        .ok_or("connect first — there is nothing to look up")?;
-    let address: SocketAddr = socks
-        .parse()
-        .map_err(|_| format!("the proxy address {socks} cannot be parsed"))?;
+pub async fn exit_info(
+    supervisor: State<'_, CoreSupervisor>,
+    chain: State<'_, Chain>,
+) -> Result<ExitInfo, String> {
+    let carrier = chain.address();
+    let address: SocketAddr = match carrier {
+        // mihomo's listener is a mixed one, so it answers SOCKS5 here exactly
+        // as the tunnel does.
+        Some(address) => address,
+        None => {
+            let socks = supervisor
+                .connected_socks()
+                .ok_or("connect first — there is nothing to look up")?;
+            socks
+                .parse()
+                .map_err(|_| format!("the proxy address {socks} cannot be parsed"))?
+        }
+    };
+    let chained = carrier.is_some();
 
-    tauri::async_runtime::spawn_blocking(move || fetch_trace(address))
+    tauri::async_runtime::spawn_blocking(move || fetch_trace(address, chained))
         .await
         .map_err(|error| format!("the lookup did not finish: {error}"))?
 }
 
-fn fetch_trace(socks: SocketAddr) -> Result<ExitInfo, String> {
+fn fetch_trace(socks: SocketAddr, chained: bool) -> Result<ExitInfo, String> {
     // Plain HTTP on purpose: this crate has no TLS client, and the endpoint
     // answers over both. Nothing here is secret -- it is the address a website
     // would read anyway -- and it travels inside the tunnel regardless.
@@ -207,6 +252,7 @@ fn fetch_trace(socks: SocketAddr) -> Result<ExitInfo, String> {
         colo: field("colo").unwrap_or_default(),
         warp: field("warp").as_deref() == Some("on"),
         gateway: field("gateway").as_deref() == Some("on"),
+        chained,
     })
 }
 
@@ -265,7 +311,7 @@ mod tests {
     #[test]
     fn a_lookup_against_a_dead_listener_fails_rather_than_inventing_a_country() {
         let dead: SocketAddr = "127.0.0.1:1".parse().unwrap();
-        assert!(fetch_trace(dead).is_err());
+        assert!(fetch_trace(dead, false).is_err());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,12 @@ fn toggle_main_window(app: &AppHandle) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        // Before anything else, so a second launch never reaches setup(). Its
+        // proxy recovery would revert the settings the running copy applied,
+        // and its window would report "Not connected" over a live tunnel.
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            show_main_window(app);
+        }))
         .plugin(tauri_plugin_opener::init())
         .manage(CoreSupervisor::new())
         .manage(Chain::new())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,10 @@ pub fn run() {
                 Err(error) => eprintln!("could not restore the system proxy: {error}"),
             }
 
+            // One thread delivers logs and status to the window on a timer, so
+            // the core's own progress never waits on the interface.
+            core_supervisor::start_pump(app.handle().clone(), &app.state::<CoreSupervisor>());
+
             let open = MenuItem::with_id(app, "open", "Open WhiteAesther", true, None::<&str>)?;
             let connection = MenuItem::with_id(
                 app,
@@ -188,6 +192,7 @@ pub fn run() {
             core_supervisor::load_profile,
             core_supervisor::save_report,
             core_supervisor::set_system_proxy,
+            core_supervisor::set_chain,
             scanner::scan_endpoints,
             scanner::test_endpoint,
             scanner::cancel_scan,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ export default function App() {
         // too, leaving the app blind to a running core for the whole session.
         unsubscribe = await subscribeCore(
           (next) => { if (!disposed) setSnapshot(next); },
-          (entry) => { if (!disposed) setLogs((current) => [...current.slice(-999), entry]); },
+          (batch) => { if (!disposed) setLogs((current) => [...current, ...batch].slice(-1000)); },
         );
         if (disposed) return;
         const [info, saved, current, history] = await Promise.allSettled([runtimeInfo(), loadProfile(), getCoreStatus(), getCoreLogs()]);

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { ConnectionProfile, CoreLogEvent, CoreProbe, CoreSnapshot } from "../types";
+import type { ChainSettings, ConnectionProfile, CoreLogEvent, CoreProbe, CoreSnapshot } from "../types";
 
 export function isDesktopRuntime(): boolean {
   return "__TAURI_INTERNALS__" in window;
@@ -58,14 +58,21 @@ export async function saveReport(contents: string, filename: string): Promise<st
   return invoke("save_report", { contents, filename });
 }
 
+/**
+ * Log lines arrive in batches, not one message per line.
+ *
+ * The thread reading the core's output is the only thing draining its pipe, so
+ * a message per line made a busy window throttle the core itself. Batching is
+ * the contract, not an optimisation: keep appending a whole batch at once.
+ */
 export async function subscribeCore(
   onStatus: (status: CoreSnapshot) => void,
-  onLog: (log: CoreLogEvent) => void,
+  onLogs: (logs: CoreLogEvent[]) => void,
 ): Promise<UnlistenFn> {
   requireDesktop();
   const unlistenStatus = await listen<CoreSnapshot>("core-status", (event) => onStatus(event.payload));
-  const unlistenLog = await listen<CoreLogEvent>("core-log", (event) => onLog(event.payload));
-  return () => { unlistenStatus(); unlistenLog(); };
+  const unlistenLogs = await listen<CoreLogEvent[]>("core-logs", (event) => onLogs(event.payload));
+  return () => { unlistenStatus(); unlistenLogs(); };
 }
 
 export type TrayAction = "toggle-connection" | "open-diagnostics" | "restore-proxy";
@@ -159,6 +166,15 @@ export interface ChainNode {
   kind: string;
   /** Milliseconds through the tunnel, or null when the last test failed. */
   delay: number | null;
+}
+
+/**
+ * Turns the chain on or off on a live connection, and reloads it after a
+ * subscription changes. Returns whether it is now carrying traffic.
+ */
+export async function setChain(settings: ChainSettings): Promise<boolean> {
+  requireDesktop();
+  return invoke("set_chain", { settings });
 }
 
 export async function chainStatus(): Promise<ChainStatus> {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -142,9 +142,15 @@ export interface ExitInfo {
   /** Two-letter country as Cloudflare geolocates that address. */
   country: string;
   colo: string;
-  /** False means the request went around the tunnel rather than through it. */
+  /**
+   * Whether Cloudflare sees a WARP connection. Only meaningful when `chained`
+   * is false — through a second hop it is always off, because the last leg is
+   * the node's own connection.
+   */
   warp: boolean;
   gateway: boolean;
+  /** Whether this was read through the second hop rather than the tunnel. */
+  chained: boolean;
 }
 
 /** Reads the exit address and country from inside the tunnel. */

--- a/src/features/Chain.tsx
+++ b/src/features/Chain.tsx
@@ -9,7 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { Row } from "./panels";
 import {
-  type ChainNode, chainNodes, chainSelect, chainStatus, chainTest,
+  type ChainNode, chainNodes, chainSelect, chainStatus, chainTest, setChain,
 } from "@/core/api";
 import type { ChainSource, ConnectionProfile } from "@/types";
 
@@ -22,13 +22,18 @@ interface ChainProps {
 
 export function Chain({ profile, onChange, connected, onToast }: ChainProps) {
   const chain = profile.chain;
-  const set = (patch: Partial<ConnectionProfile["chain"]>) =>
-    onChange({ ...profile, chain: { ...chain, ...patch } });
 
   const [running, setRunning] = useState(false);
   const [address, setAddress] = useState<string | null>(null);
   const [nodes, setNodes] = useState<ChainNode[]>([]);
   const [busy, setBusy] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  /**
+   * Kept on screen rather than shown as a toast. A chain that failed to start
+   * leaves the switch on and the node list empty, and a message that has
+   * already faded is no help at all to whoever is looking at that.
+   */
+  const [failure, setFailure] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -36,16 +41,43 @@ export function Chain({ profile, onChange, connected, onToast }: ChainProps) {
       setRunning(status.running);
       setAddress(status.address);
       setNodes(status.running ? await chainNodes() : []);
-    } catch {
-      // Not running is the ordinary case, not a failure worth a toast.
+    } catch (error) {
+      // Not running is ordinary; being unable to ask is not. Swallowing this
+      // made a failed status read indistinguishable from a stopped chain.
       setRunning(false);
       setNodes([]);
+      setFailure(error instanceof Error ? error.message : String(error));
     }
   }, []);
 
   useEffect(() => {
     void refresh();
   }, [refresh, connected]);
+
+  /**
+   * Saves a change and makes it take effect now.
+   *
+   * mihomo reads its sources once at startup, so a new subscription or a
+   * flipped switch means nothing until it is restarted -- and doing that only
+   * at the next connect is what made this screen look broken while the user
+   * was already connected.
+   */
+  const apply = async (patch: Partial<ConnectionProfile["chain"]>) => {
+    const next = { ...chain, ...patch };
+    onChange({ ...profile, chain: next });
+    setApplying(true);
+    setFailure(null);
+    try {
+      await setChain(next);
+      await refresh();
+    } catch (error) {
+      setFailure(error instanceof Error ? error.message : String(error));
+      await refresh();
+    } finally {
+      setApplying(false);
+    }
+  };
+  const set = (patch: Partial<ConnectionProfile["chain"]>) => void apply(patch);
 
   return (
     <>
@@ -67,22 +99,55 @@ export function Chain({ profile, onChange, connected, onToast }: ChainProps) {
           </Row>
           {chain.enabled ? (
             <>
-              <Separator />
-              <div className="flex items-center gap-2.5 py-3">
-                <span
-                  className={[
-                    "size-1.5 shrink-0 rounded-full",
-                    running ? "bg-primary" : connected ? "bg-warning" : "bg-muted-foreground",
-                  ].join(" ")}
+              <Row
+                title="Dial nodes through the tunnel"
+                help={
+                  chain.throughTunnel
+                    ? "This network sees only Cloudflare, never your node's address. Needs the tunnel connected."
+                    : "Your node is reached directly, so this network can see its address. Use when the tunnel will not connect."
+                }
+              >
+                <Switch
+                  checked={chain.throughTunnel}
+                  onCheckedChange={(throughTunnel) => set({ throughTunnel })}
                 />
-                <span className="text-[13px] text-muted-foreground">
-                  {running
-                    ? `Carrying traffic on ${address}`
-                    : connected
-                      ? "The tunnel is up but the chain is not running — check the log."
-                      : "Starts once the tunnel is connected."}
-                </span>
+              </Row>
+              <Separator />
+              <div className="flex items-center justify-between gap-4 py-3">
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <span
+                    className={[
+                      "size-1.5 shrink-0 rounded-full",
+                      running ? "bg-primary" : connected ? "bg-destructive" : "bg-muted-foreground",
+                    ].join(" ")}
+                  />
+                  <span className="text-[13px] text-muted-foreground">
+                    {applying
+                      ? "Starting…"
+                      : running
+                        ? `Carrying traffic on ${address}`
+                        : connected
+                          ? "Switched on, but not running."
+                          : chain.throughTunnel
+                            ? "Waiting for the tunnel. Turn off the switch above to run without it."
+                            : "Switched on, but not running."}
+                  </span>
+                </div>
+                {(connected || !chain.throughTunnel) && !running && !applying ? (
+                  <Button variant="outline" size="sm" className="shrink-0" onClick={() => set({})}>
+                    <RefreshCw />
+                    Start now
+                  </Button>
+                ) : null}
               </div>
+              {failure ? (
+                <div className="mb-3 rounded-lg border border-destructive/40 bg-destructive/[0.08] p-3">
+                  <div className="text-[12.5px] font-semibold text-destructive">
+                    The chain did not start
+                  </div>
+                  <div className="mt-1 break-words text-[12px] text-muted-foreground">{failure}</div>
+                </div>
+              ) : null}
             </>
           ) : null}
         </CardContent>
@@ -104,14 +169,34 @@ export function Chain({ profile, onChange, connected, onToast }: ChainProps) {
             className="font-mono text-[12.5px]"
             value={chain.manual}
             placeholder={"vless://…\ntrojan://…"}
-            onChange={(event) => set({ manual: event.target.value })}
+            // Typed into freely; applied on the button below. Restarting the
+            // chain on every keystroke would tear the connection down
+            // repeatedly while someone is still pasting.
+            onChange={(event) =>
+              onChange({ ...profile, chain: { ...chain, manual: event.target.value } })
+            }
           />
+          <div className="mt-3 flex items-center justify-between gap-4">
+            <p className="text-[12px] text-muted-foreground">
+              Read when the chain starts, so they take effect once applied.
+            </p>
+            <Button variant="outline" size="sm" disabled={applying} onClick={() => set({})}>
+              Apply
+            </Button>
+          </div>
         </CardContent>
       </Card>
 
       <Nodes
         nodes={nodes}
         running={running}
+        blocked={
+          !chain.enabled
+            ? "Turn on “Route through a second hop” above to load nodes."
+            : chain.throughTunnel && !connected
+              ? "Connect first, or turn off “Dial nodes through the tunnel”."
+              : "The chain did not start. The reason is shown above."
+        }
         selected={chain.node}
         busy={busy}
         onRefresh={refresh}
@@ -231,6 +316,7 @@ function Sources({
 function Nodes({
   nodes,
   running,
+  blocked,
   selected,
   busy,
   onRefresh,
@@ -239,6 +325,8 @@ function Nodes({
 }: {
   nodes: ChainNode[];
   running: boolean;
+  /** Why there is nothing to show, in terms of what to do about it. */
+  blocked: string;
   selected: string | null;
   busy: string | null;
   onRefresh: () => void;
@@ -262,12 +350,11 @@ function Nodes({
       </CardHeader>
       <CardContent className="pt-2">
         {!running ? (
-          <p className="py-6 text-center text-[13px] text-muted-foreground">
-            Connect with the chain switched on to load nodes.
-          </p>
+          <p className="py-6 text-center text-[13px] text-muted-foreground">{blocked}</p>
         ) : !nodes.length ? (
           <p className="py-6 text-center text-[13px] text-muted-foreground">
-            No nodes yet. Check that a subscription is enabled.
+            The chain is running but no nodes arrived — check that a subscription is enabled and
+            that its link is still valid.
           </p>
         ) : (
           <div className="flex flex-col">

--- a/src/features/Simple.tsx
+++ b/src/features/Simple.tsx
@@ -5,11 +5,11 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Switch } from "@/components/ui/switch";
-import { type ExitInfo, exitInfo, speedTest } from "@/core/api";
+import { type ExitInfo, chainStatus, exitInfo, speedTest } from "@/core/api";
 import { ConnectOrb, type OrbState } from "./ConnectOrb";
 import { Sparkline } from "./Sparkline";
 import { type Sample, summarise } from "./latency";
-import { CARRY_OPTIONS, type CarryMode, describeCarry } from "./carry";
+import { CARRY_OPTIONS, type CarryMode, carryDetail, describeCarry } from "./carry";
 import type { ConnectionProfile, CoreProbe, CoreSnapshot } from "@/types";
 
 interface SimpleProps {
@@ -29,8 +29,41 @@ interface SimpleProps {
 
 const BUSY = new Set(["starting", "scanning", "connecting", "reconnecting"]);
 
+/**
+ * The address traffic actually leaves this machine on.
+ *
+ * The tunnel's SOCKS port until a second hop is running, and the hop's listener
+ * after that. Everything the screen says about "point apps here" and everything
+ * it measures has to follow this, or it describes a route nothing is taking.
+ */
+function useCarryAddress(snapshot: CoreSnapshot): string {
+  const [chain, setChain] = useState<string | null>(null);
+  const live = snapshot.state === "connected";
+
+  useEffect(() => {
+    if (!live) {
+      setChain(null);
+      return;
+    }
+    let disposed = false;
+    const read = () => {
+      void chainStatus()
+        .then((status) => { if (!disposed) setChain(status.running ? status.address : null); })
+        .catch(() => { if (!disposed) setChain(null); });
+    };
+    read();
+    // The hop can be switched on from the Advanced screen while this one is
+    // mounted, and the answer here changes the moment it is.
+    const timer = window.setInterval(read, 4_000);
+    return () => { disposed = true; window.clearInterval(timer); };
+  }, [live]);
+
+  return chain ?? snapshot.socksAddress;
+}
+
 export function Simple(props: SimpleProps) {
   const { snapshot, probe } = props;
+  const carryAddress = useCarryAddress(snapshot);
   const busy = BUSY.has(snapshot.state);
   const failed = snapshot.state === "error";
   const live = snapshot.state === "connected";
@@ -54,12 +87,12 @@ export function Simple(props: SimpleProps) {
             disabled={!probe.available && !live && !busy}
             onClick={props.onToggle}
           />
-          <Headline {...props} />
+          <Headline {...props} carryAddress={carryAddress} />
           <Actions {...props} />
         </aside>
 
         <div className="flex min-w-0 flex-1 flex-col gap-3.5">
-          {live ? <Connected {...props} /> : null}
+          {live ? <Connected {...props} carryAddress={carryAddress} /> : null}
           {busy ? <Searching {...props} /> : null}
           {failed ? <Failed {...props} /> : null}
           {!live && !busy && !failed ? <Idle {...props} /> : null}
@@ -67,7 +100,7 @@ export function Simple(props: SimpleProps) {
       </div>
 
       <div className="px-5 pb-4 pt-3.5">
-        <CarryPicker carry={props.carry} onCarry={props.onCarry} />
+        <CarryPicker carry={props.carry} onCarry={props.onCarry} carryAddress={carryAddress} />
       </div>
     </div>
   );
@@ -75,14 +108,14 @@ export function Simple(props: SimpleProps) {
 
 // ------------------------------------------------------------------ the panel
 
-function Headline({ snapshot, carry, probe }: SimpleProps) {
+function Headline({ snapshot, carry, probe, carryAddress }: SimpleProps & { carryAddress: string }) {
   const live = snapshot.state === "connected";
   const busy = BUSY.has(snapshot.state);
   const failed = snapshot.state === "error";
 
   const title = live ? "You're through" : busy ? "Testing paths out" : failed ? "Nothing got out" : "Ready when you are";
   const detail = live
-    ? `${transportName(snapshot.transport)} · ${describeCarry(carry, snapshot.socksAddress)}`
+    ? `${transportName(snapshot.transport)} · ${describeCarry(carry, carryAddress)}`
     : busy
       ? (snapshot.statusMessage ?? "Testing paths out of this network.")
       : failed
@@ -185,7 +218,13 @@ function Kbd({ children }: { children: React.ReactNode }) {
 
 // -------------------------------------------------------------------- content
 
-function Connected({ snapshot, profile, latency, onProfile }: SimpleProps) {
+function Connected({
+  snapshot,
+  profile,
+  latency,
+  onProfile,
+  carryAddress,
+}: SimpleProps & { carryAddress: string }) {
   const summary = summarise(latency);
   const shown = summary.last ?? snapshot.latencyMs;
 
@@ -235,7 +274,7 @@ function Connected({ snapshot, profile, latency, onProfile }: SimpleProps) {
         </div>
       </Card>
 
-      <ExitCard />
+      <ExitCard carryAddress={carryAddress} />
 
       <Card className="surface flex items-center gap-3.5 p-3">
         <Toggle
@@ -270,28 +309,54 @@ function Connected({ snapshot, profile, latency, onProfile }: SimpleProps) {
  * WARP is explicit that it does not move you to another country. Showing the
  * real exit address settles that question instead of leaving it to guesswork.
  */
-function ExitCard() {
+/** Enough attempts to outlast a second hop loading its nodes. */
+const EXIT_TRIES = 4;
+const RETRY_AFTER_MS = 2_500;
+
+function ExitCard({ carryAddress }: { carryAddress: string }) {
   const [info, setInfo] = useState<ExitInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Keyed on where traffic is carried, so switching a second hop on or off
+  // re-reads rather than leaving the previous route's address on screen.
+  //
+  // Retried, because the first read lands while the route is still settling: a
+  // second hop answers its own port the moment it starts but cannot carry
+  // anything until its nodes have loaded, and a single attempt turned that
+  // half-second into a permanent error on a connection that was fine.
   useEffect(() => {
     let disposed = false;
+    let timer = 0;
     setInfo(null);
     setError(null);
-    void exitInfo()
-      .then((next) => { if (!disposed) setInfo(next); })
-      .catch((reason) => {
-        if (!disposed) setError(reason instanceof Error ? reason.message : String(reason));
-      });
-    return () => { disposed = true; };
-  }, []);
+
+    const attempt = (left: number) => {
+      void exitInfo()
+        .then((next) => { if (!disposed) setInfo(next); })
+        .catch((reason) => {
+          if (disposed) return;
+          if (left > 0) {
+            timer = window.setTimeout(() => attempt(left - 1), RETRY_AFTER_MS);
+            return;
+          }
+          setError(reason instanceof Error ? reason.message : String(reason));
+        });
+    };
+    attempt(EXIT_TRIES - 1);
+
+    return () => { disposed = true; window.clearTimeout(timer); };
+  }, [carryAddress]);
+
+  // Through a hop, warp is off by definition and says nothing about whether the
+  // route is good. Judging it by warp painted a working chain as a leak.
+  const good = info ? (info.chained || info.warp) : false;
 
   return (
     <Card className="surface flex items-center gap-3.5 p-3.5">
       <div
         className={[
           "grid size-[34px] shrink-0 place-items-center rounded-lg",
-          info?.warp ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground",
+          good ? "bg-primary/15 text-primary" : "bg-muted text-muted-foreground",
         ].join(" ")}
       >
         <Globe className="size-[17px]" />
@@ -310,12 +375,12 @@ function ExitCard() {
         <span
           className={[
             "shrink-0 rounded-md border px-2 py-1 text-[11px] font-semibold",
-            info.warp
+            good
               ? "border-primary/30 bg-primary/[0.11] text-primary"
               : "border-warning/40 bg-warning/[0.11] text-warning",
           ].join(" ")}
         >
-          {info.warp ? "Through the tunnel" : "Not through the tunnel"}
+          {info.chained ? "Through your node" : info.warp ? "Through the tunnel" : "Not through the tunnel"}
         </span>
       ) : null}
     </Card>
@@ -530,7 +595,11 @@ function Figure({ label, value, tone }: { label: string; value: string | number;
   );
 }
 
-function CarryPicker({ carry, onCarry }: Pick<SimpleProps, "carry" | "onCarry">) {
+function CarryPicker({
+  carry,
+  onCarry,
+  carryAddress,
+}: Pick<SimpleProps, "carry" | "onCarry"> & { carryAddress: string }) {
   return (
     <div className="grid grid-cols-3 gap-2.5">
       {CARRY_OPTIONS.map((option) => {
@@ -568,7 +637,7 @@ function CarryPicker({ carry, onCarry }: Pick<SimpleProps, "carry" | "onCarry">)
                 {active ? <Check className="size-3.5 text-primary" /> : null}
               </div>
               <div className="mt-0.5 text-[11.5px] leading-snug text-muted-foreground">
-                {option.disabled ? option.disabledReason : option.detail}
+                {option.disabled ? option.disabledReason : carryDetail(option, carryAddress)}
               </div>
             </div>
           </button>

--- a/src/features/carry.ts
+++ b/src/features/carry.ts
@@ -23,7 +23,11 @@ export const CARRY_OPTIONS: CarryOption[] = [
   {
     id: "app",
     title: "This app only",
-    detail: "Local proxy on 127.0.0.1:1819",
+    // Filled in from the address traffic is actually carried on. A literal
+    // here was wrong twice over: it ignored a changed port, and once a second
+    // hop was carrying it named the tunnel, so anything pointed at it went out
+    // past the hop and kept the old exit address.
+    detail: "Local proxy on {address}",
     icon: Laptop,
   },
   {
@@ -46,8 +50,20 @@ export function carryFromProfile(systemProxy: boolean): CarryMode {
   return systemProxy ? "system" : "app";
 }
 
-export function describeCarry(mode: CarryMode, socksAddress: string): string {
+/**
+ * Where applications have to point to get what this mode promises.
+ *
+ * `carryAddress` is the chain's listener when a second hop is running and the
+ * tunnel's otherwise — never the configured SOCKS port on its own, which stops
+ * being the right answer the moment a hop is added in front of it.
+ */
+export function describeCarry(mode: CarryMode, carryAddress: string): string {
   if (mode === "system") return "Your system proxy is set, and will be put back when you disconnect.";
   if (mode === "tun") return "Every app on this machine is going through the tunnel.";
-  return `Point apps at ${socksAddress} to use it.`;
+  return `Point apps at ${carryAddress} to use it.`;
+}
+
+/** Fills the option's address placeholder, if it has one. */
+export function carryDetail(option: CarryOption, carryAddress: string): string {
+  return option.detail.replace("{address}", carryAddress);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,12 @@ export interface ChainSource {
 
 export interface ChainSettings {
   enabled: boolean;
+  /**
+   * Dial the nodes from inside the tunnel. On by default — it is what hides the
+   * node's address from the local network — but it makes the chain impossible
+   * whenever the tunnel cannot connect.
+   */
+  throughTunnel: boolean;
   sources: ChainSource[];
   /** Config URIs pasted by hand, one per line. mihomo converts these itself. */
   manual: string;
@@ -145,7 +151,7 @@ export const DEFAULT_PROFILE: ConnectionProfile = {
   gateway: false,
   systemProxy: false,
   autoReconnect: true,
-  chain: { enabled: false, sources: [], manual: "", node: null },
+  chain: { enabled: false, throughTunnel: true, sources: [], manual: "", node: null },
   killSwitch: false,
 };
 


### PR DESCRIPTION
Everything since 1.5.0. Each of these was the app trusting or describing a route that was not the one carrying traffic.

## The tunnel would not connect

A failed attempt left the system proxy pointing at a bridge whose tunnel had already gone. Nothing restored it until the supervisor gave up or the user disconnected — so for the whole backoff **and the whole next attempt**, every application was aimed at a listener that answered nothing. In *Whole machine* mode that does not read as "one attempt did not come up"; it reads as the app having taken the network down. Ordinary retries now restore it. The kill switch, whose purpose is to hold it, still does.

## The chain's node list was never decoded

mihomo's control API is Go's `net/http`, which sets `Content-Length` only for a reply small enough to buffer and frames anything larger in chunks. The client read neither. `/version` is 35 bytes so it arrived whole and the readiness check passed — the chain reported itself up and carried traffic — while the node list, the one reply that is always large, reached the JSON parser as `8a0c\r\n{"proxies":...`. That is exactly the `expected value at line 1 column 1` on screen, and it read like a crash rather than a reply we had not finished reading.

## The app named the wrong address

The exit card read the tunnel even with a hop running, so it reported Cloudflare's address while everything left through the node. "This app only" named the tunnel's port for the same reason, sending anything pointed at it straight past the hop — and that address was a literal, so it was also wrong for anyone who had changed the SOCKS port. The hop's own port was ephemeral (`62704`, then `36701`, then `7677`), so the one address a person types into a browser moved every launch; it is now the tunnel's port plus one.

## A degraded gateway stayed pinned for good

The engine caches the gateway that last worked and asks only whether it still answers — never whether it is still worth having — and every successful connect writes it back. Measured on one machine, one minute apart:

| edge | time to first byte |
|---|---|
| freshly scanned `162.159.198.128` | 0.11 s, steady |
| cached `162.159.198.130` | 3.2 → 5.6 → 7.0 → 9.7 s → timeout |

Nothing noticed, because the latency probe timed a SOCKS5 CONNECT — which stays fast on a tunnel whose data plane is congested. The chart read 33 ms while no page would load. The probe now waits for a byte to come back, and a watcher re-scans after three checks in a row over two seconds. It leaves the transport alone: alternating H2/H3 answers a transport that cannot get through, and here the transport was fine.

## Nobody could see any of it

The core's output lived only in a 1000-line ring buffer inside the running process, so every diagnosis was inference — and inference kept landing on the engine, which was never at fault. Each line was also its own IPC message, emitted from the thread that is the sole drainer of the core's stdout pipe. mihomo's output was piped and never read at all, which blocks it on its own logging once the pipe fills, and threw away the only account of what the chain was doing.

Lines are now buffered and one pump delivers them: in batches to the window, and to a rotating `core.log` that survives a crash. mihomo's output joins it.

## And one found by accident

Launching the app while it was already running started a second process that knew nothing about the first — it showed "Not connected" over a live tunnel, and its startup proxy recovery reverted the system proxy the running copy had applied. A second launch now focuses the window already open.

## Verified

| route | address | location | warp |
|---|---|---|---|
| tunnel only | 104.28.214.151 | Singapore | on |
| through the chain | 64.110.98.173 | Japan (KIX) | off |

Nodes list with their delays, latency reads a true 79 ms, `This app only` names `127.0.0.1:1820`, the chain log captures traffic through the selected node, and nothing is left running after disconnect. Built, installed and exercised on Windows 11.

`cargo test` 55 · `pnpm check` clean · `pnpm test` 33