### PR TITLE
Release 1.7.0 — Persian, and an engine that no longer loses its lock

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   # The fork adds the reporting modes the endpoint scanner needs. Pinned to a
   # tag rather than a branch so a release is reproducible.
-  AETHER_REVISION: v1.7.0-whiteaesther.2
+  AETHER_REVISION: v1.8.0-whiteaesther.1
 
 jobs:
   gate:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,8 +8,8 @@ licence, and those licences are not superseded by WhiteAesther's.
 The connection engine. WhiteAesther ships the `aether` executable inside its installers and runs it
 to connect, and in a reporting mode to populate the endpoint picker.
 
-- Upstream: <https://github.com/CluvexStudio/Aether> — version 1.7.0
-- The build used here: <https://github.com/WhiteDNS/Aether> at tag `v1.7.0-whiteaesther.1` — a fork
+- Upstream: <https://github.com/CluvexStudio/Aether> — version 1.8.0
+- The build used here: <https://github.com/WhiteDNS/Aether> at tag `v1.8.0-whiteaesther.1` — a fork
   adding the two reporting modes the endpoint picker needs, with upstream history preserved and
   every change reviewable as a diff against it
 - Licence: GNU Affero General Public License v3.0 — see `LICENSE`, also installed as

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
 name = "whiteaesther"
 version = "1.7.0"
 dependencies = [
+ "getrandom 0.3.4",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.6.0"
+version = "1.7.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,9 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
+# The chain's control-API password. Guessing it means being able to
+# reconfigure routing, so it comes from the OS rather than from the clock.
+getrandom = "0.3"
 # A second copy knows nothing about the first: it reports "Not connected" over a
 # live tunnel, and its startup recovery reverts the system proxy the first one
 # applied -- taking the running session off the network from the outside.

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -25,7 +25,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
@@ -1044,12 +1044,22 @@ fn free_port() -> Result<u16, String> {
     Ok(port)
 }
 
+/// The password for the chain's control API.
+///
+/// Anything holding this can retarget every rule the engine routes by, so it
+/// comes from the operating system rather than from the clock. The previous
+/// version was the current nanosecond and this process id, which is guessable
+/// by anything that can see when the app started -- and on a platform whose
+/// clock is coarser than a nanosecond, two calls in succession returned the
+/// same string, which is how this was noticed.
 fn secret() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|value| value.as_nanos())
-        .unwrap_or_default();
-    format!("{:x}{:x}", nanos, std::process::id())
+    let mut bytes = [0_u8; 16];
+    if getrandom::fill(&mut bytes).is_err() {
+        // No entropy source is not a reason to run with a known password, and
+        // it is not a condition this can recover from.
+        panic!("the system refused to provide random bytes for the chain secret");
+    }
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 /// Waits for mihomo to answer, which is the only proof it actually came up.
@@ -1723,8 +1733,16 @@ mod tests {
     }
 
     #[test]
