### PR TITLE
Release 1.5.4 — share the connection, and stop losing nodes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # The fork adds the reporting modes the endpoint scanner needs. Pinned to a
   # tag rather than a branch so a release is reproducible.
-  AETHER_REVISION: v1.5.0-whiteaesther.3
+  AETHER_REVISION: v1.7.0-whiteaesther.2
 
 jobs:
   gate:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -5,18 +5,19 @@ licence, and those licences are not superseded by WhiteAesther's.
 
 ## Aether
 
-The connection engine. WhiteAesther ships the `aether` executable inside its installers and links
-the `aether` crate for endpoint scanning.
+The connection engine. WhiteAesther ships the `aether` executable inside its installers and runs it
+to connect, and in a reporting mode to populate the endpoint picker.
 
-- Upstream: <https://github.com/MatinSenPai/Aether>
-- The build used here: <https://github.com/WhiteDNS/Aether> — a fork adding an embedded API, with
-  upstream history preserved and every change reviewable as a diff against it
+- Upstream: <https://github.com/CluvexStudio/Aether> — version 1.7.0
+- The build used here: <https://github.com/WhiteDNS/Aether> at tag `v1.7.0-whiteaesther.1` — a fork
+  adding the two reporting modes the endpoint picker needs, with upstream history preserved and
+  every change reviewable as a diff against it
 - Licence: GNU Affero General Public License v3.0 — see `LICENSE`, also installed as
   `licenses/whiteaesther-AGPL-3.0.txt`
 - Copyright: the Aether authors
 
-Because WhiteAesther links Aether, WhiteAesther is itself a derivative work and is licensed
-AGPL-3.0. Its complete source is public at <https://github.com/WhiteDNS/WhiteAesther>.
+Because WhiteAesther is built around Aether and distributes it, WhiteAesther is treated as a
+derivative work and is licensed AGPL-3.0. Its complete source is public at <https://github.com/WhiteDNS/WhiteAesther>.
 
 ### Trademark
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.5.3",
+  "version": "1.5.4",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.5.3"
+version = "1.5.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.5.3"
+version = "1.5.4"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -19,9 +19,10 @@
 //! - a node blocked from this network is still reachable, because it is reached
 //!   from Cloudflare's network rather than from here.
 
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -100,6 +101,14 @@ pub struct Running {
     pub mixed: SocketAddr,
     api: SocketAddr,
     secret: String,
+    /// Whether the nodes are dialled from inside the tunnel. Decides which
+    /// protocols can work at all -- see [`unusable_behind_the_tunnel`].
+    through_tunnel: bool,
+    /// The chain directory, so the node list can read back what the
+    /// subscriptions actually contained. mihomo's API reports a protocol and a
+    /// name and nothing about REALITY, and REALITY is the one thing this
+    /// engine cannot use.
+    home: PathBuf,
 }
 
 #[derive(Default)]