-    fn a_secret_differs_between_runs() {
-        assert_ne!(secret(), secret());
+    fn a_secret_is_random_and_long_enough_to_be_worth_having() {
+        // This used to be the clock plus the process id, which two calls on a
+        // coarse-clock platform returned identically -- and which anything that
+        // knew roughly when the app started could guess. 128 bits from the OS
+        // cannot be guessed, and cannot repeat.
+        let one = secret();
+        let two = secret();
+        assert_ne!(one, two);
+        assert_eq!(one.len(), 32, "128 bits, hex encoded: {one}");
+        assert!(one.chars().all(|c| c.is_ascii_hexdigit()), "{one}");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { CommandPalette } from "@/features/CommandPalette";
 import type { SectionId } from "@/features/settingsIndex";
 import logo from "@/assets/logo.png";
 import { type Release, checkForUpdate, dismiss as dismissUpdate } from "@/core/updates";
+import { applyLanguage, getLanguage, setLanguage } from "@/core/i18n";
+import { useLanguage, useT } from "@/core/useT";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   getCoreLogs, getCoreStatus, isDesktopRuntime, loadProfile, probeCore, probeLatency, runtimeInfo,
@@ -51,15 +53,23 @@ export default function App() {
   /** A published release newer than this build, once one has been noticed. */
   const [update, setUpdate] = useState<Release | null>(null);
 
+  const t = useT();
+  const language = useLanguage();
   const desktop = isDesktopRuntime();
+
+  // The stored preference has to reach the document as well as the components:
+  // direction is a document property, and nothing below can set it.
+  useEffect(() => {
+    applyLanguage(language);
+  }, [language]);
   const effective = useMemo(() => withNormalizedEndpoint(profile), [profile]);
 
   const notify = useCallback((title: string, message: string, error?: boolean) => {
     setToast({ title, message, error });
   }, []);
   const showError = useCallback(
-    (error: unknown) => notify("Action failed", error instanceof Error ? error.message : String(error), true),
-    [notify],
+    (error: unknown) => notify(t("Action failed"), error instanceof Error ? error.message : String(error), true),
+    [notify, t],
   );
 
   useEffect(() => {
@@ -146,8 +156,8 @@ export default function App() {
       if (!resuming || resumedRef.current) return;
       resumedRef.current = true;
       notify(
-        "Restarted with permission",
-        "Full tunnel is ready. Press Connect when you want it.",
+        t("Restarted with permission"),
+        t("Full tunnel is ready. Press Connect when you want it."),
       );
     });
   }, [desktop, notify]);
@@ -367,19 +377,30 @@ export default function App() {
               focus-visible:ring-2 focus-visible:ring-ring"
           >
             <Search className="size-[13px]" />
-            <span>Search settings</span>
+            <span>{t("Search settings")}</span>
             <kbd className="rounded border bg-secondary px-1.5 py-0.5 text-[10px] font-semibold text-foreground">
               Ctrl K
             </kbd>
           </button>
           <Tabs value={mode} onValueChange={(value) => setMode(value as Mode)}>
             <TabsList className="h-8">
-              <TabsTrigger value="simple" className="px-3 py-1 text-[13px]">Simple</TabsTrigger>
-              <TabsTrigger value="advanced" className="px-3 py-1 text-[13px]">Advanced</TabsTrigger>
+              <TabsTrigger value="simple" className="px-3 py-1 text-[13px]">{t("Simple")}</TabsTrigger>
+              <TabsTrigger value="advanced" className="px-3 py-1 text-[13px]">{t("Advanced")}</TabsTrigger>
             </TabsList>
           </Tabs>
-          <Button variant="ghost" size="icon" aria-label="Advanced settings" onClick={() => setMode("advanced")}>
+          <Button variant="ghost" size="icon" aria-label={t("Advanced settings")} onClick={() => setMode("advanced")}>
             <Settings2 />
+          </Button>
+          {/* Two languages, so a toggle rather than a menu: one press, and the
+              label is always the language you would get, not the one you have. */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t("Language")}
+            className="h-8 px-2.5 text-[12px] font-semibold"
+            onClick={() => setLanguage(getLanguage() === "fa" ? "en" : "fa")}
+          >
+            {language === "fa" ? "EN" : "\u0641\u0627"}
           </Button>
         </div>
       </header>
@@ -389,10 +410,10 @@ export default function App() {
           <ArrowUpCircle className="size-4 shrink-0 text-primary" />
           <div className="min-w-0 flex-1">
             <div className="text-[12.5px] font-semibold text-primary">
-              WhiteAesther {update.version} is available
+              WhiteAesther {update.version} {t("is available")}
             </div>
             <div className="truncate text-[11.5px] text-muted-foreground">
-              You are running {appVersion}. Opening this takes you to the download page.
+              {t("You are running")} {appVersion}. {t("Opening this takes you to the download page.")}
             </div>
           </div>
           <Button
@@ -404,12 +425,12 @@ export default function App() {
               void openUrl(update.url).catch(showError);
             }}
           >
-            Get it
+            {t("Get it")}
           </Button>
           <Button
             variant="ghost"
             size="icon"
-            aria-label="Dismiss this update"
+            aria-label={t("Dismiss this update")}
             onClick={() => {
               // Remembered against this version only, so waving one away does
               // not silence the next.
@@ -426,10 +447,10 @@ export default function App() {
         <div className="flex shrink-0 items-center gap-3 border-b border-warning/30 bg-warning/[0.09] px-[18px] py-2.5">
           <ShieldAlert className="size-4 shrink-0 text-warning" />
           <div className="min-w-0 flex-1">
-            <div className="text-[12.5px] font-semibold text-warning">Traffic is blocked, not broken</div>
+            <div className="text-[12.5px] font-semibold text-warning">{t("Traffic is blocked, not broken")}</div>
             <div className="truncate text-[11.5px] text-muted-foreground">
               {snapshot.statusMessage ??
-                "The tunnel is down and your system proxy still points at it, so nothing leaves in the clear."}
+                t("The tunnel is down and your system proxy still points at it, so nothing leaves in the clear.")}
             </div>
           </div>
           <Button
@@ -439,13 +460,13 @@ export default function App() {
             onClick={async () => {
               try {
                 setSnapshot(await stopCore());
-                notify("Connection restored", "Your system proxy has been put back.");
+                notify(t("Connection restored"), t("Your system proxy has been put back."));
               } catch (error) {
                 showError(error);
               }
             }}
           >
-            Restore my connection
+            {t("Restore my connection")}
           </Button>
         </div>
       ) : null}
@@ -551,7 +572,7 @@ export default function App() {
         <div
           role="status"
           className={[
-            "fixed bottom-5 right-5 z-50 flex max-w-[420px] items-start gap-2.5 rounded-lg border bg-popover p-3.5 shadow-lg",
+            "fixed bottom-5 end-5 z-50 flex max-w-[420px] items-start gap-2.5 rounded-lg border bg-popover p-3.5 shadow-lg",
             toast.error ? "border-destructive/50" : "border-border",
           ].join(" ")}
         >
@@ -569,27 +590,27 @@ export default function App() {
 function StateChip({ snapshot }: { snapshot: CoreSnapshot }) {
   if (snapshot.state === "connected")
     return (
-      <span className="ml-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border border-primary/30 bg-primary/[0.13] px-2.5 text-[11.5px] font-semibold text-primary">
+      <span className="ms-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border border-primary/30 bg-primary/[0.13] px-2.5 text-[11.5px] font-semibold text-primary">
         <span className="size-1.5 rounded-full bg-current" />
         Connected
       </span>
     );
   if (snapshot.state === "error")
     return (
-      <span className="ml-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-2.5 text-[11.5px] font-semibold text-destructive">
+      <span className="ms-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border border-destructive/40 bg-destructive/10 px-2.5 text-[11.5px] font-semibold text-destructive">
         <span className="size-1.5 rounded-full bg-current" />
         Stopped
       </span>
     );
   if (!ACTIVE.has(snapshot.state))
     return (
-      <span className="ml-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border bg-muted px-2.5 text-[11.5px] font-semibold text-muted-foreground">
+      <span className="ms-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border bg-muted px-2.5 text-[11.5px] font-semibold text-muted-foreground">
         <span className="size-1.5 rounded-full bg-current" />
         Not connected
       </span>
     );
   return (
-    <span className="ml-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border border-warning/30 bg-warning/[0.13] px-2.5 text-[11.5px] font-semibold text-warning">
+    <span className="ms-1.5 inline-flex h-[22px] items-center gap-1.5 rounded-full border border-warning/30 bg-warning/[0.13] px-2.5 text-[11.5px] font-semibold text-warning">
       <span className="size-1.5 animate-pulse rounded-full bg-current" />
       {snapshot.attempt > 0 ? `Searching · ${snapshot.attempt} of ${snapshot.maxAttempts}` : "Searching"}
     </span>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/cn";
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:size-4 [&>svg~*]:pl-7",
+  "relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:start-4 [&>svg]:top-4 [&>svg]:size-4 [&>svg~*]:ps-7",
   {
     variants: {
       variant: {

--- a/src/core/i18n.test.ts
+++ b/src/core/i18n.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "node:test";
+import { DIRECTION, translate, translatedKeys } from "./i18n.ts";
+
+test("an untranslated key reads as English, not as a broken label", () => {
+  // The whole point of keying on the sentence: a gap in the dictionary is the
+  // interface we already had, not "simple.headline.connected" on screen.
+  assert.equal(translate("fa", "Something nobody has translated yet"), "Something nobody has translated yet");
+  assert.equal(translate("en", "Tap to connect"), "Tap to connect");
+  assert.equal(translate("fa", "Tap to connect"), "برای اتصال بزنید");
+});
+
+test("Persian is right to left and English is not", () => {
+  // Read by applyLanguage to set the document direction; getting this backwards
+  // mirrors the entire interface.
+  assert.equal(DIRECTION.fa, "rtl");
+  assert.equal(DIRECTION.en, "ltr");
+});
+
+test("no translation is left as an empty string", () => {
+  // An empty value would silently blank a label rather than falling back,
+  // because "" is a defined value.
+  for (const key of translatedKeys()) {
+    const value = translate("fa", key);
+    assert.ok(value.trim().length > 0, `empty translation for: ${key}`);
+    assert.notEqual(value, key, `untranslated placeholder left for: ${key}`);
+  }
+});
+
+/** Every .ts/.tsx file under src, so the check cannot miss a new component. */
+function sourceFiles(directory: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) sourceFiles(path, found);
+    else if (/\.tsx?$/.test(entry.name) && !entry.name.endsWith(".test.ts")) found.push(path);
+  }
+  return found;
+}
+
+test("every string marked for translation has one", () => {
+  // The other half of the drift check. Wrapping a string in t() and forgetting
+  // to translate it is silent -- the fallback shows English and looks fine to
+  // anyone reading in English, which is everyone who works on this.
+  const missing = new Set<string>();
+  for (const path of sourceFiles(join(import.meta.dirname, ".."))) {
+    const source = readFileSync(path, "utf8");
+    for (const [, key] of source.matchAll(/\bt\(\s*"((?:[^"\\]|\\.)*)"\s*\)/g)) {
+      // Skip the ones fed a variable at runtime, like t(option.title): those
+      // are checked by the entries they resolve to, which are in the dictionary
+      // as plain strings.
+      if (translate("fa", key) === key) missing.add(key);
+    }
+  }
+  assert.deepEqual([...missing], [], `marked for translation but not translated: ${[...missing].join(" | ")}`);
+});
+
+test("every Persian entry still matches a string in the source", () => {
+  // Keying on the English sentence buys a readable fallback and costs this:
+  // editing the English silently orphans its translation, and the screen goes
+  // back to English with nobody the wiser. This is the check that says so.
+  const source = sourceFiles(join(import.meta.dirname, ".."))
+    .filter((path) => !path.endsWith("i18n.ts"))
+    .map((path) => readFileSync(path, "utf8"))
+    .join("\n");
+
+  const orphans = translatedKeys().filter((key) => !source.includes(key));
+  assert.deepEqual(orphans, [], `translated strings no longer present in the interface: ${orphans.join(" | ")}`);
+});

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -1,0 +1,250 @@
+/**
+ * Persian and English, and the direction each is read in.
+ *
+ * Keyed by the English sentence rather than by an invented identifier
+ * (`simple.headline.connected`). Two reasons. A key missing from the dictionary
+ * falls back to itself, which is a correct English interface rather than a
+ * screen full of dotted identifiers — so a half-finished translation degrades
+ * into the thing we started with. And a translator reads the source sentence at
+ * the point of use instead of chasing a name through two files.
+ *
+ * The cost is that editing an English string silently orphans its translation.
+ * A test walks the source tree and fails on any orphan, which turns that from a
+ * thing someone notices in production into a thing CI says out loud.
+ *
+ * No i18n library. For one language pair, react-i18next is a dependency and a
+ * bundle for interpolation, plurals, namespaces and loaders we do not use —
+ * this is a lookup and a listener.
+ */
+
+export type Language = "en" | "fa";
+
+/** Right to left is a property of the language, so it is decided here. */
+export const DIRECTION: Record<Language, "ltr" | "rtl"> = { en: "ltr", fa: "rtl" };
+
+const STORAGE_KEY = "whiteaesther.language";
+
+/**
+ * Persian for everything a person meets before they ever open Advanced.
+ *
+ * Translated for sense, not word by word. "You're through" is an English idiom
+ * that becomes nonsense carried across literally, and a status line nobody
+ * understands is worse than an English one they can paste into a search.
+ */
+const FA: Record<string, string> = {
+  // -- the shell -------------------------------------------------------------
+  "Search settings": "جستجوی تنظیمات",
+  Simple: "ساده",
+  Advanced: "پیشرفته",
+  "Advanced settings": "تنظیمات پیشرفته",
+  Language: "زبان",
+  "Traffic is blocked, not broken": "ترافیک مسدود شده، نه خراب",
+  "The tunnel is down and your system proxy still points at it, so nothing leaves in the clear.":
+    "تونل قطع است و پروکسی سیستم هنوز به آن اشاره می‌کند، پس هیچ چیزی بدون رمز خارج نمی‌شود.",
+  "Restore my connection": "اتصال من را برگردان",
+  "Restarted with permission": "با دسترسی لازم دوباره اجرا شد",
+  "Full tunnel is ready. Press Connect when you want it.":
+    "تونل کامل آماده است. هر وقت خواستید، اتصال را بزنید.",
+  "Action failed": "انجام نشد",
+
+  // -- the update notice -----------------------------------------------------
+  "Get it": "دریافت",
+  "Dismiss this update": "بستن این اطلاع",
+  "is available": "منتشر شده است",
+  "You are running": "نسخهٔ فعلی شما",
+  "Opening this takes you to the download page.": "با باز کردن این، به صفحهٔ دانلود می‌روید.",
+  "Connection restored": "اتصال برگردانده شد",
+  "Your system proxy has been put back.": "پروکسی سیستم به حالت قبل برگشت.",
+
+  // -- the orb and the headline ---------------------------------------------
+  Connected: "متصل",
+  Searching: "در حال جستجو",
+  Stopped: "متوقف",
+  "Tap to connect": "برای اتصال بزنید",
+  "You're through": "راه باز شد",
+  "Testing paths out": "در حال آزمودن راه‌های خروج",
+  "Nothing got out": "هیچ راهی باز نشد",
+  "Ready when you are": "هر وقت آماده بودید",
+  "Testing paths out of this network.": "راه‌های خروج از این شبکه آزموده می‌شوند.",
+  "Every path was refused.": "همهٔ راه‌ها بسته بودند.",
+  "WhiteAesther finds a route that works here.":
+    "وایت‌آستر خودش مسیری پیدا می‌کند که اینجا کار کند.",
+
+  // -- the buttons -----------------------------------------------------------
+  Connect: "اتصال",
+  Disconnect: "قطع اتصال",
+  Stop: "توقف",
+  "Aether core not found": "هستهٔ Aether پیدا نشد",
+  "Try again with Stealth": "دوباره با حالت مخفی",
+  "Speed test": "تست سرعت",
+  "Speed test failed": "تست سرعت انجام نشد",
+  "Measuring…": "در حال اندازه‌گیری…",
+  "Build a report": "ساخت گزارش",
+  "Open Advanced": "باز کردن پیشرفته",
+
+  // -- what the connection is doing -----------------------------------------
+  Edge: "دروازه",
+  Transport: "پروتکل",
+  Latency: "تأخیر",
+  Uptime: "مدت اتصال",
+  "Round-trip through the tunnel": "زمان رفت و برگشت از تونل",
+  "Measured every 5 s through the tunnel. Last 80 seconds.":
+    "هر ۵ ثانیه از داخل تونل اندازه‌گیری می‌شود. ۸۰ ثانیهٔ اخیر.",
+  "Taking the first measurement…": "در حال گرفتن اولین اندازه…",
+  min: "کمینه",
+  avg: "میانگین",
+  max: "بیشینه",
+  loss: "از دست‌رفته",
+  now: "اکنون",
+
+  // -- what the outside world sees ------------------------------------------
+  "What websites see": "چیزی که سایت‌ها می‌بینند",
+  "Checking…": "در حال بررسی…",
+  "Through your node": "از نود شما",
+  "Through the tunnel": "از تونل",
+  "Not through the tunnel": "خارج از تونل",
+
+  // -- the two switches ------------------------------------------------------
+  "Keep me connected": "اتصال را نگه دار",
+  "Reconnect automatically if the route drops": "اگر مسیر قطع شد، خودکار دوباره وصل شود",
+  "Block traffic if the tunnel drops": "اگر تونل قطع شد، ترافیک را مسدود کن",
+  "Apps fail closed. Disconnect to put the proxy back.":
+    "برنامه‌ها به‌جای نشت، قطع می‌شوند. برای بازگرداندن پروکسی، اتصال را قطع کنید.",
+  "Apps fail closed instead of leaking": "برنامه‌ها به‌جای نشت کردن، قطع می‌شوند",
+
+  // -- while it is searching -------------------------------------------------
+  "What it is trying": "کاری که در حال انجام است",
+  "Device identity ready": "شناسهٔ دستگاه آماده شد",
+  "Retries alternate the two MASQUE transports on their own. Nothing to do.":
+    "تلاش‌های بعدی خودشان بین دو پروتکل MASQUE جابه‌جا می‌شوند. کاری لازم نیست.",
+
+  // -- before it starts ------------------------------------------------------
+  "What will happen": "چه اتفاقی می‌افتد",
+  "The route is found for you. These are the settings it will start from.":
+    "مسیر برای شما پیدا می‌شود. اتصال با این تنظیمات آغاز خواهد شد.",
+  Protocol: "پروتکل",
+  "Search depth": "عمق جستجو",
+  Addresses: "نوع آدرس",
+  "IPv4 and IPv6": "IPv4 و IPv6",
+  Gateway: "دروازه",
+  "found automatically": "خودکار پیدا می‌شود",
+  pinned: "ثابت‌شده",
+  "Local proxy": "پروکسی محلی",
+
+  // -- when nothing worked ---------------------------------------------------
+  "Three things to try, in order": "سه کار را به ترتیب امتحان کنید",
+  Stealth: "مخفی",
+  Aggressive: "تهاجمی",
+  "IPv4 only": "فقط IPv4",
+
+  // -- how far the tunnel reaches -------------------------------------------
+  "This app only": "فقط همین برنامه",
+  "Whole machine": "کل دستگاه",
+  "Full tunnel": "تونل کامل",
+  "Local proxy on {address}": "پروکسی محلی روی {address}",
+  "Sets your system proxy": "پروکسی سیستم را تنظیم می‌کند",
+  "Every app, even ones that ignore proxies":
+    "همهٔ برنامه‌ها، حتی آن‌هایی که پروکسی را نادیده می‌گیرند",
+  "Your system proxy is set, and will be put back when you disconnect.":
+    "پروکسی سیستم تنظیم شده و با قطع اتصال به حالت قبل برمی‌گردد.",
+  "Every app is captured through a network device, including the ones that ignore proxy settings.":
+    "همهٔ برنامه‌ها از طریق یک کارت شبکه گرفته می‌شوند، حتی آن‌هایی که تنظیمات پروکسی را نادیده می‌گیرند.",
+
+  // Split around the address rather than templated whole: Persian puts the
+  // verb last, so one string with a {placeholder} would have pinned English
+  // word order into the translation.
+  "Point apps at": "برنامه‌ها را به آدرس",
+  "to use it.": "وصل کنید",
+
+  "or press": "یا بزنید",
+  "no reply": "بی‌پاسخ",
+  "testing gateways": "در حال آزمودن دروازه‌ها",
+  Attempt: "تلاش",
+  of: "از",
+  "Retries alternate MASQUE H2 and H3 automatically, up to":
+    "تلاش‌های بعدی خودکار بین MASQUE H2 و H3 جابه‌جا می‌شوند، تا",
+  "attempts.": "بار.",
+  "Switch search depth to": "عمق جستجو را بگذارید روی",
+  "quieter probing, slower to connect": "آزمودن کم‌سروصداتر، اتصال کندتر",
+  "Set addresses to": "نوع آدرس را بگذارید روی",
+  "if this network handles IPv6 badly": "اگر این شبکه با IPv6 مشکل دارد",
+  "Turn obfuscation up to": "مبهم‌سازی را ببرید روی",
+
+  // The stored profile values the Idle card prints back. Translated because
+  // they are shown to the reader, not because anything matches on them.
+  turbo: "پرسرعت",
+  balanced: "متعادل",
+  thorough: "دقیق",
+  stealth: "مخفی",
+  ironclad: "حداکثری",
+
+  // -- the command palette ---------------------------------------------------
+  "Search settings — try dns, kill switch, scan…":
+    "جستجوی تنظیمات — مثلاً dns یا kill switch یا scan…",
+  "Nothing matches": "چیزی پیدا نشد",
+};
+
+const DICTIONARIES: Record<Language, Record<string, string>> = { en: {}, fa: FA };
+
+/**
+ * The English sentence, or its translation when one exists.
+ *
+ * An untranslated key returns itself, so a gap reads as English rather than as
+ * a broken label.
+ */
+export function translate(language: Language, key: string): string {
+  const value = DICTIONARIES[language][key];
+  return value === undefined ? key : value;
+}
+
+/** Every key that has been given a Persian translation. */
+export function translatedKeys(): string[] {
+  return Object.keys(FA);
+}
+
+// ------------------------------------------------------- the live preference
+
+function load(): Language {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored === "fa" || stored === "en") return stored;
+    // Nothing chosen yet: follow the machine. Someone whose computer is already
+    // in Persian should not have to find a menu to be spoken to in Persian.
+    return window.navigator.language?.toLowerCase().startsWith("fa") ? "fa" : "en";
+  } catch {
+    return "en";
+  }
+}
+
+let current: Language = typeof window === "undefined" ? "en" : load();
+const listeners = new Set<() => void>();
+
+export function getLanguage(): Language {
+  return current;
+}
+
+/** Applies the language to the document, so CSS and the browser agree with us. */
+export function applyLanguage(language: Language): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.lang = language;
+  document.documentElement.dir = DIRECTION[language];
+}
+
+export function setLanguage(next: Language): void {
+  if (next === current) return;
+  current = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next);
+  } catch {
+    // A preference that cannot be stored still applies to this session.
+  }
+  applyLanguage(next);
+  for (const listener of listeners) listener();
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/core/report.test.ts
+++ b/src/core/report.test.ts
@@ -10,7 +10,7 @@ function event(message: string, timestamp = 0): CoreLogEvent {
 function report(overrides: Partial<Parameters<typeof buildReport>[0]> = {}): string {
   return buildReport({
     appVersion: "1.0.0",
-    engineVersion: "aether 1.7.0",
+    engineVersion: "aether 1.8.0",
     system: "windows · x86_64",
     snapshot: IDLE_SNAPSHOT,
     profile: DEFAULT_PROFILE,
@@ -56,9 +56,9 @@ test("redaction leaves lines that only look like addresses alone", () => {
 });
 
 test("the version header is never redacted", () => {
-  const text = report({ appVersion: "1.0.0.0", engineVersion: "aether 1.7.0" });
+  const text = report({ appVersion: "1.0.0.0", engineVersion: "aether 1.8.0" });
   assert.ok(text.includes("app 1.0.0.0"), text);
-  assert.ok(text.includes("engine aether 1.7.0"), text);
+  assert.ok(text.includes("engine aether 1.8.0"), text);
 });
 
 test("Zero Trust credentials and the pinned endpoint never reach the report", () => {

--- a/src/core/useT.ts
+++ b/src/core/useT.ts
@@ -1,0 +1,19 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { type Language, getLanguage, subscribe, translate } from "./i18n";
+
+/**
+ * The current language, kept in step across every component that asks.
+ *
+ * A module-level store rather than a context provider: the language is one
+ * value for the whole window, and threading a provider through would add a
+ * wrapper to every test that renders a component in isolation.
+ */
+export function useLanguage(): Language {
+  return useSyncExternalStore(subscribe, getLanguage, () => "en" as const);
+}
+
+/** `t("Tap to connect")` — the English sentence in, the reader's language out. */
+export function useT(): (key: string) => string {
+  const language = useLanguage();
+  return useCallback((key: string) => translate(language, key), [language]);
+}

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -103,7 +103,7 @@ export function Advanced(props: AdvancedProps) {
                 aria-current={section === id}
                 onClick={() => setSection(id)}
                 className={[
-                  "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13.5px] transition-colors",
+                  "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-start text-[13.5px] transition-colors",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   section === id
                     ? "bg-primary/10 font-semibold text-primary"
@@ -264,7 +264,7 @@ function Licences() {
             <span className="font-mono text-[12.5px] text-muted-foreground">AGPL-3.0</span>
           </Row>
           <Separator />
-          <Row title="Aether" help="The connection engine, shipped as a binary and run by this app. Aether 1.7.0">
+          <Row title="Aether" help="The connection engine, shipped as a binary and run by this app. Aether 1.8.0">
             <span className="font-mono text-[12.5px] text-muted-foreground">AGPL-3.0</span>
           </Row>
           <Separator />
@@ -336,7 +336,7 @@ function Routes({ profile, onChange }: AdvancedProps) {
                   set({ protocol: option.protocol, ...(option.transport ? { masqueTransport: option.transport } : {}) })
                 }
                 className={[
-                  "flex flex-col gap-1 rounded-lg border p-3 text-left transition-colors",
+                  "flex flex-col gap-1 rounded-lg border p-3 text-start transition-colors",
                   "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   on ? "border-primary bg-primary/10 ring-1 ring-primary" : "border-border hover:bg-accent",
                 ].join(" ")}

--- a/src/features/Chain.tsx
+++ b/src/features/Chain.tsx
@@ -394,7 +394,7 @@ function Nodes({
                   <span
                     title={node.unusable ?? undefined}
                     className={[
-                      "tabular shrink-0 text-right font-mono text-[12.5px]",
+                      "tabular shrink-0 text-end font-mono text-[12.5px]",
                       node.unusable ? "w-[132px] text-amber-500/90" : "w-[68px]",
                       node.delay == null ? "text-muted-foreground" : "text-primary",
                       node.unusable ? "text-amber-500/90" : "",

--- a/src/features/CommandPalette.tsx
+++ b/src/features/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useT } from "@/core/useT";
 import { CornerDownLeft, Search } from "lucide-react";
 import { SETTINGS, type SectionId, searchSettings } from "./settingsIndex";
 
@@ -18,6 +19,7 @@ export function CommandPalette({
   onClose: () => void;
   onPick: (section: SectionId) => void;
 }) {
+  const t = useT();
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const input = useRef<HTMLInputElement>(null);
@@ -80,7 +82,7 @@ export function CommandPalette({
                 choose(active);
               }
             }}
-            placeholder="Search settings — try dns, kill switch, scan…"
+            placeholder={t("Search settings — try dns, kill switch, scan…")}
             className="h-12 w-full bg-transparent text-[14px] outline-none placeholder:text-muted-foreground"
           />
         </div>
@@ -94,7 +96,7 @@ export function CommandPalette({
                   onMouseEnter={() => setActive(index)}
                   onClick={() => choose(index)}
                   className={[
-                    "flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left",
+                    "flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-start",
                     index === active ? "bg-primary/[0.11] text-foreground" : "text-muted-foreground",
                   ].join(" ")}
                 >
@@ -115,7 +117,7 @@ export function CommandPalette({
           </ul>
         ) : (
           <p className="px-4 py-6 text-center text-[13px] text-muted-foreground">
-            Nothing matches “{query}”.
+            {t("Nothing matches")} “{query}”.
           </p>
         )}
 

--- a/src/features/Scanner.tsx
+++ b/src/features/Scanner.tsx
@@ -188,7 +188,7 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
                         onToast("Endpoint pinned", `${candidate.peer} — set Endpoint mode to use it.`);
                       }}
                       className={[
-                        "flex w-full items-center justify-between gap-3 border-b px-3.5 py-2.5 text-left transition-colors last:border-b-0",
+                        "flex w-full items-center justify-between gap-3 border-b px-3.5 py-2.5 text-start transition-colors last:border-b-0",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
                         chosen ? "bg-primary/10" : "hover:bg-accent",
                       ].join(" ")}
@@ -202,7 +202,7 @@ export function Scanner({ profile, snapshot, onPick, onToast }: ScannerProps) {
                       </div>
                       <div className="flex shrink-0 items-center gap-2.5">
                         <Latency ms={candidate.rttMs} best={candidates[0].rttMs} />
-                        <span className="tabular w-16 text-right font-mono text-[13px]">
+                        <span className="tabular w-16 text-end font-mono text-[13px]">
                           {candidate.rttMs} ms
                         </span>
                       </div>

--- a/src/features/Simple.tsx
+++ b/src/features/Simple.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Switch } from "@/components/ui/switch";
 import { type ExitInfo, chainStatus, exitInfo, speedTest } from "@/core/api";
+import { useT } from "@/core/useT";
 import { ConnectOrb, type OrbState } from "./ConnectOrb";
 import { Sparkline } from "./Sparkline";
 import { type Sample, summarise } from "./latency";
@@ -63,13 +64,20 @@ function useCarryAddress(snapshot: CoreSnapshot): string {
 
 export function Simple(props: SimpleProps) {
   const { snapshot, probe } = props;
+  const t = useT();
   const carryAddress = useCarryAddress(snapshot);
   const busy = BUSY.has(snapshot.state);
   const failed = snapshot.state === "error";
   const live = snapshot.state === "connected";
 
   const orbState: OrbState = live ? "live" : busy ? "working" : failed ? "failed" : "idle";
-  const caption = live ? "Connected" : busy ? "Searching" : failed ? "Stopped" : "Tap to connect";
+  const caption = live
+    ? t("Connected")
+    : busy
+      ? t("Searching")
+      : failed
+        ? t("Stopped")
+        : t("Tap to connect");
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -109,25 +117,37 @@ export function Simple(props: SimpleProps) {
 // ------------------------------------------------------------------ the panel
 
 function Headline({ snapshot, carry, probe, carryAddress }: SimpleProps & { carryAddress: string }) {
+  const t = useT();
   const live = snapshot.state === "connected";
   const busy = BUSY.has(snapshot.state);
   const failed = snapshot.state === "error";
 
-  const title = live ? "You're through" : busy ? "Testing paths out" : failed ? "Nothing got out" : "Ready when you are";
-  const detail = live
-    ? `${transportName(snapshot.transport)} · ${describeCarry(carry, carryAddress)}`
+  const title = live
+    ? t("You're through")
     : busy
-      ? (snapshot.statusMessage ?? "Testing paths out of this network.")
+      ? t("Testing paths out")
       : failed
-        ? (snapshot.lastError ?? "Every path was refused.")
+        ? t("Nothing got out")
+        : t("Ready when you are");
+  const detail = live
+    ? `${transportName(snapshot.transport)} · ${describeCarry(carry, carryAddress, t)}`
+    : busy
+      ? (snapshot.statusMessage ?? t("Testing paths out of this network."))
+      : failed
+        ? (snapshot.lastError ?? t("Every path was refused."))
         : probe.available
-          ? "WhiteAesther finds a route that works here."
+          ? t("WhiteAesther finds a route that works here.")
           : probe.message;
 
   return (
     <div className="mt-4 max-w-[320px] text-center">
       <div className="text-[23px] font-bold leading-tight tracking-tight">{title}</div>
-      <p className="mt-1.5 line-clamp-3 text-[13px] leading-snug text-muted-foreground">{detail}</p>
+      {/* Engine messages and errors arrive in English whatever the reader
+          chose, and English punctuation in a right-to-left paragraph lands at
+          the wrong end. dir="auto" reads the direction off the text itself. */}
+      <p dir="auto" className="mt-1.5 line-clamp-3 text-[13px] leading-snug text-muted-foreground">
+        {detail}
+      </p>
     </div>
   );
 }
@@ -139,6 +159,7 @@ function Headline({ snapshot, carry, probe, carryAddress }: SimpleProps & { carr
  * would make both of them read slow.
  */
 function SpeedTest({ onToast }: Pick<SimpleProps, "onToast">) {
+  const t = useT();
   const [busy, setBusy] = useState(false);
   const [result, setResult] = useState<number | null>(null);
 
@@ -152,22 +173,23 @@ function SpeedTest({ onToast }: Pick<SimpleProps, "onToast">) {
         try {
           const { mbps, seconds } = await speedTest();
           setResult(mbps);
-          onToast("Speed test", `${mbps.toFixed(1)} Mbps down, over ${seconds.toFixed(1)} s.`);
+          onToast(t("Speed test"), `${mbps.toFixed(1)} Mbps down, over ${seconds.toFixed(1)} s.`);
         } catch (error) {
           setResult(null);
-          onToast("Speed test failed", error instanceof Error ? error.message : String(error), true);
+          onToast(t("Speed test failed"), error instanceof Error ? error.message : String(error), true);
         } finally {
           setBusy(false);
         }
       }}
     >
       <Gauge className={busy ? "animate-spin" : undefined} />
-      {busy ? "Measuring…" : result == null ? "Speed test" : `${result.toFixed(1)} Mbps`}
+      {busy ? t("Measuring…") : result == null ? t("Speed test") : `${result.toFixed(1)} Mbps`}
     </Button>
   );
 }
 
 function Actions({ snapshot, probe, onToggle, onRetryStealth, onToast }: SimpleProps) {
+  const t = useT();
   const live = snapshot.state === "connected";
   const busy = BUSY.has(snapshot.state);
   const failed = snapshot.state === "error";
@@ -175,7 +197,7 @@ function Actions({ snapshot, probe, onToggle, onRetryStealth, onToast }: SimpleP
   if (busy)
     return (
       <Button variant="outline" className="mt-5 h-9 px-7" onClick={onToggle}>
-        Stop
+        {t("Stop")}
       </Button>
     );
   if (live)
@@ -183,7 +205,7 @@ function Actions({ snapshot, probe, onToggle, onRetryStealth, onToast }: SimpleP
       <div className="mt-5 flex gap-2.5">
         <Button variant="outline" className="h-9 px-5" onClick={onToggle}>
           <Power />
-          Disconnect
+          {t("Disconnect")}
         </Button>
         <SpeedTest onToast={onToast} />
       </div>
@@ -192,17 +214,17 @@ function Actions({ snapshot, probe, onToggle, onRetryStealth, onToast }: SimpleP
     return (
       <Button className="mt-5 h-9 px-5" onClick={onRetryStealth}>
         <Zap />
-        Try again with Stealth
+        {t("Try again with Stealth")}
       </Button>
     );
   return (
     <>
       <Button size="lg" className="mt-5 h-11 px-11 text-[14.5px]" onClick={onToggle} disabled={!probe.available}>
         <Zap className="size-[17px]" />
-        {probe.available ? "Connect" : "Aether core not found"}
+        {probe.available ? t("Connect") : t("Aether core not found")}
       </Button>
       <p className="mt-2.5 text-[11px] text-muted-foreground">
-        or press <Kbd>Ctrl</Kbd> <Kbd>Enter</Kbd>
+        {t("or press")} <Kbd>Ctrl</Kbd> <Kbd>Enter</Kbd>
       </p>
     </>
   );
@@ -225,32 +247,33 @@ function Connected({
   onProfile,
   carryAddress,
 }: SimpleProps & { carryAddress: string }) {
+  const t = useT();
   const summary = summarise(latency);
   const shown = summary.last ?? snapshot.latencyMs;
 
   return (
     <>
       <div className="grid grid-cols-4 gap-2.5">
-        <Tile label="Edge" value={snapshot.endpoint ?? "—"} />
-        <Tile label="Transport" value={transportName(snapshot.transport)} plain />
-        <Tile label="Latency" value={shown == null ? "—" : `${Math.round(shown)} ms`} good />
+        <Tile label={t("Edge")} value={snapshot.endpoint ?? "—"} />
+        <Tile label={t("Transport")} value={transportName(snapshot.transport)} plain />
+        <Tile label={t("Latency")} value={shown == null ? "—" : `${Math.round(shown)} ms`} good />
         <Uptime startedAt={snapshot.startedAt} />
       </div>
 
       <Card className="surface flex flex-1 flex-col p-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-[13px] font-semibold">Round-trip through the tunnel</h3>
+            <h3 className="text-[13px] font-semibold">{t("Round-trip through the tunnel")}</h3>
             <p className="mt-0.5 text-[11.5px] text-muted-foreground">
-              Measured every 5 s through the tunnel. Last 80 seconds.
+              {t("Measured every 5 s through the tunnel. Last 80 seconds.")}
             </p>
           </div>
-          <div className="flex shrink-0 gap-3.5 text-right">
-            <Figure label="min" value={summary.min == null ? "—" : Math.round(summary.min)} />
-            <Figure label="avg" value={summary.avg == null ? "—" : Math.round(summary.avg)} />
-            <Figure label="max" value={summary.max == null ? "—" : Math.round(summary.max)} />
+          <div className="flex shrink-0 gap-3.5 text-end">
+            <Figure label={t("min")} value={summary.min == null ? "—" : Math.round(summary.min)} />
+            <Figure label={t("avg")} value={summary.avg == null ? "—" : Math.round(summary.avg)} />
+            <Figure label={t("max")} value={summary.max == null ? "—" : Math.round(summary.max)} />
             <Figure
-              label="loss"
+              label={t("loss")}
               value={`${Math.round(summary.loss * 100)}%`}
               tone={summary.loss > 0 ? "bad" : "good"}
             />
@@ -261,16 +284,21 @@ function Connected({
             <Sparkline history={latency} height={280} />
           ) : (
             <div className="grid h-full w-full place-items-center text-[12.5px] text-muted-foreground">
-              Taking the first measurement…
+              {t("Taking the first measurement…")}
             </div>
           )}
         </div>
-        <div className="mt-1.5 flex justify-between font-mono text-[10.5px] text-muted-foreground">
+        {/* The sparkline draws oldest to newest left to right regardless of
+            language, so its axis must not mirror with the rest of the page. */}
+        <div
+          dir="ltr"
+          className="mt-1.5 flex justify-between font-mono text-[10.5px] text-muted-foreground"
+        >
           <span>-80s</span>
           <span>-60s</span>
           <span>-40s</span>
           <span>-20s</span>
-          <span>now</span>
+          <span>{t("now")}</span>
         </div>
       </Card>
 
@@ -279,19 +307,19 @@ function Connected({
       <Card className="surface flex items-center gap-3.5 p-3">
         <Toggle
           icon={Plug}
-          label="Keep me connected"
-          help="Reconnect automatically if the route drops"
+          label={t("Keep me connected")}
+          help={t("Reconnect automatically if the route drops")}
           checked={profile.autoReconnect}
           onChange={(autoReconnect) => onProfile({ autoReconnect })}
         />
         <div className="h-8 w-px shrink-0 bg-border" />
         <Toggle
           icon={Lock}
-          label="Block traffic if the tunnel drops"
+          label={t("Block traffic if the tunnel drops")}
           help={
             profile.killSwitch
-              ? "Apps fail closed. Disconnect to put the proxy back."
-              : "Apps fail closed instead of leaking"
+              ? t("Apps fail closed. Disconnect to put the proxy back.")
+              : t("Apps fail closed instead of leaking")
           }
           checked={profile.killSwitch}
           onChange={(killSwitch) => onProfile({ killSwitch })}
@@ -314,6 +342,7 @@ const EXIT_TRIES = 4;
 const RETRY_AFTER_MS = 2_500;
 
 function ExitCard({ carryAddress }: { carryAddress: string }) {
+  const t = useT();
   const [info, setInfo] = useState<ExitInfo | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -362,13 +391,13 @@ function ExitCard({ carryAddress }: { carryAddress: string }) {
         <Globe className="size-[17px]" />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="text-[12.5px] font-semibold">What websites see</div>
-        <div className="mt-0.5 truncate text-[11.5px] text-muted-foreground">
+        <div className="text-[12.5px] font-semibold">{t("What websites see")}</div>
+        <div dir="auto" className="mt-0.5 truncate text-[11.5px] text-muted-foreground">
           {error
             ? error
             : info
               ? `${info.ip} · ${info.country}${info.colo ? ` · via ${info.colo}` : ""}`
-              : "Checking…"}
+              : t("Checking…")}
         </div>
       </div>
       {info ? (
@@ -380,7 +409,11 @@ function ExitCard({ carryAddress }: { carryAddress: string }) {
               : "border-warning/40 bg-warning/[0.11] text-warning",
           ].join(" ")}
         >
-          {info.chained ? "Through your node" : info.warp ? "Through the tunnel" : "Not through the tunnel"}
+          {info.chained
+            ? t("Through your node")
+            : info.warp
+              ? t("Through the tunnel")
+              : t("Not through the tunnel")}
         </span>
       ) : null}
     </Card>
@@ -420,34 +453,35 @@ function Toggle({
 }
 
 function Searching({ snapshot }: SimpleProps) {
+  const t = useT();
   const attempt = snapshot.attempt;
   return (
     <Card className="surface flex flex-1 flex-col p-4">
-      <h3 className="text-[13px] font-semibold">What it is trying</h3>
+      <h3 className="text-[13px] font-semibold">{t("What it is trying")}</h3>
       <Progress className="mt-3" value={attempt > 0 ? Math.min(90, attempt * 12) : 25} />
       <div className="mt-4 flex flex-col">
-        <Step done icon={<Check className="size-3.5" />} label="Device identity ready" />
+        <Step done icon={<Check className="size-3.5" />} label={t("Device identity ready")} />
         {attempt > 0 ? (
           <Step
             icon={<X className="size-3.5" />}
-            label={`${snapshot.transport === "masque-h2" ? "MASQUE H3" : "MASQUE H2"} — no reply`}
+            label={`${snapshot.transport === "masque-h2" ? "MASQUE H3" : "MASQUE H2"} — ${t("no reply")}`}
           />
         ) : null}
         <Step
           active
           icon={<Radar className="size-3.5" />}
-          label={`${transportName(snapshot.transport)} — testing gateways`}
+          label={`${transportName(snapshot.transport)} — ${t("testing gateways")}`}
         />
       </div>
       <div className="mt-4 flex items-center gap-2.5 rounded-lg border border-primary/25 bg-primary/[0.06] p-2.5">
         <Search className="size-3.5 shrink-0 text-primary" />
         <span className="text-[12px] text-muted-foreground">
-          Retries alternate the two MASQUE transports on their own. Nothing to do.
+          {t("Retries alternate the two MASQUE transports on their own. Nothing to do.")}
         </span>
       </div>
       {attempt > 0 ? (
         <p className="mt-auto pt-3 text-[12px] text-muted-foreground">
-          Attempt {attempt} of {snapshot.maxAttempts}.
+          {t("Attempt")} {attempt} {t("of")} {snapshot.maxAttempts}.
         </p>
       ) : null}
     </Card>
@@ -481,24 +515,31 @@ function Step({
 }
 
 function Idle({ snapshot, profile }: SimpleProps) {
+  const t = useT();
   return (
     <Card className="surface flex flex-1 flex-col p-4">
-      <h3 className="text-[13px] font-semibold">What will happen</h3>
+      <h3 className="text-[13px] font-semibold">{t("What will happen")}</h3>
       <p className="mt-0.5 text-[11.5px] text-muted-foreground">
-        The route is found for you. These are the settings it will start from.
+        {t("The route is found for you. These are the settings it will start from.")}
       </p>
       <div className="mt-3.5 flex flex-col">
-        <Fact label="Protocol" value={transportName(snapshot.transport ?? "masque-h2")} />
-        <Fact label="Search depth" value={profile.scanMode} />
-        <Fact label="Addresses" value={profile.ipFamily === "both" ? "IPv4 and IPv6" : profile.ipFamily} />
+        <Fact label={t("Protocol")} value={transportName(snapshot.transport ?? "masque-h2")} />
+        <Fact label={t("Search depth")} value={t(profile.scanMode)} />
         <Fact
-          label="Gateway"
-          value={profile.endpointMode === "automatic" ? "found automatically" : (profile.peer ?? "pinned")}
+          label={t("Addresses")}
+          value={profile.ipFamily === "both" ? t("IPv4 and IPv6") : profile.ipFamily}
         />
-        <Fact label="Local proxy" value={profile.socksAddress} />
+        <Fact
+          label={t("Gateway")}
+          value={
+            profile.endpointMode === "automatic" ? t("found automatically") : (profile.peer ?? t("pinned"))
+          }
+        />
+        <Fact label={t("Local proxy")} value={profile.socksAddress} />
       </div>
       <p className="mt-auto pt-3 text-[12px] text-muted-foreground">
-        Retries alternate MASQUE H2 and H3 automatically, up to {snapshot.maxAttempts} attempts.
+        {t("Retries alternate MASQUE H2 and H3 automatically, up to")} {snapshot.maxAttempts}{" "}
+        {t("attempts.")}
       </p>
     </Card>
   );
@@ -514,24 +555,25 @@ function Fact({ label, value }: { label: string; value: string }) {
 }
 
 function Failed({ onReport, onAdvanced }: SimpleProps) {
+  const t = useT();
   return (
     <Card className="surface flex flex-1 flex-col p-4">
       <Alert variant="warning">
         <ShieldAlert />
-        <AlertTitle>Three things to try, in order</AlertTitle>
+        <AlertTitle>{t("Three things to try, in order")}</AlertTitle>
         <AlertDescription>
           <div className="mt-1.5 flex flex-col gap-1">
             <span>
-              <b className="text-foreground">1</b>&nbsp; Switch search depth to{" "}
-              <b className="text-foreground">Stealth</b> — quieter probing, slower to connect
+              <b className="text-foreground">1</b>&nbsp; {t("Switch search depth to")}{" "}
+              <b className="text-foreground">{t("Stealth")}</b> — {t("quieter probing, slower to connect")}
             </span>
             <span>
-              <b className="text-foreground">2</b>&nbsp; Set addresses to{" "}
-              <b className="text-foreground">IPv4 only</b> if this network handles IPv6 badly
+              <b className="text-foreground">2</b>&nbsp; {t("Set addresses to")}{" "}
+              <b className="text-foreground">{t("IPv4 only")}</b> {t("if this network handles IPv6 badly")}
             </span>
             <span>
-              <b className="text-foreground">3</b>&nbsp; Turn obfuscation up to{" "}
-              <b className="text-foreground">Aggressive</b>
+              <b className="text-foreground">3</b>&nbsp; {t("Turn obfuscation up to")}{" "}
+              <b className="text-foreground">{t("Aggressive")}</b>
             </span>
           </div>
         </AlertDescription>
@@ -539,10 +581,10 @@ function Failed({ onReport, onAdvanced }: SimpleProps) {
       <div className="mt-auto flex gap-2 pt-4">
         <Button variant="outline" className="flex-1" onClick={onReport}>
           <FileText />
-          Build a report
+          {t("Build a report")}
         </Button>
         <Button variant="ghost" onClick={onAdvanced}>
-          Open Advanced
+          {t("Open Advanced")}
         </Button>
       </div>
     </Card>
@@ -600,6 +642,7 @@ function CarryPicker({
   onCarry,
   carryAddress,
 }: Pick<SimpleProps, "carry" | "onCarry"> & { carryAddress: string }) {
+  const t = useT();
   return (
     <div className="grid grid-cols-3 gap-2.5">
       {CARRY_OPTIONS.map((option) => {
@@ -614,7 +657,7 @@ function CarryPicker({
             onClick={() => onCarry(option.id)}
             title={option.disabled ? option.disabledReason : undefined}
             className={[
-              "surface flex items-start gap-3 rounded-xl border p-3.5 text-left transition-colors",
+              "surface flex items-start gap-3 rounded-xl border p-3.5 text-start transition-colors",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               option.disabled
                 ? "cursor-not-allowed opacity-40"
@@ -633,11 +676,13 @@ function CarryPicker({
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
-                <span className="text-[13.5px] font-semibold">{option.title}</span>
+                <span className="text-[13.5px] font-semibold">{t(option.title)}</span>
                 {active ? <Check className="size-3.5 text-primary" /> : null}
               </div>
               <div className="mt-0.5 text-[11.5px] leading-snug text-muted-foreground">
-                {option.disabled ? option.disabledReason : carryDetail(option, carryAddress)}
+                {option.disabled
+                  ? option.disabledReason
+                  : carryDetail(option, carryAddress, t)}
               </div>
             </div>
           </button>

--- a/src/features/carry.ts
+++ b/src/features/carry.ts
@@ -62,15 +62,26 @@ export function carryFromProfile(systemProxy: boolean, fullTunnel = false): Carr
  * tunnel's otherwise — never the configured SOCKS port on its own, which stops
  * being the right answer the moment a hop is added in front of it.
  */
-export function describeCarry(mode: CarryMode, carryAddress: string): string {
-  if (mode === "system") return "Your system proxy is set, and will be put back when you disconnect.";
+export function describeCarry(
+  mode: CarryMode,
+  carryAddress: string,
+  t: (key: string) => string = (key) => key,
+): string {
+  if (mode === "system") return t("Your system proxy is set, and will be put back when you disconnect.");
   if (mode === "tun") {
-    return "Every app is captured through a network device, including the ones that ignore proxy settings.";
+    return t("Every app is captured through a network device, including the ones that ignore proxy settings.");
   }
-  return `Point apps at ${carryAddress} to use it.`;
+  // The address is the sentence's object, so the two halves are translated
+  // around it rather than as one string with a placeholder -- Persian puts the
+  // verb last, and a single template would have pinned English word order.
+  return `${t("Point apps at")} ${carryAddress} ${t("to use it.")}`;
 }
 
 /** Fills the option's address placeholder, if it has one. */
-export function carryDetail(option: CarryOption, carryAddress: string): string {
-  return option.detail.replace("{address}", carryAddress);
+export function carryDetail(
+  option: CarryOption,
+  carryAddress: string,
+  t: (key: string) => string = (key) => key,
+): string {
+  return t(option.detail).replace("{address}", carryAddress);
 }

--- a/src/features/panels.tsx
+++ b/src/features/panels.tsx
@@ -116,7 +116,7 @@ export function NumberField({
           type="number"
           min={min}
           max={max}
-          className="tabular pr-12 font-mono"
+          className="tabular pe-12 font-mono"
           value={value}
           onChange={(event) => {
             const next = Number(event.target.value);
@@ -124,7 +124,7 @@ export function NumberField({
           }}
         />
         {unit ? (
-          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
+          <span className="pointer-events-none absolute end-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
             {unit}
           </span>
         ) : null}

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,14 @@
     font-feature-settings: "cv11", "ss01";
   }
 
+  /* Persian in the default UI font is legible but poorly shaped. These are the
+     faces an Iranian machine is likely to already have, in the order a Persian
+     reader would prefer them; the system font stays as the last resort, so
+     nothing is downloaded and nothing breaks where none are installed. */
+  :root[lang="fa"] body {
+    font-family: Vazirmatn, "IRANSans", "IRANYekan", Tahoma, system-ui, sans-serif;
+  }
+
   /* The window is a fixed-size desktop shell, not a scrolling document. */
   html,
   body,


### PR DESCRIPTION
Two things in one release: the interface speaks Persian, and the engine moves to Aether 1.8.0.

## Persian, right to left

Everything a person meets before they open Advanced — the connect screen, the status lines, the three tunnel modes, the failure advice, the command palette. A one-press toggle in the header, and a machine already set to Persian gets Persian without being asked.

**Keyed on the English sentence**, not an invented identifier:

```ts
t("Tap to connect")   // → "برای اتصال بزنید"
```

A key missing from the dictionary falls back to itself, so a half-finished translation degrades into the interface we already had rather than into a screen of `simple.headline.connected`.

The cost is that editing an English string silently orphans its translation. Two tests walk the source tree so that cannot happen quietly:

| test | catches |
|---|---|
| every Persian entry still matches a string in the source | a translation whose English was edited away |
| every string marked for translation has one | a `t()` wrapper that never got translated |

Both caught real mistakes while this was being written — three keys where the English was guessed rather than copied, and fourteen wrapped strings whose translations were dropped in a rewrite.

**No i18n dependency.** For one language pair, `react-i18next` is a bundle for interpolation, plurals, namespaces and loaders none of which are used. This is a lookup and a listener.

### Three things RTL needed beyond the words

- **Seventeen directional classes became logical ones** (`ml-` → `ms-`, `text-left` → `text-start`), so one class serves both languages instead of a conditional in every component.
- **The latency chart's axis is pinned left-to-right.** Time runs one way whatever the language does; mirroring it would have put "now" at the oldest end while the sparkline still drew oldest-to-newest.
- **Engine text reads its own direction.** Status and error messages arrive in English whatever the reader chose, and English punctuation in an RTL paragraph lands at the wrong end — visible as `‏.Open the desktop app to control Aether` until `dir="auto"` was applied.

**Numbers stay Latin.** Persian digits belong in prose, and this app spends most of its time showing addresses, ports and round-trip times. An IP in Persian digits is a worse IP.

## Aether 1.8.0

Tag `v1.8.0-whiteaesther.1`. Four upstream fixes land on things this client actually does:

- **An upstream SOCKS5 proxy could answer the greeting with "no authentication"** and the engine would carry on without ever sending the username and password it was configured with. That is the setting shipped in 1.6.0.
- **A WireGuard tunnel stayed down after any task panicked**, because the shared lock was left poisoned. WireGuard is the default here.
- **Gool crashed** when either half stopped, and never came back.
- **ring 0.16 is gone**, and RUSTSEC-2025-0009 with it.

Upstream touched both `lib.rs` and `prober.rs` — the two files the fork patches — so the rebase was the thing worth checking. All three commits applied clean, `WIREGUARD_MTU = 1340` survived, and the scanning modes still answer:

```
aether 1.8.0
{"ok":true,"results":[{"peer":"162.159.198.1:443","rttMs":1284}, ...]}
```

---

112 Rust tests, 44 frontend tests, clippy clean. Both languages verified in a running build: no horizontal overflow in RTL, English unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)