@@ -117,6 +126,13 @@ pub struct ChainNode {
     pub kind: String,
     /// Milliseconds through the tunnel, or None when the last test failed.
     pub delay: Option<u32>,
+    /// Why this node cannot work as things are set up, when it cannot.
+    ///
+    /// A measurement that was never going to succeed is worse than no
+    /// measurement: it reads as "this node is down" and sends people off to
+    /// find a better one, when the node is fine and the route in front of it
+    /// is what cannot carry it.
+    pub unusable: Option<String>,
 }
 
 impl Chain {
@@ -164,6 +180,13 @@ impl Chain {
             .join("chain");
         std::fs::create_dir_all(home.join("providers"))
             .map_err(|error| format!("cannot prepare the chain directory: {error}"))?;
+        prune_provider_cache(
+            &home.join("providers"),
+            &usable
+                .iter()
+                .map(|source| provider_cache(&source.url))
+                .collect::<Vec<_>>(),
+        );
 
         // The mixed port is an address a person types into a browser, so it has
         // to be the same one tomorrow. An ephemeral port meant every launch
@@ -245,7 +268,14 @@ impl Chain {
 
         let mixed_address = SocketAddr::from((Ipv4Addr::LOCALHOST, mixed));
         *self.running.lock().map_err(|_| "the chain lock is poisoned")? =
-            Some(Running { child, mixed: mixed_address, api: api_address, secret });
+            Some(Running {
+            child,
+            mixed: mixed_address,
+            api: api_address,
+            secret,
+            through_tunnel: settings.through_tunnel,
+            home: home.clone(),
+        });
         Ok(mixed_address)
     }
 
@@ -260,8 +290,18 @@ impl Chain {
     }
 
     /// Every node from every source, with the delay each last recorded.
-    pub fn nodes(&self) -> Result<Vec<ChainNode>, String> {
+    pub fn nodes(&self, carries_quic: bool) -> Result<Vec<ChainNode>, String> {
         let (api, secret) = self.control()?;
+        let (through_tunnel, home) = {
+            let guard = self.running.lock().map_err(|_| "the chain lock is poisoned")?;
+            match guard.as_ref() {
+                Some(running) => (running.through_tunnel, Some(running.home.clone())),
+                None => (false, None),
+            }
+        };
+        // Read once for the whole list rather than per node: it is one small
+        // file per subscription and the answer is the same for every entry.
+        let reality = home.as_deref().map(reality_nodes).unwrap_or_default();
         let body = get(api, &secret, "/providers/proxies")?;
         let parsed: serde_json::Value = serde_json::from_str(&body)
             .map_err(|error| format!("the chain sent something unreadable: {error}"))?;
@@ -283,10 +323,19 @@ impl Chain {
                 let Some(name) = proxy.get("name").and_then(|v| v.as_str()) else {
                     continue;
                 };
+                let kind = proxy.get("type").and_then(|v| v.as_str()).unwrap_or("?").to_string();
+                let blocked = if reality.contains(name) {
+                    Some(REALITY_UNSUPPORTED.to_string())
+                } else if through_tunnel && !carries_quic {
+                    unusable_behind_the_tunnel(&kind)
+                } else {
+                    None
+                };
                 nodes.push(ChainNode {
+                    unusable: blocked,
                     name: name.to_string(),
                     source: source.clone(),
-                    kind: proxy.get("type").and_then(|v| v.as_str()).unwrap_or("?").to_string(),
+                    kind,
                     delay: proxy
                         .get("history")
                         .and_then(|v| v.as_array())
@@ -347,6 +396,163 @@ impl Chain {
     }
 }
 
+/// Said against every REALITY node, because this build cannot use one.
+///
+/// mihomo's REALITY client does not authenticate against current Xray servers:
+/// the handshake completes, the server falls back to the site it borrows its
+/// certificate from, and the connection is refused. Checked against a real
+/// subscription -- three nodes, three different keys, all refused here and all
+/// answering in under a second under Xray. Saying so is the honest thing; a
+/// node that silently never works is worse than one labelled.
+const REALITY_UNSUPPORTED: &str =
+    "REALITY is not supported yet: the engine this build uses cannot authenticate with it. \
+The node is fine -- it will work again here once the engine can.";
+
+/// The node names in this chain's sources that use REALITY.
+///
+/// Read from the files mihomo was given rather than from mihomo, which reports
+/// a name and a protocol and nothing about how the node secures itself. Both
+/// shapes a provider file arrives in are covered: a base64 block of URIs, which
+/// is what most panels serve, and a Clash document.
+fn reality_nodes(home: &Path) -> HashSet<String> {
+    let mut found = HashSet::new();
+    let Ok(entries) = std::fs::read_dir(home.join("providers")) else {
+        return found;
+    };
+    for entry in entries.flatten() {
+        let Ok(raw) = std::fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        collect_reality_names(&decode_if_base64(&raw), &mut found);
+    }
+    found
+}
+
+/// Subscriptions arrive base64-encoded as often as not.
+fn decode_if_base64(raw: &str) -> String {
+    let compact: String = raw.chars().filter(|c| !c.is_ascii_whitespace()).collect();
+    if compact.is_empty() || compact.contains("://") || compact.contains(':') {
+        return raw.to_string();
+    }
+    match base64_decode(&compact) {
+        Some(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+        None => raw.to_string(),
+    }
+}
+
+fn collect_reality_names(body: &str, into: &mut HashSet<String>) {
+    // A Clash document names the node on one line and its REALITY settings on
+    // the same one, because these files are written as flow mappings.
+    for line in body.lines() {
+        if line.contains("reality-opts") {
+            if let Some(name) = clash_name(line) {
+                into.insert(name);
+            }
+            continue;
+        }
+        // A URI carries its parameters in the query and its name in the
+        // fragment.
+        let Some((head, name)) = line.rsplit_once('#') else {
+            continue;
+        };
+        if head.contains("security=reality") {
+            into.insert(percent_decode(name.trim()));
+        }
+    }
+}
+
+fn clash_name(line: &str) -> Option<String> {
+    let after = line.split("name:").nth(1)?;
+    let name = after
+        .split(',')
+        .next()?
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim_end_matches('}')
+        .trim();
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// The inverse of [`encode`], for names that arrive from a subscription.
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(&value[index + 1..index + 3], 16) {
+                out.push(byte);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn base64_decode(input: &str) -> Option<Vec<u8>> {
+    const INVALID: u8 = 64;
+    let value = |c: u8| -> u8 {
+        match c {
+            b'A'..=b'Z' => c - b'A',
+            b'a'..=b'z' => c - b'a' + 26,
+            b'0'..=b'9' => c - b'0' + 52,
+            // Both alphabets: panels serve either, and a subscription that
+            // failed to decode would silently look like it had no REALITY.
+            b'+' | b'-' => 62,
+            b'/' | b'_' => 63,
+            _ => INVALID,
+        }
+    };
+    let mut out = Vec::with_capacity(input.len() / 4 * 3);
+    let mut buffer = 0_u32;
+    let mut held = 0;
+    for byte in input.bytes() {
+        if byte == b'=' {
+            break;
+        }
+        let bits = value(byte);
+        if bits == INVALID {
+            return None;
+        }
+        buffer = (buffer << 6) | u32::from(bits);
+        held += 6;
+        if held >= 8 {
+            held -= 8;
+            out.push((buffer >> held) as u8);
+        }
+    }
+    Some(out)
+}
+
+/// Why a protocol cannot be carried when the nodes are dialled through the
+/// tunnel, or `None` when it can.
+///
+/// QUIC is the whole of it. A QUIC handshake opens with a datagram padded to
+/// 1280 bytes, which is 1308 bytes once the IP and UDP headers are on it, and
+/// the tunnel cannot carry a packet that size: Cloudflare's connect-ip capsule
+/// tops out at 1306 bytes of inner packet, measured on a live connection. Every
+/// handshake attempt is therefore dropped before it leaves, which shows up as a
+/// node that "does not answer" no matter how healthy it is -- both ends were
+/// checked here, and the same node answers in 800ms when it is dialled
+/// directly.
+///
+/// Matched on the protocol names mihomo reports, lowercased.
+fn unusable_behind_the_tunnel(kind: &str) -> Option<String> {
+    matches!(
+        kind.to_ascii_lowercase().as_str(),
+        "hysteria" | "hysteria2" | "tuic"
+    )
+    .then(|| {
+        format!(
+            "{kind} runs over QUIC, which needs a bigger packet than a MASQUE tunnel can carry. Switch the protocol to WireGuard under Routes and transports, or turn off \"Dial nodes through the tunnel\" there."
+        )
+    })
+}
+
 impl Drop for Chain {
     fn drop(&mut self) {
         self.stop();
@@ -358,6 +564,17 @@ impl Drop for Chain {
 /// `dialer-proxy` is set per provider rather than per node, which is what lets
 /// a subscription of any size arrive without us parsing or rewriting a single
 /// entry: every node it carries inherits the tunnel.
+///
+/// `proxy` is a different question and has to be answered differently. It names
+/// the route mihomo fetches the subscription *itself* over, and leaving it
+/// unset sends that request through the rules -- which is `MATCH,exit`, so the
+/// only way to learn about the nodes was to already be running through one of
+/// them. On this subscription that failed every time (`pull error: ... EOF`),
+/// and a provider that cannot refresh keeps serving whatever it cached last,
+/// which is how the list ended up one node long and belonging to a subscription
+/// the user had already replaced. Pointing the fetch at the tunnel is what
+/// makes it independent of the hop it is trying to configure, and it still
+/// never leaves the machine in the clear.
 fn render(
     tunnel: Option<SocketAddr>,
     mixed: u16,
@@ -387,16 +604,19 @@ fn render(
 
     // Declared only when there is a tunnel to declare. A socks5 proxy pointing
     // at a port nothing is listening on would fail every node it fronted.
-    let through = match tunnel {
+    let (through, fetch_through) = match tunnel {
         Some(address) => {
             config.push_str(&format!(
                 "proxies:\n  - {{name: {TUNNEL_PROXY}, type: socks5, server: {}, port: {}, udp: true}}\n",
                 address.ip(),
                 address.port()
             ));
-            format!("\n    dialer-proxy: {TUNNEL_PROXY}")
+            (
+                format!("\n    dialer-proxy: {TUNNEL_PROXY}"),
+                format!("\n    proxy: {TUNNEL_PROXY}"),
+            )
         }
-        None => String::new(),
+        None => (String::new(), String::new()),
     };
 
     let mut names: Vec<String> = Vec::new();
@@ -408,10 +628,11 @@ fn render(
         names.push(key.clone());
         config.push_str(&format!(
             "  {key}:\n    type: http\n    url: {}\n    interval: 3600\n    \
-             path: ./providers/{key}.yaml{through}\n    \
+             path: ./providers/{}.yaml{fetch_through}{through}\n    \
              health-check: {{enable: true, url: \"http://www.gstatic.com/generate_204\", \
              interval: 300, lazy: true}}\n",
-            serde_json::to_string(&source.url).unwrap_or_default()
+            serde_json::to_string(&source.url).unwrap_or_default(),
+            provider_cache(&source.url),
         ));
     }
     if !manual.trim().is_empty() {
@@ -468,6 +689,48 @@ const DEFAULT_MIXED_PORT: u16 = 1820;
 /// One above the tunnel's own port, so the two read as a pair.
 fn next_port(tunnel: SocketAddr) -> u16 {
     tunnel.port().checked_add(1).unwrap_or(DEFAULT_MIXED_PORT)
+}
+
+/// The cache file a subscription's nodes are kept in, named after the URL.
+///
+/// Named after the position in the list, they were not: a user who replaced a
+/// subscription got a provider pointed at the new URL and a cache file left
+/// over from the old one, and every failed refresh served the previous
+/// subscription's nodes as though they were the new ones. A name derived from
+/// the URL cannot collide that way -- a different subscription is a different
+/// file, and an unreadable new one shows as empty rather than as someone
+/// else's.
+fn provider_cache(url: &str) -> String {
+    // FNV-1a. Not a security boundary -- this only has to be stable across runs
+    // and safe to put in a path.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in url.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+/// Deletes cache files for subscriptions that are no longer configured.
+///
+/// Without this the directory only ever grows, and a subscription removed today
+/// leaves its nodes on disk to be picked up if its URL is ever added back.
+fn prune_provider_cache(directory: &std::path::Path, keep: &[String]) {
+    let Ok(entries) = std::fs::read_dir(directory) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("yaml") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if !keep.iter().any(|name| name == stem) {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
 }
 
 /// Takes `want` when it is free, and any free port when it is not.
@@ -678,6 +941,49 @@ mod tests {
     }
 
     #[test]
+    fn a_subscription_is_fetched_over_the_tunnel_not_over_the_hop_it_configures() {
+        // Left to the rules, the fetch matched MATCH,exit and went out through
+        // a node -- so the node list could only be refreshed by a node already
+        // in it. Every refresh failed, the provider kept serving its last
+        // cache, and the screen showed one stale node out of seven.
+        let sources = [source("ours", "https://example.com/a")];
+        let refs: Vec<&ChainSource> = sources.iter().collect();
+        let config = render(tunnel(), 1820, 1821, "s", &refs, "");
+        assert!(config.contains("\n    proxy: aether"), "the fetch must name the tunnel");
+        // And the nodes it carries still dial through the tunnel: these are two
+        // different routes and setting one must not have replaced the other.
+        assert!(config.contains("\n    dialer-proxy: aether"));
+    }
+
+    #[test]
+    fn without_a_tunnel_the_fetch_names_no_proxy_at_all() {
+        let sources = [source("ours", "https://example.com/a")];
+        let refs: Vec<&ChainSource> = sources.iter().collect();
+        let config = render(None, 1820, 1821, "s", &refs, "");
+        assert!(!config.contains("proxy: aether"), "there is no tunnel to fetch through");
+    }
+
+    #[test]
+    fn a_replaced_subscription_cannot_serve_the_previous_one_s_nodes() {
+        // The cache file used to be named after the position in the list, so a
+        // new URL inherited the old URL's nodes and served them whenever it
+        // could not refresh.
+        let old = [source("ours", "https://example.com/old")];
+        let new = [source("ours", "https://example.com/new")];
+        let old_config = render(tunnel(), 1820, 1821, "s", &old.iter().collect::<Vec<_>>(), "");
+        let new_config = render(tunnel(), 1820, 1821, "s", &new.iter().collect::<Vec<_>>(), "");
+        let path_of = |config: &str| {
+            config
+                .lines()
+                .find_map(|line| line.trim().strip_prefix("path: ").map(ToString::to_string))
+                .expect("a provider path")
+        };
+        assert_ne!(path_of(&old_config), path_of(&new_config));
+        // Same URL, same file: a restart has to find what it already pulled.
+        assert_eq!(provider_cache("https://example.com/old"), provider_cache("https://example.com/old"));
+    }
+
+    #[test]
     fn nothing_is_allowed_to_take_a_direct_route() {
         let config = render(tunnel(), 1820, 1821, "s", &[], "vless://pasted");
         assert!(config.contains("MATCH,exit"));
@@ -727,6 +1033,99 @@ mod tests {
         // Everything else must still hold: no direct rule, DNS inside the chain.
         assert!(config.contains("MATCH,exit"));
         assert!(config.contains("enhanced-mode: fake-ip"));
+    }
+
+    #[test]
+    fn a_cache_for_a_subscription_that_is_gone_is_deleted() {
+        let directory = std::env::temp_dir().join(format!("whiteaesther-prune-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let keep = provider_cache("https://example.com/keep");
+        for name in [format!("{keep}.yaml"), "0123456789abcdef.yaml".to_string()] {
+            std::fs::write(directory.join(name), "proxies: []").unwrap();
+        }
+        // Pasted configs are not a subscription cache and must survive.
+        std::fs::write(directory.join("manual.txt"), "vless://x").unwrap();
+
+        prune_provider_cache(&directory, std::slice::from_ref(&keep));
+
+        assert!(directory.join(format!("{keep}.yaml")).exists());
+        assert!(!directory.join("0123456789abcdef.yaml").exists());
+        assert!(directory.join("manual.txt").exists());
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    #[test]
+    fn quic_protocols_are_named_as_unusable_behind_the_tunnel() {
+        // Measured on a live connection: Cloudflare's connect-ip capsule carries
+        // 1306 bytes of inner packet, and a QUIC handshake needs 1308. The node
+        // is fine -- the same one answers in under a second dialled directly --
+        // so reporting it as unreachable sends people looking for a fault that
+        // is not there.
+        for kind in ["Hysteria2", "hysteria", "Tuic"] {
+            let reason = unusable_behind_the_tunnel(kind).expect("QUIC cannot be carried");
+            assert!(reason.contains(kind), "the reason should name the protocol: {reason}");
+            assert!(reason.contains("Dial nodes through the tunnel"), "say what to do: {reason}");
+        }
+    }
+
+    #[test]
+    fn a_reality_node_is_found_in_a_base64_subscription() {
+        // The shape the user's own panel serves: a base64 block of URIs, the
+        // name in the fragment, percent-encoded.
+        let body = "vless://id@host:443?security=reality&pbk=x&sid=y#WhiteAesther%20REALITY%20fallback\n\
+                    vless://id@host:8080?security=none&type=ws#VLESS-WS";
+        let mut found = HashSet::new();
+        collect_reality_names(body, &mut found);
+        assert!(found.contains("WhiteAesther REALITY fallback"), "{found:?}");
+        assert!(!found.contains("VLESS-WS"), "a plain node must not be labelled");
+    }
+
+    #[test]
+    fn a_reality_node_is_found_in_a_clash_provider() {
+        // The other shape: a Clash document, written as flow mappings, which is
+        // what a panel serving clash-meta returns.
+        let body = "proxies:\n                      - {name: TROJAN-REALITY-A, type: trojan, server: h, port: 8081,                     reality-opts: {public-key: k, short-id: s}}\n                      - {name: plain-trojan, type: trojan, server: h, port: 443}\n";
+        let mut found = HashSet::new();
+        collect_reality_names(body, &mut found);
+        assert!(found.contains("TROJAN-REALITY-A"), "{found:?}");
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn a_base64_subscription_is_decoded_and_a_plain_one_is_left_alone() {
+        let plain = "vless://id@host:443?security=reality#node";
+        // Encoded the way a panel serves it, with the line wrapping they add.
+        let encoded = "dmxlc3M6Ly9pZEBob3N0OjQ0Mz9zZWN1cml0eT1yZWFsaXR5I25vZGU=";
+        assert_eq!(decode_if_base64(encoded), plain);
+        // A file that is already readable must survive untouched, or a Clash
+        // document would be turned into rubbish.
+        assert_eq!(decode_if_base64(plain), plain);
+    }
+
+    #[test]
+    fn a_name_with_spaces_and_emoji_survives_the_round_trip() {
+        // Node names routinely carry both, and a mangled name matches nothing,
+        // which would leave the node silently unlabelled.
+        assert_eq!(percent_decode("%F0%9F%87%AF%F0%9F%87%B5%20tokyo"), "\u{1F1EF}\u{1F1F5} tokyo");
+        assert_eq!(percent_decode("plain-name"), "plain-name");
+        // A stray percent is not an escape and must not eat the next character.
+        assert_eq!(percent_decode("100%"), "100%");
+    }
+
+    #[test]
+    fn quic_is_only_a_problem_on_the_transport_that_cannot_carry_it() {
+        // WireGuard has 60 bytes of room the MASQUE path does not, which is the
+        // whole difference between a hysteria2 node that works behind the
+        // tunnel and one that never completes a handshake.
+        let reason = unusable_behind_the_tunnel("Hysteria2").expect("QUIC needs the bigger MTU");
+        assert!(reason.contains("WireGuard"), "say which way out there is: {reason}");
+    }
+
+    #[test]
+    fn everything_that_runs_over_tcp_is_left_alone() {
+        for kind in ["Vless", "Trojan", "Vmess", "Shadowsocks", "?"] {
+            assert!(unusable_behind_the_tunnel(kind).is_none(), "{kind} works behind the tunnel");
+        }
     }
 
     #[test]

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use crate::chain::{Chain, ChainSettings};
 use crate::http_bridge::{self, HttpBridge};
+use crate::lan_share::{LanDoor, LanSettings, LanStatus};
 use crate::system_proxy::{self, ProxyTargets};
 use tauri::{AppHandle, Emitter, Manager, State};
 
@@ -79,6 +80,10 @@ pub struct CoreProfile {
     pub auto_reconnect: bool,
     /// The second hop, and where its nodes come from.
     pub chain: ChainSettings,
+    /// Whether other devices on this network may use the tunnel, and on what
+    /// terms.
+    #[serde(default)]
+    pub lan_share: LanSettings,
     /// Leave the system proxy pointed at the dead listener when the tunnel
     /// fails, so applications that follow it fail rather than send the traffic
     /// in the clear.
@@ -113,6 +118,7 @@ impl Default for CoreProfile {
             keepalive_secs: 5,
             auto_reconnect: true,
             chain: ChainSettings::default(),
+            lan_share: LanSettings::default(),
             kill_switch: false,
             noize: "balanced".into(),
             profile_retry: true,
@@ -473,6 +479,17 @@ impl CoreSupervisor {
         (snapshot.state == "connected").then(|| snapshot.socks_address.clone())
     }
 
+    /// Whether the first hop can carry a QUIC handshake.
+    ///
+    /// MASQUE cannot and WireGuard can, and the difference is 28 bytes: see
+    /// [`crate::chain::unusable_behind_the_tunnel`]. Reported rather than
+    /// worked out in the chain, because only the supervisor knows which
+    /// transport actually came up -- a profile set to MASQUE can fall back.
+    pub fn carries_quic(&self) -> bool {
+        let snapshot = lock(&self.inner.snapshot);
+        !matches!(snapshot.transport.as_deref(), Some("masque-h2") | Some("masque-h3"))
+    }
+
     /// Records a line from something the app runs alongside the core.
     ///
     /// The chain uses this for mihomo's output. Anything with a piped stream
@@ -788,9 +805,12 @@ pub fn set_system_proxy(
         let snapshot = lock(&inner.snapshot);
         (snapshot.state.clone(), snapshot.socks_address.clone())
     };
-    let chain_requested = lock(&inner.session)
-        .as_ref()
-        .is_some_and(|session| session.profile.chain.enabled);
+    let chain_requested = chain_is_in_play(
+        chain.is_running(),
+        lock(&inner.session)
+            .as_ref()
+            .is_some_and(|session| session.profile.chain.enabled),
+    );
     // Before the listener exists there is nothing to point at; the connect path
     // applies it when the core reports itself up.
     if state != "connected" {
@@ -818,6 +838,70 @@ pub fn set_system_proxy(
         let _ = tunnel_proxy_route(&socks, inner);
     }
     Ok(proxy_is_applied(inner))
+}
+
+/// Opens or closes the door other devices on this network come in through.
+///
+/// Deliberately separate from the system proxy: that decides how far the tunnel
+/// reaches on *this* machine, and this decides whether it reaches off it at
+/// all. Sharing without credentials is allowed, because a household network
+/// where that is fine is the common case -- but it is the caller's job to have
+/// said so plainly first, and [`LanStatus::open`] carries it back so the screen
+/// can keep saying it.
+#[tauri::command]
+pub fn set_lan_share(
+    supervisor: State<'_, CoreSupervisor>,
+    chain: State<'_, Chain>,
+    door: State<'_, LanDoor>,
+    settings: LanSettings,
+) -> Result<LanStatus, String> {
+    let inner = &supervisor.inner;
+
+    // Remembered for the rest of the session, so a reconnect keeps the choice.
+    if let Some(session) = lock(&inner.session).as_mut() {
+        session.profile.lan_share = settings.clone();
+    }
+
+    if !settings.enabled {
+        door.close();
+        supervisor_log(inner, "info", "network sharing stopped".into());
+        return Ok(LanStatus::stopped());
+    }
+
+    let carrier = carrier_address(inner, &chain).ok_or(
+        "connect first: there is nothing to share until the tunnel is carrying traffic",
+    )?;
+    let status = door.open(carrier, &settings)?;
+    supervisor_log(
+        inner,
+        "info",
+        match (&status.address, status.open) {
+            (Some(address), true) => format!(
+                "network sharing open on {address} with no sign-in; anyone on this network can use it"
+            ),
+            (Some(address), false) => format!("network sharing open on {address}, sign-in required"),
+            (None, _) => "network sharing open".into(),
+        },
+    );
+    Ok(status)
+}
+
+#[tauri::command]
+pub fn lan_share_status(door: State<'_, LanDoor>) -> LanStatus {
+    door.status()
+}
+
+/// The listener traffic is actually leaving through: the second hop when one is
+/// running, the tunnel when it is not, and nothing at all when disconnected.
+fn carrier_address(inner: &SupervisorInner, chain: &Chain) -> Option<SocketAddr> {
+    if let Some(address) = chain.address() {
+        return Some(address);
+    }
+    let snapshot = lock(&inner.snapshot);
+    if snapshot.state != "connected" {
+        return None;
+    }
+    snapshot.socks_address.parse().ok()
 }
 
 /// Turns the chain on or off on a connection that is already up.
@@ -871,6 +955,13 @@ pub async fn set_chain(
         chain.stop();
         None
     };
+
+    // Anything pointed at the old listener would go around the change the user
+    // just made -- devices on the network included, which is why the shared
+    // door is retargeted rather than left to be reconfigured by hand.
+    if let Some(carrier) = started.or_else(|| tunnel) {
+        app.state::<LanDoor>().retarget(carrier);
+    }
 
     // The proxy has to follow whichever listener is now carrying traffic.
     // Leaving it pointed at the old one would send everything around the change
@@ -1626,14 +1717,18 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     // fresh problem and gets the full retry budget again. Kept out of the
     // snapshot lock above so the two are never held at once.
     if connected {
-        let (wanted, chain_settings) = {
+        let (wanted, chain_settings, lan) = {
             let mut guard = lock(&inner.session);
             match guard.as_mut() {
                 Some(session) => {
                     session.attempt = 0;
-                    (session.profile.system_proxy, session.profile.chain.clone())
+                    (
+                        session.profile.system_proxy,
+                        session.profile.chain.clone(),
+                        session.profile.lan_share.clone(),
+                    )
                 }
-                None => (false, ChainSettings::default()),
+                None => (false, ChainSettings::default(), LanSettings::default()),
             }
         };
 
@@ -1679,6 +1774,35 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
             None
         };
 
+        // Whether or not this machine's own proxy is being pointed anywhere,
+        // a device on the network that was already sharing must not be left
+        // aimed at the listener from the previous session.
+        if let Some(address) = carrier.or_else(|| chain.address()).or_else(|| socks.parse().ok()) {
+            let door = app.state::<LanDoor>();
+            door.retarget(address);
+            // Reconnecting, or starting the app with sharing already switched
+            // on, has to put the door back. Leaving it to the screen would mean
+            // the setting only took effect if someone opened that panel.
+            if lan.enabled && !door.status().running {
+                match door.open(address, &lan) {
+                    Ok(status) => supervisor_log(
+                        inner,
+                        "info",
+                        match (&status.address, status.open) {
+                            (Some(at), true) => format!(
+                                "network sharing open on {at} with no sign-in; anyone on this network can use it"
+                            ),
+                            (Some(at), false) => format!("network sharing open on {at}, sign-in required"),
+                            (None, _) => "network sharing open".into(),
+                        },
+                    ),
+                    Err(error) => {
+                        supervisor_log(inner, "warn", format!("could not share on this network: {error}"))
+                    }
+                }
+            }
+        }
+
         if wanted {
             match carrier.or_else(|| chain.address()) {
                 // mihomo's mixed listener speaks HTTP itself, so it is what the
@@ -1711,6 +1835,18 @@ fn tunnel_proxy_route(socks: &str, inner: &SupervisorInner) -> Option<ProxyRoute
             None
         }
     }
+}
+
+/// Whether a second hop is what traffic should be following right now.
+///
+/// A chain that is already listening settles this on its own, whatever the
+/// profile says. Asking the profile alone let the two disagree, and when they
+/// did, "this app only" named the chain's listener while "whole machine"
+/// pointed the machine at WARP -- one browser, two exit addresses, decided by a
+/// switch that is supposed to change how far the tunnel reaches and not where
+/// it comes out.
+fn chain_is_in_play(chain_running: bool, chain_enabled: bool) -> bool {
+    chain_running || chain_enabled
 }
 
 /// Chooses the route for a live Whole machine request.
@@ -1986,8 +2122,12 @@ fn parse_latency_ms(message: &str) -> Option<f64> {
 
 fn stop_inner(inner: &SupervisorInner, app: &AppHandle) -> Result<(), String> {
     // The chain exists only to carry a live tunnel's traffic; without one it
-    // would sit there dialling a SOCKS port nothing is answering on.
+    // would sit there dialling a SOCKS port nothing is answering on. The same
+    // is true of the door other devices come in through: left open over a dead
+    // tunnel it is a machine on the network that accepts connections and then
+    // fails every one of them.
     app.state::<Chain>().stop();
+    app.state::<LanDoor>().close();
     // Invalidate first. A retry sleeping out its backoff has no child to kill,
     // and would otherwise launch a process after the user asked it to stop.
     inner.generation.fetch_add(1, Ordering::SeqCst);
@@ -2804,6 +2944,17 @@ mod tests {
             desired_proxy_route(true, Some(chain), Some(tunnel)),
             Some(ProxyRoute::Chain(chain))
         );
+    }
+
+    #[test]
+    fn a_listening_chain_counts_as_requested_whatever_the_profile_says() {
+        // The two can disagree: the chain is started from its own screen and
+        // the carry mode is read from the session profile. When they did, Whole
+        // machine sent the OS to WARP while the very same connection was being
+        // advertised to applications as the chain's port.
+        assert!(chain_is_in_play(true, false));
+        assert!(chain_is_in_play(false, true));
+        assert!(!chain_is_in_play(false, false));
     }
 
     #[test]

--- a/src-tauri/src/lan_share.rs
+++ b/src-tauri/src/lan_share.rs
@@ -1,0 +1,809 @@
+//! Lets other devices on the same network use this machine's tunnel.
+//!
+//! The listeners the app already runs are on loopback, which is the right
+//! default: a proxy reachable from the network is a proxy anyone on that
+//! network can use. This opens a second door, deliberately, on request -- a
+//! phone or a television that cannot run the app itself can be pointed at this
+//! machine instead.
+//!
+//! One port speaks both HTTP and SOCKS5, because the devices people want to
+//! share with are split between the two and asking which one a television wants
+//! is not a question anybody can answer. The first byte says which it is:
+//! SOCKS5 always opens with 0x05, and no HTTP method does.
+//!
+//! Whatever arrives is forwarded to whichever listener is currently carrying
+//! traffic -- the second hop when one is running, the tunnel otherwise -- so a
+//! device configured once keeps working when the chain is switched on or off.
+
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::http_bridge::socks5_connect;
+
+/// Long enough for a slow tunnel to answer, short enough that a wedged peer
+/// does not hold a thread forever.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+/// A request line plus headers. Anything larger is not a proxy request.
+const MAX_HEADER_BYTES: usize = 32 * 1024;
+
+/// What the user asked for, kept in the profile so it survives a restart.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LanSettings {
+    pub enabled: bool,
+    /// The port other devices are pointed at.
+    pub port: u16,
+    /// Both empty means no sign-in, which is a real decision and not a default:
+    /// see [`LanStatus::open`].
+    pub username: String,
+    pub password: String,
+}
+
+impl Default for LanSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            // 1080 is what a person expects a SOCKS proxy to be on, and this
+            // port is typed into another device by hand.
+            port: 1080,
+            username: String::new(),
+            password: String::new(),
+        }
+    }
+}
+
+impl LanSettings {
+    /// The credentials to enforce, or `None` when the user chose to run open.
+    ///
+    /// A username without a password (or the reverse) is treated as no
+    /// credentials rather than as a half-configured lock, because enforcing an
+    /// empty password would be worse than not pretending to have one.
+    pub fn credentials(&self) -> Option<(String, String)> {
+        let user = self.username.trim();
+        let password = self.password.trim();
+        if user.is_empty() || password.is_empty() {
+            return None;
+        }
+        Some((user.to_string(), password.to_string()))
+    }
+}
+
+/// What the interface shows about the shared door.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LanStatus {
+    pub running: bool,
+    /// The address to type into the other device, e.g. `192.168.1.24:1080`.
+    pub address: Option<String>,
+    /// Running without credentials: anyone on this network can use the tunnel.
+    pub open: bool,
+}
+
+impl LanStatus {
+    pub fn stopped() -> Self {
+        Self { running: false, address: None, open: false }
+    }
+}
+
+/// The one door this process has open, if any.
+///
+/// Held as Tauri state so every path that changes what is carrying traffic can
+/// point it at the new listener without threading a handle through them all.
+#[derive(Default)]
+pub struct LanDoor(Mutex<Option<LanShare>>);
+
+impl LanDoor {
+    pub fn status(&self) -> LanStatus {
+        self.0
+            .lock()
+            .ok()
+            .and_then(|held| held.as_ref().map(LanShare::status))
+            .unwrap_or_else(LanStatus::stopped)
+    }
+
+    /// Opens the door, replacing any door already open.
+    pub fn open(&self, carrier: SocketAddr, settings: &LanSettings) -> Result<LanStatus, String> {
+        let share = start(carrier, settings).map_err(|error| match error.kind() {
+            // The message a person can act on: the port is the one thing they
+            // chose, and something else on the machine already has it.
+            io::ErrorKind::AddrInUse => {
+                format!("port {} is already in use; pick another", settings.port)
+            }
+            _ => format!("cannot share on port {}: {error}", settings.port),
+        })?;
+        let status = share.status();
+        let mut held = self.0.lock().map_err(|_| "the sharing lock is poisoned")?;
+        // The old door is dropped, and stopped, only once the new one is bound.
+        *held = Some(share);
+        Ok(status)
+    }
+
+    pub fn close(&self) {
+        if let Ok(mut held) = self.0.lock() {
+            held.take();
+        }
+    }
+
+    /// Follows the listener that is now carrying traffic.
+    pub fn retarget(&self, carrier: SocketAddr) {
+        if let Ok(held) = self.0.lock() {
+            if let Some(share) = held.as_ref() {
+                share.retarget(carrier);
+            }
+        }
+    }
+}
+
+pub struct LanShare {
+    port: u16,
+    stop: Arc<AtomicBool>,
+    /// Where traffic is handed on. Held behind a lock rather than copied into
+    /// each thread so switching the second hop on does not strand devices on
+    /// the listener that was carrying traffic when they connected.
+    carrier: Arc<Mutex<SocketAddr>>,
+    open: bool,
+}
+
+impl LanShare {
+    pub fn status(&self) -> LanStatus {
+        LanStatus {
+            running: true,
+            address: Some(format!("{}:{}", local_address(), self.port)),
+            open: self.open,
+        }
+    }
+
+    /// Points the door at a different listener, in place.
+    pub fn retarget(&self, carrier: SocketAddr) {
+        if let Ok(mut held) = self.carrier.lock() {
+            *held = carrier;
+        }
+    }
+
+    pub fn stop(&self) {
+        self.stop.store(true, Ordering::SeqCst);
+        // Unblock the accept loop, which is parked in accept() rather than
+        // polling a flag it cannot see.
+        let _ = TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, self.port)));
+    }
+}
+
+impl Drop for LanShare {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Opens the door on every interface and forwards to `carrier`.
+///
+/// Binding `0.0.0.0` is the whole point and also the risk, so the caller is
+/// expected to have told the user what it means. On Windows the first run
+/// raises a firewall prompt; until it is accepted, the port is reachable from
+/// this machine only.
+pub fn start(
+    carrier: SocketAddr,
+    settings: &LanSettings,
+) -> io::Result<LanShare> {
+    let credentials = settings.credentials();
+    let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, settings.port)))?;
+    let port = listener.local_addr()?.port();
+    let stop = Arc::new(AtomicBool::new(false));
+    let carrier = Arc::new(Mutex::new(carrier));
+
+    let accept_stop = stop.clone();
+    let accept_carrier = carrier.clone();
+    let accept_credentials = credentials.clone();
+    thread::Builder::new()
+        .name("whiteaesther-lan-share".into())
+        .spawn(move || {
+            for client in listener.incoming() {
+                if accept_stop.load(Ordering::SeqCst) {
+                    return;
+                }
+                let Ok(client) = client else { continue };
+                let carrier = accept_carrier.clone();
+                let credentials = accept_credentials.clone();
+                thread::spawn(move || {
+                    let to = carrier.lock().map(|held| *held).ok();
+                    if let Some(to) = to {
+                        // A failed exchange closes that connection and nothing
+                        // else.
+                        let _ = serve(client, to, credentials.as_ref());
+                    }
+                });
+            }
+        })?;
+
+    Ok(LanShare { port, stop, carrier, open: credentials.is_none() })
+}
+
+fn serve(mut client: TcpStream, carrier: SocketAddr, auth: Option<&(String, String)>) -> io::Result<()> {
+    client.set_read_timeout(Some(HANDSHAKE_TIMEOUT))?;
+
+    let mut first = [0_u8; 1];
+    if client.read(&mut first)? == 0 {
+        return Ok(());
+    }
+    if first[0] == 0x05 {
+        return serve_socks5(client, carrier, auth);
+    }
+    serve_http(client, carrier, auth, first[0])
+}
+
+// ---------------------------------------------------------------------------
+// SOCKS5
+// ---------------------------------------------------------------------------
+
+const SOCKS_NO_AUTH: u8 = 0x00;
+const SOCKS_USER_PASS: u8 = 0x02;
+const SOCKS_NO_ACCEPTABLE: u8 = 0xFF;
+
+fn serve_socks5(
+    mut client: TcpStream,
+    carrier: SocketAddr,
+    auth: Option<&(String, String)>,
+) -> io::Result<()> {
+    // The version byte has already been read.
+    let mut count = [0_u8; 1];
+    client.read_exact(&mut count)?;
+    let mut methods = vec![0_u8; count[0] as usize];
+    client.read_exact(&mut methods)?;
+
+    let wanted = if auth.is_some() { SOCKS_USER_PASS } else { SOCKS_NO_AUTH };
+    if !methods.contains(&wanted) {
+        // Refused rather than downgraded: a client that will not sign in does
+        // not get in because it asked nicely.
+        client.write_all(&[0x05, SOCKS_NO_ACCEPTABLE])?;
+        return Ok(());
+    }
+    client.write_all(&[0x05, wanted])?;
+
+    if let Some((user, password)) = auth {
+        if !socks5_sign_in(&mut client, user, password)? {
+            return Ok(());
+        }
+    }
+
+    let mut head = [0_u8; 4];
+    client.read_exact(&mut head)?;
+    if head[1] != 0x01 {
+        // CONNECT only. BIND and UDP ASSOCIATE would need the carrier to offer
+        // them too, and saying so is better than half-supporting them.
+        return socks5_reply(&mut client, 0x07);
+    }
+    let host = match head[3] {
+        0x01 => {
+            let mut raw = [0_u8; 4];
+            client.read_exact(&mut raw)?;
+            Ipv4Addr::from(raw).to_string()
+        }
+        0x03 => {
+            let mut length = [0_u8; 1];
+            client.read_exact(&mut length)?;
+            let mut name = vec![0_u8; length[0] as usize];
+            client.read_exact(&mut name)?;
+            String::from_utf8_lossy(&name).into_owned()
+        }
+        0x04 => {
+            let mut raw = [0_u8; 16];
+            client.read_exact(&mut raw)?;
+            std::net::Ipv6Addr::from(raw).to_string()
+        }
+        _ => return socks5_reply(&mut client, 0x08),
+    };
+    let mut port = [0_u8; 2];
+    client.read_exact(&mut port)?;
+    let port = u16::from_be_bytes(port);
+
+    let upstream = match socks5_connect(carrier, &host, port, HANDSHAKE_TIMEOUT) {
+        Ok(upstream) => upstream,
+        Err(_) => return socks5_reply(&mut client, 0x05),
+    };
+    socks5_reply(&mut client, 0x00)?;
+    client.set_read_timeout(None)?;
+    splice(client, upstream);
+    Ok(())
+}
+
+/// RFC 1929. Returns whether the client got in.
+fn socks5_sign_in(client: &mut TcpStream, user: &str, password: &str) -> io::Result<bool> {
+    let mut version = [0_u8; 1];
+    client.read_exact(&mut version)?;
+    if version[0] != 0x01 {
+        client.write_all(&[0x01, 0x01])?;
+        return Ok(false);
+    }
+    let mut length = [0_u8; 1];
+    client.read_exact(&mut length)?;
+    let mut offered_user = vec![0_u8; length[0] as usize];
+    client.read_exact(&mut offered_user)?;
+    client.read_exact(&mut length)?;
+    let mut offered_password = vec![0_u8; length[0] as usize];
+    client.read_exact(&mut offered_password)?;
+
+    let ok = offered_user == user.as_bytes() && offered_password == password.as_bytes();
+    client.write_all(&[0x01, if ok { 0x00 } else { 0x01 }])?;
+    Ok(ok)
+}
+
+fn socks5_reply(client: &mut TcpStream, code: u8) -> io::Result<()> {
+    client.write_all(&[0x05, code, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+}
+
+// ---------------------------------------------------------------------------
+// HTTP
+// ---------------------------------------------------------------------------
+
+fn serve_http(
+    mut client: TcpStream,
+    carrier: SocketAddr,
+    auth: Option<&(String, String)>,
+    first: u8,
+) -> io::Result<()> {
+    let mut reader = BufReader::new(client.try_clone()?);
+    let mut request_line = String::from(first as char);
+    if reader.read_line(&mut request_line)? == 0 {
+        return Ok(());
+    }
+    let mut parts = request_line.split_whitespace();
+    let (method, target) = match (parts.next(), parts.next()) {
+        (Some(method), Some(target)) => (method.to_string(), target.to_string()),
+        _ => return respond(&mut client, 400, "Bad Request"),
+    };
+
+    let mut headers = Vec::new();
+    let mut total = request_line.len();
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        total += line.len();
+        if total > MAX_HEADER_BYTES {
+            return respond(&mut client, 431, "Request Header Fields Too Large");
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        headers.push(line);
+    }
+
+    if let Some((user, password)) = auth {
+        if !http_signed_in(&headers, user, password) {
+            return respond_unauthorized(&mut client);
+        }
+    }
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        let Some((host, port)) = split_authority(&target, 443) else {
+            return respond(&mut client, 400, "Bad Request");
+        };
+        let upstream = match socks5_connect(carrier, &host, port, HANDSHAKE_TIMEOUT) {
+            Ok(upstream) => upstream,
+            Err(_) => return respond(&mut client, 502, "Bad Gateway"),
+        };
+        client.write_all(b"HTTP/1.1 200 Connection established\r\n\r\n")?;
+        client.set_read_timeout(None)?;
+        splice(client, upstream);
+        return Ok(());
+    }
+
+    let Some((host, port, path)) = split_absolute_uri(&target) else {
+        return respond(&mut client, 400, "Bad Request");
+    };
+    let mut upstream = match socks5_connect(carrier, &host, port, HANDSHAKE_TIMEOUT) {
+        Ok(upstream) => upstream,
+        Err(_) => return respond(&mut client, 502, "Bad Gateway"),
+    };
+
+    let mut head = format!("{method} {path} HTTP/1.1\r\n");
+    for header in &headers {
+        // Hop-by-hop: meaningful to this proxy, not to the origin server. The
+        // credentials especially must not travel on to the destination.
+        let lowered = header.to_ascii_lowercase();
+        if lowered.starts_with("proxy-connection:") || lowered.starts_with("proxy-authorization:") {
+            continue;
+        }
+        head.push_str(header);
+    }
+    head.push_str("\r\n");
+    upstream.write_all(head.as_bytes())?;
+
+    let buffered = reader.buffer().to_vec();
+    if !buffered.is_empty() {
+        upstream.write_all(&buffered)?;
+    }
+    client.set_read_timeout(None)?;
+    splice(client, upstream);
+    Ok(())
+}
+
+/// Whether a `Proxy-Authorization: Basic` header carries these credentials.
+fn http_signed_in(headers: &[String], user: &str, password: &str) -> bool {
+    let expected = base64(format!("{user}:{password}").as_bytes());
+    headers.iter().any(|header| {
+        let Some((name, value)) = header.split_once(':') else {
+            return false;
+        };
+        if !name.trim().eq_ignore_ascii_case("proxy-authorization") {
+            return false;
+        }
+        let value = value.trim();
+        let Some(offered) = value
+            .strip_prefix("Basic ")
+            .or_else(|| value.strip_prefix("basic "))
+        else {
+            return false;
+        };
+        offered.trim() == expected
+    })
+}
+
+fn respond(client: &mut TcpStream, code: u16, reason: &str) -> io::Result<()> {
+    write!(client, "HTTP/1.1 {code} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+}
+
+fn respond_unauthorized(client: &mut TcpStream) -> io::Result<()> {
+    write!(
+        client,
+        "HTTP/1.1 407 Proxy Authentication Required\r\n\
+         Proxy-Authenticate: Basic realm=\"WhiteAesther\"\r\n\
+         Content-Length: 0\r\nConnection: close\r\n\r\n"
+    )
+}
+
+/// Standard base64, no padding shortcuts. Small enough not to be worth a
+/// dependency, and only ever fed a username and password.
+fn base64(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
+        let bits = (u32::from(b[0]) << 16) | (u32::from(b[1]) << 8) | u32::from(b[2]);
+        for index in 0..4 {
+            if index <= chunk.len() {
+                out.push(ALPHABET[((bits >> (18 - index * 6)) & 0x3F) as usize] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}
+
+/// `host:port`, with IPv6 in brackets.
+fn split_authority(target: &str, default_port: u16) -> Option<(String, u16)> {
+    if let Some(rest) = target.strip_prefix('[') {
+        let (host, tail) = rest.split_once(']')?;
+        let port = match tail.strip_prefix(':') {
+            Some(port) => port.parse().ok()?,
+            None => default_port,
+        };
+        return Some((host.to_string(), port));
+    }
+    match target.rsplit_once(':') {
+        Some((host, port)) if !host.is_empty() => Some((host.to_string(), port.parse().ok()?)),
+        _ => Some((target.to_string(), default_port)),
+    }
+}
+
+/// `http://host[:port]/path` into its parts, with the path in origin form.
+fn split_absolute_uri(target: &str) -> Option<(String, u16, String)> {
+    let rest = target
+        .strip_prefix("http://")
+        .or_else(|| target.strip_prefix("HTTP://"))?;
+    let (authority, path) = match rest.find('/') {
+        Some(index) => (&rest[..index], &rest[index..]),
+        None => (rest, "/"),
+    };
+    let (host, port) = split_authority(authority, 80)?;
+    Some((host, port, path.to_string()))
+}
+
+/// Copies in both directions until either side closes.
+fn splice(client: TcpStream, upstream: TcpStream) {
+    let Ok(client_reader) = client.try_clone() else { return };
+    let Ok(upstream_reader) = upstream.try_clone() else { return };
+
+    let outbound = thread::spawn(move || {
+        let mut from = client_reader;
+        let mut to = upstream;
+        let _ = io::copy(&mut from, &mut to);
+        let _ = to.shutdown(std::net::Shutdown::Write);
+    });
+
+    let mut from = upstream_reader;
+    let mut to = client;
+    let _ = io::copy(&mut from, &mut to);
+    let _ = to.shutdown(std::net::Shutdown::Write);
+    let _ = outbound.join();
+}
+
+/// This machine's address on the local network.
+///
+/// Found by asking the routing table which source address it would use to reach
+/// the internet, which is the one another device on the same network can reach.
+/// Nothing is sent: a UDP socket that has only been connected has not spoken.
+fn local_address() -> IpAddr {
+    UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))
+        .and_then(|socket| {
+            socket.connect((Ipv4Addr::new(1, 1, 1, 1), 80))?;
+            socket.local_addr()
+        })
+        .map(|address| address.ip())
+        .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn half_filled_credentials_do_not_pretend_to_be_a_lock() {
+        // A username with no password is someone who started typing and stopped.
+        // Enforcing it would accept an empty password as valid.
+        let mut settings = LanSettings { enabled: true, port: 1080, ..LanSettings::default() };
+        settings.username = "alex".into();
+        assert!(settings.credentials().is_none());
+        settings.password = "  ".into();
+        assert!(settings.credentials().is_none());
+        settings.password = "hunter2".into();
+        assert_eq!(settings.credentials(), Some(("alex".into(), "hunter2".into())));
+    }
+
+    #[test]
+    fn base64_matches_the_header_browsers_send() {
+        // The values in RFC 7617 and the classic example, because a wrong
+        // encoder would reject every correct password instead of failing loudly.
+        assert_eq!(base64(b"Aladdin:open sesame"), "QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        assert_eq!(base64(b"a"), "YQ==");
+        assert_eq!(base64(b"ab"), "YWI=");
+        assert_eq!(base64(b"abc"), "YWJj");
+        assert_eq!(base64(b""), "");
+    }
+
+    #[test]
+    fn the_right_credentials_get_in_and_nothing_else_does() {
+        let header = |value: &str| vec![format!("Proxy-Authorization: {value}\r\n")];
+        let ok = format!("Basic {}", base64(b"alex:hunter2"));
+        assert!(http_signed_in(&header(&ok), "alex", "hunter2"));
+        // Right user, wrong password.
+        assert!(!http_signed_in(&header(&format!("Basic {}", base64(b"alex:wrong"))), "alex", "hunter2"));
+        // No header at all, which is what the first request from a browser is.
+        assert!(!http_signed_in(&[], "alex", "hunter2"));
+        // A scheme we do not implement must not be waved through.
+        assert!(!http_signed_in(&header("Bearer somethingelse"), "alex", "hunter2"));
+    }
+
+    #[test]
+    fn the_door_binds_on_every_interface_not_just_loopback() {
+        // The entire point of the feature. Binding loopback would look like it
+        // worked from this machine and be unreachable from the phone.
+        let carrier = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let settings = LanSettings { enabled: true, port: 0, ..LanSettings::default() };
+        let share = start(carrier, &settings).expect("the door should open");
+        let status = share.status();
+        assert!(status.running);
+        assert!(status.open, "no credentials were set, so it is open");
+        share.stop();
+    }
+
+    /// A stand-in for whatever is carrying traffic: speaks just enough SOCKS5
+    /// to accept one CONNECT, then echoes. Returns its address and a handle
+    /// that yields the bytes it was asked to send onward.
+    fn stub_carrier() -> (SocketAddr, std::sync::mpsc::Receiver<Vec<u8>>) {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let tx = tx.clone();
+                thread::spawn(move || {
+                    let mut greeting = [0_u8; 2];
+                    if stream.read_exact(&mut greeting).is_err() {
+                        return;
+                    }
+                    let mut methods = vec![0_u8; greeting[1] as usize];
+                    let _ = stream.read_exact(&mut methods);
+                    let _ = stream.write_all(&[0x05, 0x00]);
+
+                    let mut head = [0_u8; 4];
+                    if stream.read_exact(&mut head).is_err() {
+                        return;
+                    }
+                    match head[3] {
+                        0x01 => {
+                            let mut raw = [0_u8; 4];
+                            let _ = stream.read_exact(&mut raw);
+                        }
+                        0x03 => {
+                            let mut length = [0_u8; 1];
+                            let _ = stream.read_exact(&mut length);
+                            let mut name = vec![0_u8; length[0] as usize];
+                            let _ = stream.read_exact(&mut name);
+                        }
+                        _ => {
+                            let mut raw = [0_u8; 16];
+                            let _ = stream.read_exact(&mut raw);
+                        }
+                    }
+                    let mut port = [0_u8; 2];
+                    let _ = stream.read_exact(&mut port);
+                    let _ = stream.write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0]);
+
+                    let mut buffer = [0_u8; 1024];
+                    while let Ok(read) = stream.read(&mut buffer) {
+                        if read == 0 {
+                            break;
+                        }
+                        let _ = tx.send(buffer[..read].to_vec());
+                        let _ = stream.write_all(&buffer[..read]);
+                    }
+                });
+            }
+        });
+        (address, rx)
+    }
+
+    fn open_door(credentials: bool) -> (LanShare, std::sync::mpsc::Receiver<Vec<u8>>) {
+        let (carrier, rx) = stub_carrier();
+        let settings = LanSettings {
+            enabled: true,
+            port: 0,
+            username: if credentials { "alex".into() } else { String::new() },
+            password: if credentials { "hunter2".into() } else { String::new() },
+        };
+        (start(carrier, &settings).expect("the door should open"), rx)
+    }
+
+    #[test]
+    fn a_signed_in_socks_client_reaches_the_carrier() {
+        let (share, _rx) = open_door(true);
+        let mut client =
+            TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, share.port))).unwrap();
+        client.write_all(&[0x05, 0x01, SOCKS_USER_PASS]).unwrap();
+        let mut reply = [0_u8; 2];
+        client.read_exact(&mut reply).unwrap();
+        assert_eq!(reply, [0x05, SOCKS_USER_PASS]);
+
+        // RFC 1929: version, username, password.
+        client.write_all(&[0x01, 4]).unwrap();
+        client.write_all(b"alex").unwrap();
+        client.write_all(&[7]).unwrap();
+        client.write_all(b"hunter2").unwrap();
+        let mut auth = [0_u8; 2];
+        client.read_exact(&mut auth).unwrap();
+        assert_eq!(auth, [0x01, 0x00], "the right password must be accepted");
+
+        // CONNECT example.com:80, as a domain so the name is resolved beyond
+        // the tunnel rather than here.
+        client.write_all(&[0x05, 0x01, 0x00, 0x03, 11]).unwrap();
+        client.write_all(b"example.com").unwrap();
+        client.write_all(&80_u16.to_be_bytes()).unwrap();
+        let mut response = [0_u8; 10];
+        client.read_exact(&mut response).unwrap();
+        assert_eq!(response[1], 0x00, "the carrier accepted, so the client must be told so");
+
+        client.write_all(b"hello").unwrap();
+        let mut echoed = [0_u8; 5];
+        client.read_exact(&mut echoed).unwrap();
+        assert_eq!(&echoed, b"hello", "bytes must travel both ways");
+        share.stop();
+    }
+
+    #[test]
+    fn a_wrong_password_does_not_get_through() {
+        let (share, _rx) = open_door(true);
+        let mut client =
+            TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, share.port))).unwrap();
+        client.write_all(&[0x05, 0x01, SOCKS_USER_PASS]).unwrap();
+        let mut reply = [0_u8; 2];
+        client.read_exact(&mut reply).unwrap();
+        client.write_all(&[0x01, 4]).unwrap();
+        client.write_all(b"alex").unwrap();
+        client.write_all(&[5]).unwrap();
+        client.write_all(b"wrong").unwrap();
+        let mut auth = [0_u8; 2];
+        client.read_exact(&mut auth).unwrap();
+        assert_eq!(auth, [0x01, 0x01], "refused");
+        // And the connection is over: no second guess at the password.
+        let mut anything = [0_u8; 1];
+        assert_eq!(client.read(&mut anything).unwrap_or(0), 0);
+        share.stop();
+    }
+
+    #[test]
+    fn an_http_request_arrives_at_the_carrier_in_origin_form() {
+        // The first byte of the request line is read before the protocol is
+        // known, so it has to be put back before the line is parsed. Getting
+        // that wrong turns every GET into "ET".
+        let (share, rx) = open_door(false);
+        let mut client =
+            TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, share.port))).unwrap();
+        client
+            .write_all(b"GET http://example.com/a?b=c HTTP/1.1\r\nHost: example.com\r\n\r\n")
+            .unwrap();
+        let forwarded = rx.recv_timeout(Duration::from_secs(5)).expect("the carrier should be dialled");
+        let text = String::from_utf8_lossy(&forwarded);
+        assert!(text.starts_with("GET /a?b=c HTTP/1.1\r\n"), "got: {text}");
+        assert!(text.contains("Host: example.com"), "got: {text}");
+        share.stop();
+    }
+
+    #[test]
+    fn an_http_connect_tunnel_carries_bytes_once_established() {
+        let (share, _rx) = open_door(true);
+        let mut client =
+            TcpStream::connect(SocketAddr::from((Ipv4Addr::LOCALHOST, share.port))).unwrap();
+        let credentials = base64(b"alex:hunter2");
+        write!(
+            client,
+            "CONNECT example.com:443 HTTP/1.1\r\nProxy-Authorization: Basic {credentials}\r\n\r\n"
+        )
+        .unwrap();
+        let mut header = [0_u8; 39];
+        client.read_exact(&mut header).unwrap();
+        assert!(
+            String::from_utf8_lossy(&header).starts_with("HTTP/1.1 200"),
+            "got: {}",
+            String::from_utf8_lossy(&header)
+        );
+        client.write_all(b"hello").unwrap();
+        let mut echoed = [0_u8; 5];
+        client.read_exact(&mut echoed).unwrap();
+        assert_eq!(&echoed, b"hello");
+        share.stop();
+    }
+
+    #[test]
+    fn a_socks_client_that_will_not_sign_in_is_refused() {
+        let carrier = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let settings = LanSettings {
+            enabled: true,
+            port: 0,
+            username: "alex".into(),
+            password: "hunter2".into(),
+        };
+        let share = start(carrier, &settings).expect("the door should open");
+        assert!(!share.status().open, "credentials were set");
+
+        let address = SocketAddr::from((Ipv4Addr::LOCALHOST, share.port));
+        let mut client = TcpStream::connect(address).expect("should accept");
+        // "SOCKS5, and the only method I know is no authentication."
+        client.write_all(&[0x05, 0x01, SOCKS_NO_AUTH]).unwrap();
+        let mut reply = [0_u8; 2];
+        client.read_exact(&mut reply).unwrap();
+        assert_eq!(reply, [0x05, SOCKS_NO_ACCEPTABLE]);
+        share.stop();
+    }
+
+    #[test]
+    fn an_http_client_without_credentials_is_told_to_authenticate() {
+        let carrier = SocketAddr::from((Ipv4Addr::LOCALHOST, 1));
+        let settings = LanSettings {
+            enabled: true,
+            port: 0,
+            username: "alex".into(),
+            password: "hunter2".into(),
+        };
+        let share = start(carrier, &settings).expect("the door should open");
+        let address = SocketAddr::from((Ipv4Addr::LOCALHOST, share.port));
+        let mut client = TcpStream::connect(address).expect("should accept");
+        client
+            .write_all(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+            .unwrap();
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 407"), "got: {response}");
+        assert!(response.contains("Proxy-Authenticate: Basic"), "got: {response}");
+        share.stop();
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod chain;
 mod core_supervisor;
 mod http_bridge;
+mod lan_share;
 mod latency;
 mod scanner;
 mod system_proxy;
@@ -33,8 +34,13 @@ async fn chain_status(chain: tauri::State<'_, Chain>) -> Result<ChainStatus, Str
 
 /// Every node the chain knows about, with the delay each last recorded.
 #[tauri::command]
-async fn chain_nodes(chain: tauri::State<'_, Chain>) -> Result<Vec<chain::ChainNode>, String> {
-    chain.nodes()
+async fn chain_nodes(
+    chain: tauri::State<'_, Chain>,
+    supervisor: tauri::State<'_, CoreSupervisor>,
+) -> Result<Vec<chain::ChainNode>, String> {
+    // Which transport came up decides whether a QUIC node behind the tunnel can
+    // work at all, and only the supervisor knows that.
+    chain.nodes(supervisor.carries_quic())
 }
 
 /// Measures one node through the tunnel.
@@ -86,6 +92,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(CoreSupervisor::new())
         .manage(Chain::new())
+        .manage(lan_share::LanDoor::default())
         .setup(|app| {
             // A previous run that was killed rather than closed may have left
             // the system proxy pointing at a listener that is now gone, which
@@ -199,6 +206,8 @@ pub fn run() {
             core_supervisor::save_report,
             core_supervisor::set_system_proxy,
             core_supervisor::set_chain,
+            core_supervisor::set_lan_share,
+            core_supervisor::lan_share_status,
             scanner::scan_endpoints,
             scanner::test_endpoint,
             scanner::cancel_scan,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { ChainSettings, ConnectionProfile, CoreLogEvent, CoreProbe, CoreSnapshot } from "../types";
+import type { ChainSettings, ConnectionProfile, LanSettings, CoreLogEvent, CoreProbe, CoreSnapshot } from "../types";
 
 export function isDesktopRuntime(): boolean {
   return "__TAURI_INTERNALS__" in window;
@@ -172,6 +172,14 @@ export interface ChainNode {
   kind: string;
   /** Milliseconds through the tunnel, or null when the last test failed. */
   delay: number | null;
+  /**
+   * Why this node cannot work as things are set up, when it cannot.
+   *
+   * Set for QUIC protocols while the nodes are dialled through the tunnel: the
+   * handshake needs a bigger packet than the tunnel carries, so a measurement
+   * would fail however healthy the node is.
+   */
+  unusable: string | null;
 }
 
 /**
@@ -186,6 +194,31 @@ export async function setChain(settings: ChainSettings): Promise<boolean> {
 export async function chainStatus(): Promise<ChainStatus> {
   requireDesktop();
   return invoke("chain_status");
+}
+
+/** Where another device points, and on what terms. */
+export interface LanStatus {
+  running: boolean;
+  /** The address to type into the other device, e.g. `192.168.1.24:1080`. */
+  address: string | null;
+  /** Running with no sign-in: anyone on this network can use the tunnel. */
+  open: boolean;
+}
+
+/**
+ * Opens or closes the door other devices come in through.
+ *
+ * Takes effect immediately rather than at the next connect, because the person
+ * flipping it is usually standing next to the device they are configuring.
+ */
+export async function setLanShare(settings: LanSettings): Promise<LanStatus> {
+  requireDesktop();
+  return invoke("set_lan_share", { settings });
+}
+
+export async function lanShareStatus(): Promise<LanStatus> {
+  requireDesktop();
+  return invoke("lan_share_status");
 }
 
 export async function chainNodes(): Promise<ChainNode[]> {

--- a/src/core/report.test.ts
+++ b/src/core/report.test.ts
@@ -10,7 +10,7 @@ function event(message: string, timestamp = 0): CoreLogEvent {
 function report(overrides: Partial<Parameters<typeof buildReport>[0]> = {}): string {
   return buildReport({
     appVersion: "1.0.0",
-    engineVersion: "aether 1.5.0",
+    engineVersion: "aether 1.7.0",
     system: "windows · x86_64",
     snapshot: IDLE_SNAPSHOT,
     profile: DEFAULT_PROFILE,
@@ -56,9 +56,9 @@ test("redaction leaves lines that only look like addresses alone", () => {
 });
 
 test("the version header is never redacted", () => {
-  const text = report({ appVersion: "1.0.0.0", engineVersion: "aether 1.5.0" });
+  const text = report({ appVersion: "1.0.0.0", engineVersion: "aether 1.7.0" });
   assert.ok(text.includes("app 1.0.0.0"), text);
-  assert.ok(text.includes("engine aether 1.5.0"), text);
+  assert.ok(text.includes("engine aether 1.7.0"), text);
 });
 
 test("Zero Trust credentials and the pinned endpoint never reach the report", () => {

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -126,6 +126,16 @@ function settingsLine(profile: ConnectionProfile): string {
     ["zeroTrust", Boolean(profile.team?.trim())],
     ["gateway", profile.gateway],
     ["systemProxy", profile.systemProxy],
+    // Whether the machine is a door onto the tunnel for the rest of the
+    // network, and whether that door asks for anything. Never the credentials
+    // themselves: this file gets handed to other people.
+    ["lanShare", profile.lanShare.enabled],
+    [
+      "lanShareSignIn",
+      profile.lanShare.enabled
+        ? Boolean(profile.lanShare.username.trim() && profile.lanShare.password.trim())
+        : false,
+    ],
   ];
   return `settings ${values.map(([key, value]) => `${key}=${value}`).join(" ")}`;
 }

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -10,7 +10,7 @@ import { Switch } from "@/components/ui/switch";
 import { buildCoreCommand } from "@/core/command";
 import { endpointError, normalizeEndpoint } from "@/core/endpoint";
 import { REPORT_EVENT_LIMIT, buildReport, reportFilename } from "@/core/report";
-import { saveReport } from "@/core/api";
+import { type LanStatus, lanShareStatus, saveReport, setLanShare } from "@/core/api";
 import { NumberField, Row, RulesField, Seg, TextField } from "./panels";
 import { Chain } from "./Chain";
 import { Scanner } from "./Scanner";
@@ -20,7 +20,7 @@ import { transportName } from "./Simple";
 // that. The same text is installed beside the executable under licences/.
 import notices from "../../THIRD_PARTY_NOTICES.md?raw";
 import {
-  ENDPOINT_MODES, type ConnectionProfile, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
+  ENDPOINT_MODES, type ConnectionProfile, type LanSettings, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
 } from "@/types";
 
 type SectionId =
@@ -264,7 +264,7 @@ function Licences() {
             <span className="font-mono text-[12.5px] text-muted-foreground">AGPL-3.0</span>
           </Row>
           <Separator />
-          <Row title="Aether" help="The connection engine, linked into this app and shipped as a binary">
+          <Row title="Aether" help="The connection engine, shipped as a binary and run by this app. Aether 1.7.0">
             <span className="font-mono text-[12.5px] text-muted-foreground">AGPL-3.0</span>
           </Row>
           <Separator />
@@ -547,7 +547,7 @@ function Endpoint({ profile, onChange, snapshot, onToast }: AdvancedProps) {
 
 // --------------------------------------------------------------------- traffic
 
-function Traffic({ profile, onChange, runtime }: AdvancedProps) {
+function Traffic({ profile, onChange, runtime, snapshot, onToast }: AdvancedProps) {
   const set = (patch: Partial<ConnectionProfile>) => onChange({ ...profile, ...patch });
   return (
     <>
@@ -594,6 +594,13 @@ function Traffic({ profile, onChange, runtime }: AdvancedProps) {
         </CardContent>
       </Card>
 
+      <LanSharing
+        profile={profile}
+        onChange={onChange}
+        connected={snapshot.state === "connected"}
+        onToast={onToast}
+      />
+
       <Card>
         <CardHeader className="pb-1">
           <CardTitle className="text-[15px]">Routing rules</CardTitle>
@@ -623,6 +630,159 @@ function Traffic({ profile, onChange, runtime }: AdvancedProps) {
         </CardContent>
       </Card>
     </>
+  );
+}
+
+/**
+ * Sharing this machine's tunnel with the rest of the network.
+ *
+ * The switch is the whole feature and the warning is half of it: a proxy on a
+ * network port is a proxy anyone on that network can use, and on a café or
+ * office network that is everyone. Sign-in is optional because a home network
+ * where it does not matter is the common case -- but the consequence is stated
+ * on screen while it is off, not buried in a help line nobody opens.
+ */
+function LanSharing({
+  profile,
+  onChange,
+  connected,
+  onToast,
+}: {
+  profile: ConnectionProfile;
+  onChange: (profile: ConnectionProfile) => void;
+  connected: boolean;
+  onToast: (title: string, message: string, error?: boolean) => void;
+}) {
+  const share = profile.lanShare;
+  const [status, setStatus] = useState<LanStatus>({ running: false, address: null, open: false });
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    lanShareStatus().then(setStatus).catch(() => setStatus({ running: false, address: null, open: false }));
+  }, [connected]);
+
+  /**
+   * Saves and applies together. A port or a password that was typed but never
+   * reached the listener is the worst of both: the screen says one thing and
+   * the open port does another.
+   */
+  const apply = async (patch: Partial<LanSettings>) => {
+    const next = { ...share, ...patch };
+    onChange({ ...profile, lanShare: next });
+    if (!connected && next.enabled) return;
+    setBusy(true);
+    try {
+      setStatus(await setLanShare(next));
+    } catch (error) {
+      // Put the switch back: it must not sit on over a door that never opened.
+      onChange({ ...profile, lanShare: { ...next, enabled: false } });
+      setStatus({ running: false, address: null, open: false });
+      onToast("Could not share", error instanceof Error ? error.message : String(error), true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-1">
+        <CardTitle className="text-[15px]">Share with other devices</CardTitle>
+        <CardDescription>
+          Opens a proxy on this machine that phones, televisions and anything else on the same
+          network can point at. They go out through whatever is carrying traffic here — the second
+          hop when one is running, the tunnel when it is not.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <Row
+          first
+          title="Share this connection on my network"
+          help={
+            connected
+              ? "The port is opened while connected and closed when you disconnect."
+              : "Connect first — there is nothing to share until the tunnel is carrying traffic."
+          }
+        >
+          <Switch
+            checked={share.enabled}
+            disabled={busy || (!connected && !share.enabled)}
+            onCheckedChange={(enabled) => void apply({ enabled })}
+          />
+        </Row>
+
+        {share.enabled ? (
+          <>
+            <div className="grid grid-cols-3 gap-4 py-3">
+              <TextField
+                label="Port"
+                mono
+                value={String(share.port)}
+                onChange={(value) => {
+                  const port = Number(value.replace(/[^0-9]/g, ""));
+                  onChange({
+                    ...profile,
+                    lanShare: { ...share, port: Number.isFinite(port) ? port : 0 },
+                  });
+                }}
+                help="Typed into the other device."
+              />
+              <TextField
+                label="Username"
+                value={share.username}
+                onChange={(username) => onChange({ ...profile, lanShare: { ...share, username } })}
+                help="Optional."
+              />
+              <TextField
+                label="Password"
+                value={share.password}
+                onChange={(password) => onChange({ ...profile, lanShare: { ...share, password } })}
+                help="Optional."
+              />
+            </div>
+
+            {!share.username.trim() || !share.password.trim() ? (
+              <div className="mb-3 rounded-lg border border-amber-500/40 bg-amber-500/[0.08] p-3">
+                <div className="text-[12.5px] font-semibold text-amber-500">
+                  No sign-in: anyone on this network can use your tunnel
+                </div>
+                <div className="mt-1 text-[12px] text-muted-foreground">
+                  Every device that can reach this machine — including guests and anything else on a
+                  shared or public network — can send traffic through your connection, and it will
+                  leave from your exit address. Fill in both a username and a password to require a
+                  sign-in.
+                </div>
+              </div>
+            ) : null}
+
+            <div className="flex items-center justify-between gap-4 border-t pt-3">
+              <div className="min-w-0">
+                <div className="text-[13px] font-medium">
+                  {status.running ? "Open" : "Not open"}
+                </div>
+                <div className="truncate font-mono text-[11.5px] text-muted-foreground">
+                  {status.running && status.address
+                    ? `Point devices at ${status.address} — HTTP or SOCKS5, same port`
+                    : "Apply to open the port."}
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={busy || !connected}
+                onClick={() => void apply({})}
+              >
+                Apply
+              </Button>
+            </div>
+
+            <p className="pt-2 text-[12px] text-muted-foreground">
+              Windows asks to allow this the first time. Until you say yes, the port answers on this
+              machine only.
+            </p>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/features/Chain.tsx
+++ b/src/features/Chain.tsx
@@ -233,6 +233,17 @@ export function Chain({ profile, onChange, connected, onToast }: ChainProps) {
   );
 }
 
+/**
+ * Two words for a reason that needs a sentence.
+ *
+ * The column is 132 pixels wide and the full reason is in the tooltip, so this
+ * only has to be enough to tell the two cases apart at a glance: a node this
+ * build cannot use at all, and one that only needs a different first hop.
+ */
+function unusableLabel(reason: string): string {
+  return reason.startsWith("REALITY") ? "not supported" : "needs WireGuard";
+}
+
 function Sources({
   sources,
   onChange,
@@ -340,7 +351,8 @@ function Nodes({
           <CardTitle className="text-[15px]">Nodes</CardTitle>
           <CardDescription>
             Every measurement here travels the tunnel, so a figure means the node works from behind
-            it — and a failure means it does not.
+            it — and a failure means it does not. A node marked in amber is not broken and was not
+            measured: hover it to read why this build cannot use it, and what to change.
           </CardDescription>
         </div>
         <Button variant="outline" size="sm" className="shrink-0" onClick={onRefresh}>
@@ -380,18 +392,25 @@ function Nodes({
                     </div>
                   </div>
                   <span
+                    title={node.unusable ?? undefined}
                     className={[
-                      "tabular w-[68px] shrink-0 text-right font-mono text-[12.5px]",
+                      "tabular shrink-0 text-right font-mono text-[12.5px]",
+                      node.unusable ? "w-[132px] text-amber-500/90" : "w-[68px]",
                       node.delay == null ? "text-muted-foreground" : "text-primary",
+                      node.unusable ? "text-amber-500/90" : "",
                     ].join(" ")}
                   >
-                    {node.delay == null ? "—" : `${node.delay} ms`}
+                    {node.unusable
+                      ? unusableLabel(node.unusable)
+                      : node.delay == null
+                        ? "—"
+                        : `${node.delay} ms`}
                   </span>
                   <Button
                     variant="ghost"
                     size="sm"
                     className="shrink-0"
-                    disabled={busy === node.name}
+                    disabled={busy === node.name || node.unusable != null}
                     onClick={() => onTest(node)}
                   >
                     Test
@@ -400,7 +419,8 @@ function Nodes({
                     variant={active ? "secondary" : "outline"}
                     size="sm"
                     className="w-[86px] shrink-0"
-                    disabled={busy === node.name}
+                    title={node.unusable ?? undefined}
+                    disabled={busy === node.name || node.unusable != null}
                     onClick={() => onSelect(node)}
                   >
                     {active ? "In use" : <><Zap />Use</>}

--- a/src/features/settingsIndex.ts
+++ b/src/features/settingsIndex.ts
@@ -68,6 +68,7 @@ export const SETTINGS: SettingEntry[] = [
   { label: "Set the system proxy while connected", section: "traffic", where: "Traffic & DNS", keywords: "whole machine system proxy windows wininet browser all apps" },
   { label: "Block traffic if the tunnel drops", section: "traffic", where: "Traffic & DNS", keywords: "kill switch killswitch fail closed leak protection block traffic drop" },
   { label: "Keep me connected", section: "traffic", where: "Traffic & DNS", keywords: "auto reconnect retry keep alive stay connected reconnection" },
+  { label: "Share this connection on my network", section: "traffic", where: "Traffic & DNS", keywords: "lan share network other devices phone tv wifi hotspot proxy for phone username password" },
   { label: "Local proxy address", section: "traffic", where: "Traffic & DNS", keywords: "socks5 socks port 1819 bind listener point apps at" },
   { label: "DNS resolvers", section: "traffic", where: "Traffic & DNS", keywords: "dns resolver 1.1.1.1 leak nameserver" },
   { label: "Routing rules", section: "traffic", where: "Traffic & DNS", keywords: "route block direct bypass split tunnel exclude sites rules file" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,19 @@ export interface ChainSettings {
   node: string | null;
 }
 
+/** Sharing this machine's tunnel with other devices on the same network. */
+export interface LanSettings {
+  enabled: boolean;
+  /** The port another device is pointed at. */
+  port: number;
+  /**
+   * Both empty means no sign-in at all — anyone who can reach this machine on
+   * the network can use the tunnel. Allowed on purpose; the screen says so.
+   */
+  username: string;
+  password: string;
+}
+
 export interface ConnectionProfile {
   name: string;
   protocol: "masque" | "wg" | "gool";
@@ -74,6 +87,8 @@ export interface ConnectionProfile {
   autoReconnect: boolean;
   /** The second hop that changes the exit address. Off unless configured. */
   chain: ChainSettings;
+  /** Whether other devices on this network may use the tunnel. */
+  lanShare: LanSettings;
   /** Leave the system proxy on a dead tunnel so apps fail rather than leak. */
   killSwitch: boolean;
 }
@@ -152,6 +167,7 @@ export const DEFAULT_PROFILE: ConnectionProfile = {
   systemProxy: false,
   autoReconnect: true,
   chain: { enabled: false, throughTunnel: true, sources: [], manual: "", node: null },
+  lanShare: { enabled: false, port: 1080, username: "", password: "" },
   killSwitch: false,
 };
 


### PR DESCRIPTION
Five fixes, all found by measuring one subscription end to end.

### The node list was one stale node long
mihomo fetched the subscription through its own rules — `MATCH,exit` — so the only way to learn about the nodes was to already be running through one of them. Every refresh failed with `EOF`, and the provider kept serving its last cache, which belonged to a subscription that had already been replaced: the cache file was named after the position in the list, so a new URL inherited the old URL's nodes.

The fetch now names the tunnel (`proxy: aether`), and the cache is named after the URL. **Seven nodes arrive where one did.**

### Whole machine could point at WARP while the chain carried traffic
A running second hop now settles the route on its own, whatever the profile says. The two could disagree, and when they did, "This app only" advertised the chain's port while the machine went out past it — one browser, two exit addresses, decided by a switch that is supposed to change reach and not route.

### QUIC nodes could not be reached from behind the tunnel
A hysteria2 handshake opens with a 1280-byte datagram — 1308 bytes as an IP packet — and the netstack was built with an inner MTU of 1280.

That is the right number for MASQUE and cannot be raised: Cloudflare's connect-ip capsule carries 1306 bytes of inner packet, measured on a live connection. WireGuard is bound by the path instead and has 60 bytes to spare, so the engine now gives it 1340.

| | inner MTU | UDP ceiling | hysteria2 |
|---|---|---|---|
| MASQUE | 1280 | 1252 | needs 1280 — impossible |
| WireGuard, before | 1280 | 1252 | fails |
| WireGuard, now | 1340 | 1312 | **817 ms** |

Engine tag moves to `v1.7.0-whiteaesther.2` — Aether **1.7.0**. Upstream shipped its own library in 1.6/1.7, so the fork's embedded-API commit is dropped and only the scanner's reporting modes remain on top.

### Nodes this build cannot use now say so
- **REALITY** nodes are labelled rather than measured: mihomo's REALITY client cannot authenticate against current Xray servers. Three nodes, three different keys, all refused here — and all three answering in under a second under Xray, so the servers are fine.
- **QUIC** nodes are labelled only when the live transport is MASQUE, and the label says to switch to WireGuard.

### The connection can be shared with the rest of the network
One port speaks HTTP and SOCKS5 both, decided by the first byte, and forwards to whichever listener is carrying traffic — so a phone configured once survives the chain being switched on or off. Sign-in is optional, and while it is off the screen says plainly that anyone on the network can use the tunnel.

---

81 Rust tests, 33 frontend tests, clippy clean. Installers built and exercised locally against a real subscription and a live tunnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)