### PR TITLE
Carry the traffic with Psiphon and Tor, not only with Aether

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -197,6 +197,7 @@ jobs:
           libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev
           libssl-dev libayatana-appindicator3-dev librsvg2-dev patchelf
           cmake ninja-build perl pkg-config clang rpm xdg-utils
+          libevent-2.1-7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -275,18 +276,18 @@ jobs:
 
       - name: Build the desktop package
         env:
-          # linuxdeploy strips every ELF it finds while assembling an AppImage,
-          # and the Tor carrier puts two it did not build -- tor and lyrebird --
-          # in the resource directory. It failed there with no diagnostic of its
-          # own; the Linux arm64 job, which ships no Tor because upstream
-          # publishes no bundle for it, went green on the same commit.
-          #
-          # Stripping them buys nothing anyway: they arrive already stripped
-          # from a release build we verified by digest, and modifying them would
-          # invalidate exactly the thing that check established.
+          # Not what fixed the AppImage build -- that was libevent, installed
+          # above -- but kept on its own merits. linuxdeploy strips every ELF it
+          # assembles, and tor and lyrebird arrive already stripped from a
+          # release build checked against the digest Tor publishes for it.
+          # Modifying them afterwards invalidates precisely what that check
+          # established, for no gain.
           #
           # Read only by the AppImage bundler; harmless everywhere else.
           NO_STRIP: "true"
+        # --verbose because linuxdeploy failed silently once and cost a round
+        # trip. The line that mattered was one ERROR in four hundred lines of
+        # deployment chatter, and it named the missing library exactly.
         run: pnpm tauri build --verbose --bundles "${{ matrix.bundles }}"
 
       - name: Upload desktop packages

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -247,6 +247,29 @@ jobs:
       - name: Stage the chain engine
         run: pnpm stage:chain
 
+      # Psiphon is the one carrier that cannot be downloaded: upstream publishes
+      # library archives and no console client, so it is compiled here from a
+      # pinned revision. CGO_ENABLED=0 in the staging script means the toolchain
+      # alone is enough and every target cross-compiles.
+      - name: Install Go for the Psiphon carrier
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          # Keyed on the pinned revision rather than a lockfile: the checkout is
+          # made by the staging script and there is no go.sum in this repo.
+          cache: false
+
+      - name: Stage the Psiphon carrier
+        run: pnpm stage:psiphon
+
+      # Downloaded and checked against the digest Tor publishes for it, so the
+      # check is against their number rather than one computed from whatever
+      # arrived. Skips itself with a warning on the two arm64 targets Tor
+      # publishes no expert bundle for; those builds ship the other carriers and
+      # the app offers only what it actually has.
+      - name: Stage the Tor carrier
+        run: pnpm stage:tor
+
       - name: Test the Tauri backend
         run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -274,7 +274,20 @@ jobs:
         run: cargo test --release --locked --manifest-path src-tauri/Cargo.toml
 
       - name: Build the desktop package
-        run: pnpm tauri build --bundles "${{ matrix.bundles }}"
+        env:
+          # linuxdeploy strips every ELF it finds while assembling an AppImage,
+          # and the Tor carrier puts two it did not build -- tor and lyrebird --
+          # in the resource directory. It failed there with no diagnostic of its
+          # own; the Linux arm64 job, which ships no Tor because upstream
+          # publishes no bundle for it, went green on the same commit.
+          #
+          # Stripping them buys nothing anyway: they arrive already stripped
+          # from a release build we verified by digest, and modifying them would
+          # invalidate exactly the thing that check established.
+          #
+          # Read only by the AppImage bundler; harmless everywhere else.
+          NO_STRIP: "true"
+        run: pnpm tauri build --verbose --bundles "${{ matrix.bundles }}"
 
       - name: Upload desktop packages
         uses: actions/upload-artifact@v7

--- a/PORT-CARRIERS.md
+++ b/PORT-CARRIERS.md
@@ -1,0 +1,106 @@
+# Adding Psiphon and Tor as carriers
+
+A brief for whoever picks this up, written straight after building the same thing
+in the Android client at `E:\projects\whiteAesther android`. Read
+`native/psiphon/README.md` and `native/tor/README.md` there first: they record what
+was measured, and most of it transfers.
+
+Start by reading `src-tauri/src/core_supervisor.rs` and `src-tauri/src/chain.rs`
+and saying back how the core is supervised and how the chain config is rendered,
+**before changing anything**.
+
+## The design, and why this repo is already most of the way there
+
+A *carrier* is whatever gets us out of the network. Each one ends in a SOCKS5
+listener on loopback. mihomo owns the interface and routes everything into
+whichever carrier is running.
+
+This app already works exactly that way and does not know it. `core_supervisor.rs`
+runs the Aether core as a child process and exposes `connected_socks()`;
+`chain.rs` declares that listener to mihomo as the proxy named `aether` and puts
+every node behind it with `dialer-proxy`. A carrier is one more child process that
+ends in a SOCKS listener, and `TUNNEL_PROXY` becoming a parameter rather than the
+constant `"aether"`.
+
+So the shape of the work is: a second and third supervisor beside
+`core_supervisor.rs`, and one string in `chain.rs` that stops being a constant.
+
+## What is different from Android, and it makes this much easier
+
+- Everything here is already a child process, so there is no "one Go runtime per
+  process" problem and no JNI. Psiphon's `ConsoleClient` and `tor.exe` are two more
+  supervised children, configured by a file and read on stdout — the same pattern
+  `core_supervisor.rs` already implements.
+- Windows and Linux have no restriction on executing shipped binaries, so nothing
+  has to be disguised as a library the way Android forces.
+- A normal `tor.exe` launches its own pluggable transports. Use
+  `ClientTransportPlugin obfs4 exec <path>` and do **not** port the Android
+  managed-proxy handshake — that existed only because Guardian Project's JNI build
+  aborts on `exec`, which cost half a day to find.
+- Psiphon is a Go program but nothing here needs to link it. Ship the console
+  client binary; the app stays Rust.
+
+## Traps, all found by measurement on Android
+
+1. **tor reports its control port up before it has a circuit.** Poll
+   `status/bootstrap-phase` and only report connected at `PROGRESS=100`. Skipping
+   this ships a carrier that says connected and carries nothing — which is exactly
+   how meek passed review and then failed for three minutes straight.
+2. **Never measure the exit address from the process that runs the carrier.** On
+   Android that process is excluded from the interface, so the answer was the
+   user's own address under a label saying the opposite. Here the equivalent
+   mistake is measuring before mihomo is in the path. Ask through the carrier's own
+   SOCKS listener.
+3. **Tor carries no UDP.** Declare `udp: false` on the proxy *and* put
+   `NETWORK,udp,REJECT` above `MATCH`, or DNS and QUIC hang instead of falling
+   back within a round trip.
+4. **Built-in bridge lists rot.** The first list shipped on Android was written
+   from memory and two of its three bridges were already unreachable from an
+   uncensored network. Fetch from Tor's own service and health-check every address
+   before shipping — port `native/tor/refresh-bridges.ps1`, which does both.
+5. **Public bridges are blocked where they matter.** Implement the one-tap fetch
+   from `bridges.torproject.org/moat/circumvention/settings`: ask about the
+   *user's* country, not the exit's, and send the request through whichever carrier
+   is already up, because that host is itself blocked in most of the places its
+   answer is wanted. For Iran it currently answers `webtunnel`, and a circuit
+   behind it built in seventeen seconds. On a desktop there is no SIM to read the
+   country from — offer the field rather than guessing from the exit.
+6. **Psiphon replays the server that worked**, so the exit address stops changing
+   and users read it as being stuck on one server. Offer the exit country, and read
+   the list from Psiphon's own available-regions notice rather than a hardcoded
+   table — it reported 25 regions.
+7. **Every string that names Cloudflare or assumes the engine has to be re-read.**
+   The Android exit-chain screen said "Traffic leaves from Cloudflare" while
+   Psiphon was carrying the session out of Singapore, and offered a switch the
+   carrier path never reads. A control that saves and does nothing is worse than
+   one that is absent.
+
+## Order of work, each ending at a gate checked from outside the app
+
+1. `TUNNEL_PROXY` becomes a parameter, and a carrier setting chooses which
+   supervisor runs. **Gate:** the engine path behaves exactly as it does today.
+2. Psiphon as a supervised child. **Gate:** a request through its own SOCKS returns
+   an address that is not this machine's, and the whole desktop follows once mihomo
+   is pointed at it.
+3. Exit country. **Gate:** choosing a country moves the exit address.
+4. Tor, direct. **Gate:** connected only at bootstrap 100, and an exit relay
+   answers.
+5. Bridges — built-in, pasted, fetched in one tap. **Gate:** all three reach a
+   circuit, and a fetch asked as a censored country returns real lines.
+6. Kill switch and leak matrix on both platforms this app ships to. A carrier that
+   leaks on failure is worse than no carrier.
+
+## Rules
+
+- Keep mihomo's controller and DNS listener loopback-only.
+- The scanner, the endpoint pinning and the discovery depth all describe a search
+  for a Cloudflare gateway. Under a carrier they do nothing — say so on the screen
+  rather than leaving controls that quietly have no effect.
+- Do not claim any carrier works until traffic from another process has been
+  observed leaving through it. Building is not evidence.
+- Pin every downloaded binary by revision and checksum, the way
+  `native/chain/setup.ps1` and `native/psiphon/setup.ps1` do on Android.
+- `psiphon-tunnel-core` is GPL-3.0; tor, lyrebird and snowflake are BSD-3-Clause.
+  This app is AGPL-3.0, and section 13 permits the combination — but the notice
+  obligation is real. Record each one in `THIRD_PARTY_NOTICES.md` with the exact
+  revision and where to get the source.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -36,7 +36,11 @@ installers and drives it over its local control API; the two are separate progra
 over documented interfaces, and no mihomo code is linked into WhiteAesther.
 
 - Upstream: <https://github.com/MetaCubeX/mihomo>
-- The build shipped here: release `v1.19.30`, downloaded unmodified by `scripts/stage-chain.mjs`
+- The build shipped here: release `v1.19.30`, downloaded unmodified by `scripts/stage-chain.mjs`,
+  which refuses to stage an asset whose SHA-256 is not the one pinned in that script — so
+  "unmodified" is checked at build time rather than asserted here. The Windows x86-64 binary we
+  ship is `6ac25fcb26afe8e1bea24b6e6e80805bf884a33232d12e2d78dfa0b6c529ac14`; the digests for the
+  other five targets are in `DIGESTS` in the same script.
 - Corresponding source: <https://github.com/MetaCubeX/mihomo/tree/v1.19.30>
 - Licence: GNU General Public License v3.0 — the full text is in `licenses/mihomo-GPL-3.0.txt`,
   copied verbatim from that tag and installed alongside the binary
@@ -51,6 +55,70 @@ MIT at a glance. The proxy core lives on the `Meta` branch and its releases, and
 Because mihomo is conveyed as a separate executable rather than linked, its licence does not extend
 to WhiteAesther's own source, which remains AGPL-3.0. GPL-3.0 still obliges us to pass the licence
 on with the binary and to say where its source is; both are above.
+
+## psiphon-tunnel-core
+
+The Psiphon carrier. WhiteAesther ships the `psiphon-tunnel-core` console client inside its
+installers and drives it as a child process, reading its JSON notice stream and routing traffic
+into the SOCKS5 listener it produces. The two are separate programs communicating over documented
+interfaces, and no Psiphon code is linked into WhiteAesther.
+
+- Upstream: <https://github.com/Psiphon-Labs/psiphon-tunnel-core>
+- The build shipped here: **built from source**, not downloaded. Psiphon publishes no console-client
+  executable — its releases carry only `Psiphon-Android-Library.zip`, `Psiphon-Client-Library.zip`
+  and `Psiphon-iOS-Library.zip` — so `scripts/stage-psiphon.mjs` compiles `./ConsoleClient` from the
+  pinned revision `v2.0.41` with `CGO_ENABLED=0 go build -trimpath`.
+- Corresponding source: <https://github.com/Psiphon-Labs/psiphon-tunnel-core/tree/v2.0.41>
+- Licence: GNU General Public License v3.0 — the full text is in
+  `licenses/psiphon-tunnel-core-GPL-3.0.txt`, copied verbatim from that tag and installed alongside
+  the binary
+- Copyright: Psiphon Inc.
+
+Because we build and distribute this binary rather than merely fetching one, GPL-3.0's source
+obligation is ours to meet: the revision above is the exact source of what we ship, and the build
+command is recorded here and in the staging script so anyone can reproduce it.
+
+`PropagationChannelId` and `SponsorId` are set to the all-Fs and all-1s placeholders that appear in
+tunnel-core's own tests and in open-source clients that have not been issued their own. They are not
+credentials and authenticate nothing; they identify who distributed a client so Psiphon can plan
+capacity. Ours are therefore indistinguishable from every other unattributed client.
+
+### The bootstrap server list
+
+`psiphon_server_entries.txt` is the embedded list tunnel-core bootstraps from — one hex-encoded
+server entry per line. Psiphon publishes it only inside their own clients, so it is fetched from a
+third-party mirror (`mbm110/MSN-GUARD`) pinned to a revision and verified against a SHA-256 before
+it is staged. That is safe in a way it would not be for a binary: every entry is signed and verified
+by tunnel-core itself, so a substituted file costs a slow first connect rather than trust. Psiphon
+replaces the list from inside the tunnel once a connection is up.
+
+## Tor, and the lyrebird pluggable transport
+
+The Tor carrier. WhiteAesther ships `tor` and `lyrebird` inside its installers and drives `tor` as a
+child process over its loopback control port, routing traffic into the SOCKS5 listener it produces.
+`tor` launches `lyrebird` itself when bridges are turned on. All are separate programs communicating
+over documented interfaces, and none of their code is linked into WhiteAesther.
+
+- Upstream: <https://gitlab.torproject.org/tpo/core/tor> and
+  <https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird>
+- The build shipped here: the **Tor Expert Bundle** `15.0.21`, downloaded unmodified by
+  `scripts/stage-tor.mjs` and verified against the SHA-256 Tor publishes for it in
+  `sha256sums-signed-build.txt` — so the check is against Tor's own number, not one we computed from
+  bytes we happened to receive. The Windows x86-64 bundle we ship is
+  `f22b8b17cb18c9fa775dfcf68acf6a2fe788336535fe94645204ca85158aa490`; the digests for the other
+  targets are in `BUNDLES` in that script.
+- Corresponding source: <https://dist.torproject.org/torbrowser/15.0.21/>
+- Licence: BSD 3-Clause. The full texts are in `licenses/tor-BSD-3-Clause.txt` and
+  `licenses/lyrebird-BSD-3-Clause.txt`, copied out of that same archive rather than fetched
+  separately — a licence file that can drift from the build it describes is worse than none.
+- Copyright: The Tor Project, Inc., and contributors
+
+The bundle also supplies `geoip`, `geoip6`, and `pt_config.json`. That last file carries **Tor's own
+built-in bridge lists**, which is why WhiteAesther maintains none of its own: a hand-written list
+rots between releases, and this one can only go stale when the bundle does.
+
+Tor publishes no expert bundle for `windows-aarch64` or `linux-aarch64`. Builds for those targets
+ship without the Tor carrier, and the application offers only the carriers it actually has.
 
 ## Iran routing lists
 

--- a/licenses/lyrebird-BSD-3-Clause.txt
+++ b/licenses/lyrebird-BSD-3-Clause.txt
@@ -1,0 +1,5076 @@
+filippo.io/edwards25519/LICENSE
+===============================
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/andybalholm/brotli/LICENSE
+=====================================
+Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+github.com/aws/aws-sdk-go-v2/LICENSE.txt
+========================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/NOTICE.txt
+=======================================
+AWS SDK for Go
+Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2014-2015 Stripe, Inc.
+
+
+github.com/aws/aws-sdk-go-v2/config/LICENSE.txt
+===============================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/credentials/LICENSE.txt
+====================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/feature/ec2/imds/LICENSE.txt
+=========================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/internal/configsources/LICENSE.txt
+===============================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2/LICENSE.txt
+==============================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/internal/ini/LICENSE.txt
+=====================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/internal/sync/singleflight/LICENSE
+===============================================================
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding/LICENSE.txt
+=========================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url/LICENSE.txt
+=======================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/service/sqs/LICENSE.txt
+====================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/service/sso/LICENSE.txt
+====================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/service/ssooidc/LICENSE.txt
+========================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/aws-sdk-go-v2/service/sts/LICENSE.txt
+====================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/aws/smithy-go/LICENSE
+================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+
+github.com/aws/smithy-go/NOTICE
+===============================
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+
+github.com/aws/smithy-go/internal/sync/singleflight/LICENSE
+===========================================================
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+github.com/cloudflare/circl/LICENSE
+===================================
+Copyright (c) 2019 Cloudflare. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Cloudflare nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+========================================================================
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/cloudflare/circl/ecc/p384/LICENSE
+============================================
+Copyright (c) 2018, Brendan McMillion. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/dchest/siphash/LICENSE
+=================================
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+
+
+github.com/golang/mock/gomock/LICENSE
+=====================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/google/uuid/LICENSE
+==============================
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/klauspost/compress/LICENSE
+=====================================
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2019 Klaus Post. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------
+
+Files: gzhttp/*
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016-2017 The New York Times Company
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------
+
+Files: s2/cmd/internal/readahead/*
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Klaus Post
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---------------------
+Files: snappy/*
+Files: internal/snapref/*
+
+Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------------
+
+Files: s2/cmd/internal/filepathx/*
+
+Copyright 2016 The filepathx Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/klauspost/compress/internal/snapref/LICENSE
+======================================================
+Copyright (c) 2011 The Snappy-Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/klauspost/compress/zstd/internal/xxhash/LICENSE.txt
+==============================================================
+Copyright (c) 2016 Caleb Spare
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/klauspost/cpuid/v2/LICENSE
+=====================================
+The MIT License (MIT)
+
+Copyright (c) 2015 Klaus Post
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+github.com/klauspost/reedsolomon/LICENSE
+========================================
+The MIT License (MIT)
+
+Copyright (c) 2015 Klaus Post
+Copyright (c) 2015 Backblaze
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+github.com/miekg/dns/LICENSE
+============================
+BSD 3-Clause License
+
+Copyright (c) 2009, The Go Authors. Extensions copyright (c) 2011, Miek Gieben. 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/patrickmn/go-cache/LICENSE
+=====================================
+Copyright (c) 2012-2017 Patrick Mylund Nielsen and the go-cache contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+github.com/pion/datachannel/LICENSE
+===================================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/dtls/v3/LICENSE
+===============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/ice/v4/LICENSE
+==============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/interceptor/LICENSE
+===================================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/logging/LICENSE
+===============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/mdns/v2/LICENSE
+===============================
+MIT License
+
+Copyright (c) 2018 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+github.com/pion/randutil/LICENSE
+================================
+MIT License
+
+Copyright (c) 2020 Pion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+github.com/pion/rtcp/LICENSE
+============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/rtp/LICENSE
+===========================
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/sctp/LICENSE
+============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/sdp/v3/LICENSE
+==============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/srtp/v3/LICENSE
+===============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/stun/v3/LICENSE
+===============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/transport/v3/LICENSE
+====================================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/turn/v4/LICENSE
+===============================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pion/webrtc/v4/LICENSE
+=================================
+MIT License
+
+Copyright (c) 2023 The Pion community <https://pion.ly>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+github.com/pkg/errors/LICENSE
+=============================
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/realclientip/realclientip-go/LICENSE
+===============================================
+BSD Zero Clause License
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+github.com/refraction-networking/utls/LICENSE
+=============================================
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/refraction-networking/utls/dicttls/LICENSE
+=====================================================
+BSD 3-Clause License
+
+Copyright (c) 2023, Gaukas Wang
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/templexxx/cpu/LICENSE
+================================
+BSD 3-Clause License
+
+Copyright (c) 2018 Temple3x (temple3x@gmail.com)
+Copyright 2017 The Go Authors
+Copyright (c) 2015 Klaus Post
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/templexxx/xorsimd/LICENSE
+====================================
+MIT License
+
+Copyright (c) 2019 Temple3x (temple3x@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+github.com/tjfoc/gmsm/sm4/LICENSE
+=================================
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+github.com/txthinking/runnergroup/LICENSE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2020-present Cloud <cloud@txthinking.com> https://www.txthinking.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+github.com/txthinking/socks5/LICENSE
+====================================
+MIT License
+
+Copyright (c) 2015-present Cloud <cloud@txthinking.com> https://www.txthinking.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+github.com/wlynxg/anet/LICENSE
+==============================
+BSD 3-Clause License
+
+Copyright (c) 2023, wlynxg
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+github.com/xtaci/kcp-go/v5/LICENSE
+==================================
+The MIT License (MIT)
+
+Copyright (c) 2015 xtaci
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+github.com/xtaci/smux/LICENSE
+=============================
+MIT License
+
+Copyright (c) 2016-2017 xtaci
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+gitlab.com/yawning/edwards25519-extra/LICENSE
+=============================================
+Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+Copyright (c) 2021 Yawning Angel. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/goptlib/COPYING
+==============================================================================
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+
+
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird/LICENSE
+===============================================================================
+Copyright (c) 2023, The Tor Project
+Copyright (c) 2014-2023, Yawning Angel <yawning at schwanenlied dot me>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+==============================================================================
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/ptutil/LICENSE
+=============================================================================
+              This file contains the license for "ptutil"
+     a free software project which provides a utils for pluggable transport.
+
+================================================================================
+Copyright (c) 2016, Serene Han, Arlo Breault
+Copyright (c) 2019-2024, The Tor Project, Inc
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+  * Neither the names of the copyright owners nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+================================================================================
+
+
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/snowflake/v2/LICENSE
+===================================================================================
+              This file contains the license for "Snowflake"
+     a free software project which provides a WebRTC pluggable transport.
+
+================================================================================
+Copyright (c) 2016, Serene Han, Arlo Breault
+Copyright (c) 2019-2020, The Tor Project, Inc
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+  * Neither the names of the copyright owners nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+================================================================================
+
+
+gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/webtunnel/LICENSE
+================================================================================
+Copyright 2022 The Tor Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+golang.org/x/crypto/LICENSE
+===========================
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+golang.org/x/net/LICENSE
+========================
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+golang.org/x/sys/LICENSE
+========================
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+golang.org/x/text/LICENSE
+=========================
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/licenses/psiphon-tunnel-core-GPL-3.0.txt
+++ b/licenses/psiphon-tunnel-core-GPL-3.0.txt
@@ -1,0 +1,675 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+

--- a/licenses/tor-BSD-3-Clause.txt
+++ b/licenses/tor-BSD-3-Clause.txt
@@ -1,0 +1,416 @@
+                    This file contains the license for Tor,
+        a free software project to provide anonymity on the Internet.
+
+        It also lists the licenses for other components used by Tor.
+
+       For more information about Tor, see https://www.torproject.org/.
+
+             If you got this file as a part of a larger bundle,
+        there may be other license terms that you should be aware of.
+
+===============================================================================
+Tor is distributed under the "3-clause BSD" license, a commonly used
+software license that means Tor is both free software and open source:
+
+Copyright (c) 2001-2004, Roger Dingledine
+Copyright (c) 2004-2006, Roger Dingledine, Nick Mathewson
+Copyright (c) 2007-2019, The Tor Project, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+    * Neither the names of the copyright owners nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+===============================================================================
+src/ext/strlcat.c and src/ext/strlcpy.c by Todd C. Miller are licensed
+under the following license:
+
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+ * THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+===============================================================================
+src/ext/tor_queue.h is licensed under the following license:
+
+ * Copyright (c) 1991, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+
+===============================================================================
+src/ext/csiphash.c is licensed under the following license:
+
+ Copyright (c) 2013  Marek Majkowski <marek@popcount.org>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+===============================================================================
+Trunnel is distributed under this license:
+
+Copyright 2014  The Tor Project, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+    * Neither the names of the copyright owners nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===============================================================================
+getdelim.c is distributed under this license:
+
+ Copyright (c) 2011 The NetBSD Foundation, Inc.
+ All rights reserved.
+
+ This code is derived from software contributed to The NetBSD Foundation
+ by Christos Zoulas.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
+===============================================================================
+src/config/geoip and src/config/geoip6:
+
+These files are based on the IPFire Location Database. For more
+information, see https://location.ipfire.org/.
+
+The data is distributed under a creative commons "BY-SA 4.0" license.
+
+Find the full license terms at:
+     https://creativecommons.org/licenses/by-sa/4.0/
+
+===============================================================================
+m4/pc_from_ucontext.m4 is available under the following license.  Note that
+it is *not* built into the Tor software.
+
+Copyright (c) 2005, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===============================================================================
+m4/pkg.m4 is available under the following license.  Note that
+it is *not* built into the Tor software.
+
+pkg.m4 - Macros to locate and utilise pkg-config.            -*- Autoconf -*-
+serial 1 (pkg-config-0.24)
+
+Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+As a special exception to the GNU General Public License, if you
+distribute this file as part of a program that contains a
+configuration script generated by Autoconf, you may include it under
+the same distribution terms that you use for the rest of that program.
+===============================================================================
+src/ext/readpassphrase.[ch] are distributed under this license:
+
+  Copyright (c) 2000-2002, 2007 Todd C. Miller <Todd.Miller@courtesan.com>
+
+  Permission to use, copy, modify, and distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+  Sponsored in part by the Defense Advanced Research Projects
+  Agency (DARPA) and Air Force Research Laboratory, Air Force
+  Materiel Command, USAF, under agreement number F39502-99-1-0512.
+
+===============================================================================
+src/ext/mulodi4.c is distributed under this license:
+
+     =========================================================================
+     compiler_rt License
+     =========================================================================
+
+     The compiler_rt library is dual licensed under both the
+     University of Illinois "BSD-Like" license and the MIT license.
+     As a user of this code you may choose to use it under either
+     license.  As a contributor, you agree to allow your code to be
+     used under both.
+
+     Full text of the relevant licenses is included below.
+
+     =========================================================================
+
+     University of Illinois/NCSA
+     Open Source License
+
+     Copyright (c) 2009-2016 by the contributors listed in CREDITS.TXT
+
+     All rights reserved.
+
+     Developed by:
+
+         LLVM Team
+
+         University of Illinois at Urbana-Champaign
+
+         http://llvm.org
+
+     Permission is hereby granted, free of charge, to any person
+     obtaining a copy of this software and associated documentation
+     files (the "Software"), to deal with the Software without
+     restriction, including without limitation the rights to use,
+     copy, modify, merge, publish, distribute, sublicense, and/or sell
+     copies of the Software, and to permit persons to whom the
+     Software is furnished to do so, subject to the following
+     conditions:
+
+         * Redistributions of source code must retain the above
+           copyright notice, this list of conditions and the following
+           disclaimers.
+
+         * Redistributions in binary form must reproduce the above
+           copyright notice, this list of conditions and the following
+           disclaimers in the documentation and/or other materials
+           provided with the distribution.
+
+         * Neither the names of the LLVM Team, University of Illinois
+           at Urbana-Champaign, nor the names of its contributors may
+           be used to endorse or promote products derived from this
+           Software without specific prior written permission.
+
+     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+     NONINFRINGEMENT.  IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT
+     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+     OTHER DEALINGS WITH THE SOFTWARE.
+
+     =========================================================================
+
+     Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
+
+     Permission is hereby granted, free of charge, to any person
+     obtaining a copy of this software and associated documentation
+     files (the "Software"), to deal in the Software without
+     restriction, including without limitation the rights to use,
+     copy, modify, merge, publish, distribute, sublicense, and/or sell
+     copies of the Software, and to permit persons to whom the
+     Software is furnished to do so, subject to the following
+     conditions:
+
+     The above copyright notice and this permission notice shall be
+     included in all copies or substantial portions of the Software.
+
+     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+     OTHER DEALINGS IN THE SOFTWARE.
+
+     =========================================================================
+     Copyrights and Licenses for Third Party Software Distributed with LLVM:
+     =========================================================================
+
+     The LLVM software contains code written by third parties.  Such
+     software will have its own individual LICENSE.TXT file in the
+     directory in which it appears.  This file will describe the
+     copyrights, license, and restrictions which apply to that code.
+
+     The disclaimer of warranty in the University of Illinois Open
+     Source License applies to all code in the LLVM Distribution, and
+     nothing in any of the other licenses gives permission to use the
+     names of the LLVM Team or the University of Illinois to endorse
+     or promote products derived from this Software.
+
+===============================================================================
+Parts of src/ext/polyval are based on Thomas Pornin's GHASH implementation in
+BearSSL, and distributed under the following license:
+
+        Copyright (c) 2016 Thomas Pornin <pornin@bolet.org>
+
+        Permission is hereby granted, free of charge, to any person obtaining
+        a copy of this software and associated documentation files (the
+        "Software"), to deal in the Software without restriction, including
+        without limitation the rights to use, copy, modify, merge, publish,
+        distribute, sublicense, and/or sell copies of the Software, and to
+        permit persons to whom the Software is furnished to do so, subject to
+        the following conditions:
+
+        The above copyright notice and this permission notice shall be
+        included in all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+
+
+===============================================================================
+If you got Tor as a static binary with OpenSSL included, then you should know:
+ "This product includes software developed by the OpenSSL Project
+ for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+===============================================================================

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "stage:core": "node scripts/stage-core.mjs",
     "stage:chain": "node scripts/stage-chain.mjs",
     "update:iran-routes": "node scripts/update-iran-routes.mjs",
-    "desktop:dev": "pnpm stage:core && pnpm stage:chain && tauri dev",
-    "desktop:build": "pnpm stage:core && pnpm stage:chain && tauri build",
-    "tauri": "tauri"
+    "desktop:dev": "pnpm stage:core && pnpm stage:chain && pnpm stage:psiphon && pnpm stage:tor && tauri dev",
+    "desktop:build": "pnpm stage:core && pnpm stage:chain && pnpm stage:psiphon && pnpm stage:tor && tauri build",
+    "tauri": "tauri",
+    "stage:psiphon": "node scripts/stage-psiphon.mjs",
+    "stage:tor": "node scripts/stage-tor.mjs"
   },
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.3.0",

--- a/scripts/stage-chain.mjs
+++ b/scripts/stage-chain.mjs
@@ -28,6 +28,30 @@ const option = (name) => {
 const VERSION = "v1.19.30";
 
 /**
+ * SHA-256 of the *extracted* binary for each target, as staged.
+ *
+ * A pinned version alone is a promise the release host makes and can retract:
+ * a tag can be moved and an asset can be replaced, and neither leaves a trace
+ * in a build that only asks for the name. The digest is the part upstream
+ * cannot change under us.
+ *
+ * Used on both paths, which is the point -- verifying only the download would
+ * leave a binary that is already on disk trusted forever, and a cached artifact
+ * is exactly what an attacker who got one bad build through would rely on.
+ *
+ * Regenerate every entry when VERSION moves; a stale digest fails the build
+ * rather than silently passing, which is the direction to fail in.
+ */
+const DIGESTS = {
+  "x86_64-pc-windows-msvc": "6ac25fcb26afe8e1bea24b6e6e80805bf884a33232d12e2d78dfa0b6c529ac14",
+  "aarch64-pc-windows-msvc": "27a3132a81a53d41a027b2844b994f3f8eb08f9435e9b339c5507b37b5c548df",
+  "x86_64-apple-darwin": "30895e01ba17cc4293f9fa192c0601e91fcb812acb72a03a0286b8ffef72dadc",
+  "aarch64-apple-darwin": "e80c6334b4e3aae53dfbc86cddd4434cec1565a61d4483931fac2ae12fec6d30",
+  "x86_64-unknown-linux-gnu": "8ad44e28fe72be4640254b96741b677f4074991b99186cc4486a1c28ded02b1a",
+  "aarch64-unknown-linux-gnu": "b9456718a8955364b9a77c80f74dca49ded10f071c1c6b4513a0ea68a3d87a50",
+};
+
+/**
  * The "compatible" builds avoid newer CPU instructions, which is the right
  * default for a client that has to run on whatever machine a user has.
  */
@@ -47,12 +71,21 @@ if (!asset) {
     `No mihomo build is mapped for ${target}. Add it to ASSETS, or the chain will be missing.`,
   );
 }
+const expected = DIGESTS[target];
+if (!expected) {
+  // Refused rather than staged unverified. A target that downloads whatever
+  // upstream is serving today is the exact thing the pin exists to prevent, and
+  // making it opt-in by omission would mean the weakest path is the quiet one.
+  throw new Error(
+    `No pinned digest for ${target}. Add its SHA-256 to DIGESTS before staging that target.`,
+  );
+}
 
 const extension = target.includes("windows") ? ".exe" : "";
 const destination = join(appRoot, "src-tauri", "binaries", `mihomo-${target}${extension}`);
 await mkdir(dirname(destination), { recursive: true });
 
-if (await isStaged(destination)) {
+if (await isStaged(destination, expected)) {
   console.log(`mihomo ${VERSION} already staged for ${target}`);
 } else {
   const url = `https://github.com/MetaCubeX/mihomo/releases/download/${VERSION}/${asset}`;
@@ -74,6 +107,21 @@ if (await isStaged(destination)) {
     await rm(archive, { force: true });
   }
 
+  // Checked before it is put anywhere the build will find it, and the scratch
+  // copy is removed on failure -- so a bad download cannot be left behind to be
+  // picked up by the next run, which would turn one bad fetch into a permanent
+  // one.
+  const actual = await sha256(scratch);
+  if (actual !== expected) {
+    await rm(scratch, { force: true });
+    throw new Error(
+      `${asset} does not match its pinned digest.\n` +
+        `  expected ${expected}\n` +
+        `  actual   ${actual}\n` +
+        `Upstream may have replaced the asset. Verify what changed before updating DIGESTS.`,
+    );
+  }
+
   await rm(destination, { force: true });
   await writeFile(destination, await readFile(scratch));
   await rm(scratch, { force: true });
@@ -81,18 +129,32 @@ if (await isStaged(destination)) {
 }
 
 const size = (await stat(destination)).size;
-const digest = createHash("sha256");
-await pipeline(createReadStream(destination), digest);
 console.log(`Staged mihomo ${VERSION} for ${target}`);
 console.log(`  ${destination}`);
-console.log(`  ${(size / 1048576).toFixed(1)} MB  sha256:${digest.digest("hex").slice(0, 16)}…`);
+console.log(`  ${(size / 1048576).toFixed(1)} MB  sha256:${expected.slice(0, 16)}… verified`);
 
-async function isStaged(path) {
+/**
+ * Whether the binary already on disk is the one we pinned.
+ *
+ * This used to ask only whether the file was over a megabyte, which accepted
+ * anything at all -- a truncated download, a half-written file from an
+ * interrupted run, or a binary someone swapped in. It is also the path taken on
+ * every build after the first, so it was the check that mattered most and did
+ * the least.
+ */
+async function isStaged(path, digest) {
   try {
-    return (await stat(path)).size > 1_000_000;
+    if ((await stat(path)).size < 1_000_000) return false;
   } catch {
     return false;
   }
+  return (await sha256(path)) === digest;
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
 }
 
 function unzipSingle(archive, into) {

--- a/scripts/stage-psiphon.mjs
+++ b/scripts/stage-psiphon.mjs
@@ -1,0 +1,206 @@
+/**
+ * Builds the Psiphon console client and stages it as a Tauri sidecar, with the
+ * bootstrap server list it needs to reach anything the first time.
+ *
+ * Unlike mihomo, this one cannot be downloaded. Psiphon publishes three library
+ * archives and no console executable -- `Psiphon-Client-Library.zip` holds
+ * c-shared `.dll`/`.so`/`.dylib` builds, which would mean FFI and a Go runtime
+ * inside the Tauri process instead of a supervised child, and which in any case
+ * ship no Windows arm64 or Apple Silicon build. So the binary is built here from
+ * a pinned source revision.
+ *
+ * That changes what "pinned" can mean. A Go build is not bit-identical across
+ * toolchain versions, so a digest of the output cannot be the gate the way it is
+ * for mihomo. What is pinned is the *revision*; what is checked is the server
+ * list, which is a downloaded artifact and does have a stable digest.
+ */
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { access, chmod, mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const option = (name) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+/** Pinned to a tag, not a branch. Bump deliberately. */
+const REVISION = "v2.0.41";
+const REPOSITORY = "https://github.com/Psiphon-Labs/psiphon-tunnel-core.git";
+
+/**
+ * The bootstrap list: one hex-encoded server entry per line, which is what
+ * tunnel-core takes as `-serverList`.
+ *
+ * A third-party mirror rather than Psiphon, who publish it only inside their own
+ * clients. That is acceptable here and would not be for a binary: every entry is
+ * signed and verified by tunnel-core itself, so a substituted file costs a slow
+ * first connect rather than trust. Psiphon replaces the list from inside the
+ * tunnel once a connection is up, so it goes stale the way a phone book does
+ * rather than the way a key does.
+ */
+const SERVER_LIST = {
+  repository: "mbm110/MSN-GUARD",
+  revision: "a6379f5d060bc7ca48a4c4ee015648afc8c07a05",
+  path: "app/src/main/assets/server_entries.txt",
+  sha256: "6d6d10c4ef8eaf656cb9614513568f40d5590477fc25215507517d51fc6a293e",
+};
+
+/** Rust target triple to the GOOS/GOARCH pair that produces it. */
+const GO_TARGETS = {
+  "x86_64-pc-windows-msvc": { GOOS: "windows", GOARCH: "amd64" },
+  "aarch64-pc-windows-msvc": { GOOS: "windows", GOARCH: "arm64" },
+  "x86_64-apple-darwin": { GOOS: "darwin", GOARCH: "amd64" },
+  "aarch64-apple-darwin": { GOOS: "darwin", GOARCH: "arm64" },
+  "x86_64-unknown-linux-gnu": { GOOS: "linux", GOARCH: "amd64" },
+  "aarch64-unknown-linux-gnu": { GOOS: "linux", GOARCH: "arm64" },
+};
+
+const target = option("--target") ?? process.env.CARGO_BUILD_TARGET ?? rustHost();
+const goTarget = GO_TARGETS[target];
+if (!goTarget) {
+  throw new Error(`No Go target is mapped for ${target}. Add it to GO_TARGETS.`);
+}
+
+const extension = target.includes("windows") ? ".exe" : "";
+const binariesDir = join(appRoot, "src-tauri", "binaries");
+const destination = join(binariesDir, `psiphon-tunnel-core-${target}${extension}`);
+const serverListDestination = join(binariesDir, "psiphon_server_entries.txt");
+await mkdir(binariesDir, { recursive: true });
+
+// The checkout lives beside the app rather than inside it: it is large, it is
+// not ours, and it is regenerable -- the same three reasons the Aether fork sits
+// where it does.
+const checkout = option("--source") ?? process.env.PSIPHON_SOURCE ?? join(appRoot, "..", "psiphon-tunnel-core");
+
+if (await isBuilt(destination)) {
+  console.log(`Psiphon ${REVISION} already staged for ${target}`);
+} else {
+  await ensureCheckout(checkout);
+  console.log(`Building the console client for ${target} (${goTarget.GOOS}/${goTarget.GOARCH})`);
+  const scratch = `${destination}.build`;
+  execFileSync(
+    "go",
+    ["build", "-trimpath", "-ldflags=-s -w", "-o", scratch, "./ConsoleClient"],
+    {
+      cwd: checkout,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        ...goTarget,
+        // No cgo, so every target cross-compiles from any host with nothing but
+        // the Go toolchain. It is also what keeps the binary static, which
+        // matters for a sidecar that has to run on whatever the user has.
+        CGO_ENABLED: "0",
+      },
+    },
+  );
+  await rm(destination, { force: true });
+  await rename(scratch, destination);
+  if (!target.includes("windows")) await chmod(destination, 0o755);
+}
+
+await stageServerList();
+
+const size = (await stat(destination)).size;
+console.log(`Staged Psiphon ${REVISION} for ${target}`);
+console.log(`  ${destination}`);
+console.log(`  ${(size / 1048576).toFixed(1)} MB  sha256:${(await sha256(destination)).slice(0, 16)}…`);
+console.log(`  ${serverListDestination}`);
+
+/**
+ * Fetches the bootstrap list and checks it before it is put anywhere.
+ *
+ * Two checks, not one. The digest catches a substituted or truncated file; the
+ * hex check catches the case the digest cannot explain -- an HTML error page
+ * served with a 200, which tunnel-core would reject as a whole without saying
+ * which line lost it.
+ */
+async function stageServerList() {
+  if (await matches(serverListDestination, SERVER_LIST.sha256)) {
+    console.log("server list already present and matches the pin");
+    return;
+  }
+  const url = `https://raw.githubusercontent.com/${SERVER_LIST.repository}/${SERVER_LIST.revision}/${SERVER_LIST.path}`;
+  console.log("Fetching the Psiphon server list");
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  const body = Buffer.from(await response.arrayBuffer());
+
+  const actual = createHash("sha256").update(body).digest("hex");
+  if (actual !== SERVER_LIST.sha256) {
+    throw new Error(
+      `The Psiphon server list does not match its pinned digest.\n` +
+        `  expected ${SERVER_LIST.sha256}\n` +
+        `  actual   ${actual}`,
+    );
+  }
+  const lines = body.toString("utf8").split(/\r?\n/).filter((line) => line.trim());
+  const bad = lines.findIndex((line) => !/^[0-9a-fA-F]+$/.test(line));
+  if (bad !== -1) {
+    throw new Error(`The Psiphon server list is not hex at line ${bad + 1}`);
+  }
+  await writeFile(serverListDestination, body);
+  console.log(`  ${lines.length} server entries`);
+}
+
+async function ensureCheckout(path) {
+  try {
+    await access(join(path, "ConsoleClient"));
+  } catch {
+    console.log(`Cloning psiphon-tunnel-core ${REVISION} into ${path}`);
+    execFileSync(
+      "git",
+      ["clone", "--depth", "1", "--branch", REVISION, REPOSITORY, path],
+      { stdio: "inherit" },
+    );
+    return;
+  }
+  // A checkout that is present but on the wrong revision is the trap the Aether
+  // fork already fell into once: it silently staged an older engine. Refuse
+  // rather than build whatever is sitting there.
+  const described = execFileSync("git", ["describe", "--tags", "--always"], {
+    cwd: path,
+    encoding: "utf8",
+  }).trim();
+  if (described !== REVISION) {
+    throw new Error(
+      `${path} is at ${described}, not ${REVISION}. ` +
+        `Check it out at the pinned revision, or delete it and let this script clone it.`,
+    );
+  }
+}
+
+async function isBuilt(path) {
+  try {
+    return (await stat(path)).size > 1_000_000;
+  } catch {
+    return false;
+  }
+}
+
+async function matches(path, digest) {
+  try {
+    await access(path);
+  } catch {
+    return false;
+  }
+  return (await sha256(path)) === digest;
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
+}
+
+function rustHost() {
+  const output = execFileSync("rustc", ["-vV"], { encoding: "utf8", windowsHide: true });
+  const host = output.match(/^host:\s*(.+)$/m)?.[1]?.trim();
+  if (!host) throw new Error("Could not determine the Rust host target");
+  return host;
+}

--- a/scripts/stage-tor.mjs
+++ b/scripts/stage-tor.mjs
@@ -1,0 +1,226 @@
+/**
+ * Fetches the Tor Expert Bundle and stages what the Tor carrier needs.
+ *
+ * Unlike Psiphon this one is downloadable: Tor Project publishes the expert
+ * bundle for every desktop target, already carrying `tor`, the pluggable
+ * transports, and the geoip data. And unlike mihomo it publishes a *signed*
+ * digest manifest alongside it, so the pins below are Tor's own numbers rather
+ * than ones we computed from bytes we happened to receive.
+ *
+ * Four files come out of it:
+ *
+ * - `tor` itself,
+ * - `lyrebird`, which provides obfs4, webtunnel, meek_lite and snowflake — one
+ *   binary for every transport we would offer,
+ * - `geoip` and `geoip6`, which tor wants for country data, and
+ * - `pt_config.json`, which carries **Tor's own built-in bridge lists**.
+ *
+ * That last one is the answer to a trap the Android client hit: a bridge list
+ * written by hand rots, and two of the three it first shipped were already
+ * unreachable. Reading the list out of the pinned bundle means it can only go
+ * stale when the bundle does, and bumping the bundle bumps both together.
+ */
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { access, copyFile, chmod, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const option = (name) => {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+};
+
+/** Pinned so a build is reproducible. Bump deliberately, digests and all. */
+const VERSION = "15.0.21";
+
+/**
+ * Rust target triple to the bundle that serves it, with the SHA-256 Tor
+ * published for it.
+ *
+ * Taken from `sha256sums-signed-build.txt` at this version, not computed from a
+ * download — which is the difference between checking that a file arrived
+ * intact and checking that it is the file Tor built. Their `.asc` alongside it
+ * signs the manifest; verifying that signature needs a key and a GPG dependency
+ * this script does not have, so the manifest is trusted at the same level as
+ * the TLS connection that fetched it. Better than nothing and honestly less
+ * than a signature check; a build server with gpg should do the stronger thing.
+ *
+ * Two desktop targets are missing on purpose: Tor publishes no
+ * `windows-aarch64` or `linux-aarch64` expert bundle at this version. They are
+ * absent rather than mapped to a near-miss, so staging refuses them loudly.
+ */
+const BUNDLES = {
+  "x86_64-pc-windows-msvc": {
+    asset: `tor-expert-bundle-windows-x86_64-${VERSION}.tar.gz`,
+    sha256: "f22b8b17cb18c9fa775dfcf68acf6a2fe788336535fe94645204ca85158aa490",
+  },
+  "x86_64-apple-darwin": {
+    asset: `tor-expert-bundle-macos-x86_64-${VERSION}.tar.gz`,
+    sha256: "7e21f5dab4c627e2ff8e894b2039fa49bdd78d12b025f96893d4d6238c6577e4",
+  },
+  "aarch64-apple-darwin": {
+    asset: `tor-expert-bundle-macos-aarch64-${VERSION}.tar.gz`,
+    sha256: "83dec16412c1d97b91af603229481dd29f578e1485620ecffd9ac4aabcf6fb46",
+  },
+  "x86_64-unknown-linux-gnu": {
+    asset: `tor-expert-bundle-linux-x86_64-${VERSION}.tar.gz`,
+    sha256: "40ef58c536d7077543a25707be5ba467f4b6bcdbafdc015daa25bcf9cb1edc11",
+  },
+};
+
+const target = option("--target") ?? process.env.CARGO_BUILD_TARGET ?? rustHost();
+const bundle = BUNDLES[target];
+if (!bundle) {
+  // Skipped, not fatal. Refusing the whole build because one of three carriers
+  // is unavailable would mean never shipping for arm64 Windows or Linux at all,
+  // where Aether and Psiphon both work perfectly well. The app asks which
+  // carriers are actually present (`carriers_available`) and offers only those,
+  // so a build without Tor is honest about it rather than showing a control
+  // that cannot start.
+  console.warn(
+    `Tor publishes no expert bundle for ${target} at ${VERSION}; ` +
+      `building without the Tor carrier. Aether and Psiphon are unaffected.`,
+  );
+  process.exit(0);
+}
+
+const extension = target.includes("windows") ? ".exe" : "";
+const binariesDir = join(appRoot, "src-tauri", "binaries");
+const destination = join(binariesDir, `tor-${target}${extension}`);
+// The transports and the data files are resources rather than sidecars: tor
+// launches the transport itself, and nothing renames these per target.
+const supportDir = join(binariesDir, "tor");
+await mkdir(supportDir, { recursive: true });
+
+const staged = [
+  destination,
+  join(supportDir, `lyrebird${extension}`),
+  join(supportDir, "geoip"),
+  join(supportDir, "geoip6"),
+  join(supportDir, "pt_config.json"),
+];
+
+if (await allPresent(staged)) {
+  console.log(`Tor ${VERSION} already staged for ${target}`);
+} else {
+  const url = `https://dist.torproject.org/torbrowser/${VERSION}/${bundle.asset}`;
+  console.log(`Fetching ${bundle.asset}`);
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+  const archive = join(binariesDir, `${bundle.asset}.download`);
+  await writeFile(archive, Buffer.from(await response.arrayBuffer()));
+
+  // Checked before a single file is unpacked. The alternative -- extract, then
+  // verify what came out -- has already run an archive of unknown provenance
+  // through a decompressor by the time it decides whether to trust it.
+  const actual = await sha256(archive);
+  if (actual !== bundle.sha256) {
+    await rm(archive, { force: true });
+    throw new Error(
+      `${bundle.asset} does not match the digest Tor published for it.\n` +
+        `  expected ${bundle.sha256}\n` +
+        `  actual   ${actual}`,
+    );
+  }
+
+  const scratch = join(binariesDir, "tor-unpack");
+  await rm(scratch, { recursive: true, force: true });
+  await mkdir(scratch, { recursive: true });
+  // bsdtar ships with Windows 10 and later, and tar is everywhere else.
+  //
+  // Relative names, with the directory passed as `cwd`: an absolute Windows
+  // path contains a drive colon, and every tar reads `E:\...` as `host:path`
+  // and tries to fetch it over rsh. The failure is an unrecoverable status 128
+  // that says nothing about why.
+  execFileSync("tar", ["-xzf", `${bundle.asset}.download`, "-C", "tor-unpack"], {
+    cwd: binariesDir,
+    stdio: "inherit",
+  });
+
+  await rm(destination, { force: true });
+  await copyFile(join(scratch, "tor", `tor${extension}`), destination);
+  await copyFile(
+    join(scratch, "tor", "pluggable_transports", `lyrebird${extension}`),
+    join(supportDir, `lyrebird${extension}`),
+  );
+  for (const name of ["geoip", "geoip6"]) {
+    await copyFile(join(scratch, "data", name), join(supportDir, name));
+  }
+  // Tor's own bridge lists travel with the binary they are meant to work with.
+  await copyFile(
+    join(scratch, "tor", "pluggable_transports", "pt_config.json"),
+    join(supportDir, "pt_config.json"),
+  );
+
+  // The licences come out of the same pinned archive as the binaries they
+  // cover, rather than being fetched separately: a licence file that can drift
+  // from the build it describes is worse than none, because it reads as a
+  // statement about what we shipped.
+  const licences = join(appRoot, "licenses");
+  await mkdir(licences, { recursive: true });
+  for (const [from, to] of [
+    ["tor.txt", "tor-BSD-3-Clause.txt"],
+    ["lyrebird.txt", "lyrebird-BSD-3-Clause.txt"],
+  ]) {
+    await copyFile(join(scratch, "docs", from), join(licences, to));
+  }
+
+  if (!target.includes("windows")) {
+    await chmod(destination, 0o755);
+    await chmod(join(supportDir, "lyrebird"), 0o755);
+  }
+  await rm(scratch, { recursive: true, force: true });
+  await rm(archive, { force: true });
+}
+
+const bridges = await countBridges(join(supportDir, "pt_config.json"));
+console.log(`Staged Tor ${VERSION} for ${target}`);
+console.log(`  ${destination}  (${((await stat(destination)).size / 1048576).toFixed(1)} MB)`);
+console.log(`  ${supportDir}`);
+console.log(`  built-in bridges: ${bridges}`);
+
+/**
+ * How many bridges Tor's own list carries, by transport.
+ *
+ * Printed rather than checked: a bundle that shipped an empty list would be a
+ * surprise worth seeing at build time rather than discovering when someone in a
+ * censored country taps the one control that was supposed to help them.
+ */
+async function countBridges(path) {
+  try {
+    const config = JSON.parse(await (await import("node:fs/promises")).readFile(path, "utf8"));
+    return Object.entries(config.bridges ?? {})
+      .map(([transport, list]) => `${transport} ${list.length}`)
+      .join(", ") || "none — the bundle shipped no list";
+  } catch (error) {
+    return `unreadable (${error.message})`;
+  }
+}
+
+async function allPresent(paths) {
+  for (const path of paths) {
+    try {
+      await access(path);
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
+}
+
+function rustHost() {
+  const output = execFileSync("rustc", ["-vV"], { encoding: "utf8", windowsHide: true });
+  const host = output.match(/^host:\s*(.+)$/m)?.[1]?.trim();
+  if (!host) throw new Error("Could not determine the Rust host target");
+  return host;
+}

--- a/scripts/stage-tor.mjs
+++ b/scripts/stage-tor.mjs
@@ -51,7 +51,9 @@ const VERSION = "15.0.21";
  *
  * Two desktop targets are missing on purpose: Tor publishes no
  * `windows-aarch64` or `linux-aarch64` expert bundle at this version. They are
- * absent rather than mapped to a near-miss, so staging refuses them loudly.
+ * absent rather than mapped to a near-miss, and staging skips them with a
+ * warning rather than failing -- see below for why the whole build should not
+ * stop over one carrier.
  */
 const BUNDLES = {
   "x86_64-pc-windows-msvc": {
@@ -85,15 +87,32 @@ if (!bundle) {
     `Tor publishes no expert bundle for ${target} at ${VERSION}; ` +
       `building without the Tor carrier. Aether and Psiphon are unaffected.`,
   );
+  // The bundle configuration globs this directory, and a glob that matches
+  // nothing is a packaging error on some targets. A note is written instead of
+  // a placeholder binary: an empty file named `tor` would be found by the very
+  // lookup that decides whether this carrier can run.
+  const supportDir = join(appRoot, "src-tauri", "binaries", "tor");
+  await mkdir(supportDir, { recursive: true });
+  await writeFile(
+    join(supportDir, "UNAVAILABLE.txt"),
+    `The Tor carrier is not part of this build.\n\n` +
+      `Tor publishes no expert bundle for ${target} at ${VERSION}, so there is no tor binary\n` +
+      `to ship. The application asks which carriers are present and offers only those, so\n` +
+      `Tor does not appear as a choice on this build. Aether and Psiphon are unaffected.\n`,
+  );
   process.exit(0);
 }
 
 const extension = target.includes("windows") ? ".exe" : "";
 const binariesDir = join(appRoot, "src-tauri", "binaries");
-const destination = join(binariesDir, `tor-${target}${extension}`);
-// The transports and the data files are resources rather than sidecars: tor
-// launches the transport itself, and nothing renames these per target.
+// Everything travels in one resource directory rather than as a target-triple
+// sidecar. Tor is not shipped for every target -- there is no linux-aarch64
+// expert bundle -- and a declared sidecar that is missing fails the whole
+// bundle, which would mean no arm64 Linux build at all rather than one without
+// this one carrier. It also keeps tor next to the transports it launches and
+// the geoip data it reads.
 const supportDir = join(binariesDir, "tor");
+const destination = join(supportDir, `tor${extension}`);
 await mkdir(supportDir, { recursive: true });
 
 const staged = [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2703,6 +2703,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,6 +2742,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3133,6 +3182,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3979,6 +4034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,6 +4283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4262,12 +4332,14 @@ name = "whiteaesther"
 version = "1.7.1"
 dependencies = [
  "getrandom 0.3.4",
+ "rustls",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
+ "webpki-roots",
  "windows-sys 0.61.2",
  "winreg",
 ]
@@ -4464,6 +4536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4912,6 +4993,12 @@ dependencies = [
  "syn 2.0.119",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,21 @@ tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# TLS, for exactly one request: asking Tor's circumvention service which bridges
+# work in a given country. That request has to go out through whichever carrier
+# is up, because the service is itself blocked in most of the places its answer
+# is wanted -- so the webview's own TLS is no use, and a plain-HTTP client (what
+# the rest of this crate uses, deliberately) cannot speak to it at all.
+#
+# `ring` rather than the default `aws-lc-rs` provider: the default wants cmake
+# and nasm on Windows, which is a build-toolchain requirement for every
+# contributor in exchange for nothing we need here.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+# The trust roots. Deliberately not the platform store: this is a pinned set
+# that travels with the build, so a request made through a carrier cannot be
+# read by a root someone added to this machine.
+webpki-roots = "1"
+
 # System proxy control. Both are already in the tree via Tauri; naming them here
 # only adds the dependency edge.
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/src/carrier.rs
+++ b/src-tauri/src/carrier.rs
@@ -1,0 +1,227 @@
+//! What gets us out of the network, and what the routing engine needs to know
+//! about it.
+//!
+//! Aether is one way out; Psiphon and Tor are others. They have nothing in
+//! common internally -- one is a Cloudflare MASQUE tunnel, one finds its own
+//! path, one builds a circuit through three relays -- but they end in the same
+//! place: a SOCKS5 listener on loopback that mihomo routes the interface into.
+//!
+//! That listener is all [`chain`](crate::chain) ever needed. What it *also*
+//! needs, and used to have as three constants naming Aether, is everything
+//! about the carrier that changes the config it renders:
+//!
+//! - the **name** the proxy takes in the YAML, because every node's
+//!   `dialer-proxy` points at it,
+//! - the **process** it runs as, because under full tunnel the default route
+//!   goes into the TUN device and the carrier's own packets have to be let out
+//!   of it, and
+//! - whether it carries **datagrams**, because a proxy declared as carrying UDP
+//!   that cannot swallows every one -- which is experienced as DNS and QUIC
+//!   hanging while TCP works, the hardest shape of broken to recognise.
+
+use std::net::{IpAddr, SocketAddr};
+
+use serde::{Deserialize, Serialize};
+
+/// Which way out the user has chosen.
+///
+/// Serialised into the profile, so the names are a stored format: renaming one
+/// silently moves everybody who chose it back to the default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum CarrierKind {
+    /// The Aether engine: Cloudflare MASQUE or WireGuard.
+    #[default]
+    Aether,
+    /// Psiphon, which finds its own way out and picks its own exit country.
+    Psiphon,
+    /// Tor, through three relays and optionally a bridge.
+    Tor,
+}
+
+impl CarrierKind {
+    /// The name this carrier's proxy takes in the rendered config.
+    ///
+    /// Every node's `dialer-proxy` and every provider's `proxy` names it, and
+    /// the catch-all falls back to it when there is no exit chain -- so it has
+    /// to be stable within a run and distinct between carriers, which is the
+    /// whole reason it is no longer the constant `"aether"`.
+    pub fn proxy_name(self) -> &'static str {
+        match self {
+            Self::Aether => "aether",
+            Self::Psiphon => "psiphon",
+            Self::Tor => "tor",
+        }
+    }
+
+    /// The executable this carrier runs as, for the rule that keeps its own
+    /// packets out of the device they would otherwise be fed back into.
+    ///
+    /// Matched on the process rather than the address deliberately: see the
+    /// rule this feeds in [`crate::chain`]. Getting it wrong under full tunnel
+    /// is not a degraded connection, it is total silent loss -- the carrier's
+    /// packets are handed back to the carrier that produced them, including the
+    /// ones that would have explained why.
+    pub fn process_name(self) -> &'static str {
+        match self {
+            Self::Aether => {
+                if cfg!(windows) {
+                    "aether.exe"
+                } else {
+                    "aether"
+                }
+            }
+            Self::Psiphon => {
+                if cfg!(windows) {
+                    "psiphon-tunnel-core.exe"
+                } else {
+                    "psiphon-tunnel-core"
+                }
+            }
+            Self::Tor => {
+                if cfg!(windows) {
+                    "tor.exe"
+                } else {
+                    "tor"
+                }
+            }
+        }
+    }
+
+    /// Whether this carrier can carry datagrams at all.
+    ///
+    /// Tor cannot: it is a TCP-only transport, and nothing configures that
+    /// away. Declaring the proxy `udp: true` anyway produces a carrier that
+    /// swallows every datagram -- DNS and QUIC hang rather than failing, and
+    /// neither falls back because nothing told them to. Refused, a resolver
+    /// retries over TCP and a browser drops off QUIC, both within a round trip.
+    pub fn carries_udp(self) -> bool {
+        match self {
+            Self::Aether | Self::Psiphon => true,
+            Self::Tor => false,
+        }
+    }
+
+    /// What to call this on screen, and in a log line a person reads.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Aether => "Aether",
+            Self::Psiphon => "Psiphon",
+            Self::Tor => "Tor",
+        }
+    }
+}
+
+/// A carrier that is up, and everything the routing engine needs about it.
+///
+/// Built by whichever supervisor is running and handed to
+/// [`crate::chain::ChainRequest`]. Deliberately not the supervisor itself: the
+/// chain has no business reading state it cannot act on, and this is the whole
+/// of what it can.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Carrier {
+    pub kind: CarrierKind,
+    /// The SOCKS5 listener everything is routed into.
+    pub socks: SocketAddr,
+    /// The gateway this carrier is connected to, when it has a single one.
+    ///
+    /// Only Aether does. It is exempted from the TUN device by address as a
+    /// second line of defence behind the process rule, for a platform where
+    /// process matching is unavailable. Psiphon and Tor have no one address to
+    /// name -- the process rule carries it alone there, which is what it was
+    /// already doing everywhere.
+    pub endpoint: Option<IpAddr>,
+    /// Whether a QUIC handshake fits through this carrier.
+    ///
+    /// Narrower than [`CarrierKind::carries_udp`] and not the same question. A
+    /// MASQUE tunnel carries datagrams perfectly well and still cannot carry
+    /// QUIC: hysteria2 needs 1308 bytes and Cloudflare's capsule carries 1306.
+    /// So this is false for MASQUE and true for WireGuard, on the same carrier
+    /// -- which is why it is measured per-connection here rather than declared
+    /// per-kind above.
+    pub carries_quic: bool,
+}
+
+impl Carrier {
+    /// The name this carrier's proxy takes in the config.
+    pub fn proxy_name(&self) -> &'static str {
+        self.kind.proxy_name()
+    }
+
+    /// The executable to exempt from the TUN device.
+    pub fn process_name(&self) -> &'static str {
+        self.kind.process_name()
+    }
+
+    /// Whether to declare the proxy as carrying datagrams.
+    ///
+    /// A carrier that cannot carry QUIC can still carry ordinary UDP, so this
+    /// follows the kind and not `carries_quic`.
+    pub fn carries_udp(&self) -> bool {
+        self.kind.carries_udp()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tor_is_the_one_carrier_that_carries_no_datagrams() {
+        // Declared rather than discovered. A proxy that claims UDP and swallows
+        // it is experienced as DNS and QUIC hanging while TCP works, which is
+        // the hardest shape of broken to recognise.
+        assert!(!CarrierKind::Tor.carries_udp());
+        assert!(CarrierKind::Aether.carries_udp());
+        assert!(CarrierKind::Psiphon.carries_udp());
+    }
+
+    #[test]
+    fn every_carrier_has_a_distinct_name_and_process() {
+        // Two carriers sharing a proxy name would render a config where one
+        // node's dialer-proxy silently points at the other carrier; two sharing
+        // a process name would exempt the wrong executable from the TUN device.
+        let kinds = [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor];
+        for (index, one) in kinds.iter().enumerate() {
+            for other in &kinds[index + 1..] {
+                assert_ne!(one.proxy_name(), other.proxy_name());
+                assert_ne!(one.process_name(), other.process_name());
+            }
+        }
+    }
+
+    #[test]
+    fn the_stored_names_are_a_format_and_do_not_drift() {
+        // Serialised into the profile. A rename moves everyone who chose that
+        // carrier silently back to the default at the next load.
+        for (kind, stored) in [
+            (CarrierKind::Aether, "\"aether\""),
+            (CarrierKind::Psiphon, "\"psiphon\""),
+            (CarrierKind::Tor, "\"tor\""),
+        ] {
+            assert_eq!(serde_json::to_string(&kind).unwrap(), stored);
+            assert_eq!(serde_json::from_str::<CarrierKind>(stored).unwrap(), kind);
+        }
+    }
+
+    #[test]
+    fn a_profile_that_names_no_carrier_reads_as_aether() {
+        // Every saved profile predates carriers. Defaulting to anything else
+        // would move existing users onto a way out they never chose.
+        assert_eq!(CarrierKind::default(), CarrierKind::Aether);
+    }
+
+    #[test]
+    fn carrying_datagrams_and_carrying_quic_are_different_questions() {
+        // MASQUE carries UDP perfectly well and still cannot carry QUIC:
+        // hysteria2 needs 1308 bytes and Cloudflare's capsule carries 1306.
+        let masque = Carrier {
+            kind: CarrierKind::Aether,
+            socks: "127.0.0.1:1819".parse().unwrap(),
+            endpoint: None,
+            carries_quic: false,
+        };
+        assert!(masque.carries_udp(), "the tunnel carries datagrams");
+        assert!(!masque.carries_quic, "but not a QUIC handshake");
+    }
+}

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -21,7 +21,7 @@
 
 use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
@@ -30,11 +30,9 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
+use crate::carrier::{Carrier, CarrierKind};
 use crate::core_supervisor::CoreSupervisor;
 
-/// The name the generated config gives the first hop. Referenced by every node
-/// through `dialer-proxy`, which is what puts them behind the tunnel.
-const TUNNEL_PROXY: &str = "aether";
 /// The group every rule points at. Selecting a node means selecting into this.
 const EXIT_GROUP: &str = "exit";
 /// The provider holding whatever the user pasted by hand.
@@ -46,12 +44,6 @@ const IRAN_DOMAIN_PROVIDER: &str = "iran-domain";
 /// The name the TUN device takes, so a person looking at their adapter list
 /// can tell what made it.
 const TUN_DEVICE: &str = "WhiteAesther";
-/// The tunnel's executable, named so its own packets can be kept out of the
-/// device they would otherwise be fed back into.
-#[cfg(windows)]
-const TUNNEL_PROCESS: &str = "aether.exe";
-#[cfg(not(windows))]
-const TUNNEL_PROCESS: &str = "aether";
 /// How long to wait for the TUN device to actually come up before giving up on
 /// it. Creating an adapter and installing routes is slower than binding a port.
 const TUN_READY_TIMEOUT: Duration = Duration::from_secs(10);
@@ -118,8 +110,13 @@ impl Default for ChainSettings {
 /// them are bare bools and an Option, which is exactly the shape that gets
 /// silently transposed at a call site.
 pub struct ChainRequest<'a> {
-    /// The tunnel's SOCKS5 listener, when one is up.
-    pub tunnel: Option<SocketAddr>,
+    /// Whatever is getting us out of the network right now, when something is.
+    ///
+    /// Was the Aether listener as a bare address. It carries the listener still,
+    /// and with it the three things about the carrier that change what gets
+    /// rendered -- the proxy name, the process to exempt from the TUN device,
+    /// and whether datagrams survive the trip. See [`crate::carrier`].
+    pub carrier: Option<Carrier>,
     pub settings: &'a ChainSettings,
     /// Let Iranian sites go straight out. See [`crate::iran_routes`].
     pub bypass_iran_sites: bool,
@@ -128,21 +125,28 @@ pub struct ChainRequest<'a> {
     /// close a DNS leak, since a program that speaks to port 53 directly never
     /// consults a proxy.
     pub tun: bool,
-    /// The gateway address the tunnel is connected to.
-    ///
-    /// Only used with `tun`, and required by it: with a default route pointing
-    /// into the TUN device, the tunnel's own packets to its gateway would be
-    /// captured and fed back into the tunnel that produced them. Naming the
-    /// address here is what lets that one destination stay on the physical
-    /// interface.
-    pub endpoint: Option<IpAddr>,
 }
 
 impl ChainRequest<'_> {
     /// Whether a second hop is wanted, as opposed to the engine running only to
-    /// hold up a TUN device.
+    /// carry a carrier's traffic or hold up a TUN device.
     fn wants_exit_chain(&self) -> bool {
         self.settings.enabled
+    }
+
+    /// Whether mihomo has any reason to run at all.
+    ///
+    /// Three of them, and it used to know only two. A carrier that is not
+    /// Aether needs the engine running even with no second hop and no device:
+    /// the whole arrangement is that mihomo owns the interface and routes it
+    /// into whichever carrier is up, so refusing to start without an exit chain
+    /// would leave Psiphon or Tor connected and carrying nothing.
+    fn has_something_to_do(&self) -> bool {
+        self.wants_exit_chain()
+            || self.tun
+            || self
+                .carrier
+                .is_some_and(|carrier| carrier.kind != CarrierKind::Aether)
     }
 }
 
@@ -153,9 +157,17 @@ pub struct Running {
     pub mixed: SocketAddr,
     api: SocketAddr,
     secret: String,
-    /// Whether the nodes are dialled from inside the tunnel. Decides which
-    /// protocols can work at all -- see [`unusable_behind_the_tunnel`].
+    /// Whether the nodes are dialled from inside the carrier. Decides which
+    /// protocols can work at all -- see [`unusable_behind_the_carrier`].
     through_tunnel: bool,
+    /// Which carrier this run was rendered for.
+    ///
+    /// The *kind* only, and deliberately: a carrier change always restarts the
+    /// chain, so it cannot go stale here, whereas which transport Aether came
+    /// up on can change under a chain that keeps running -- which is why
+    /// `carries_quic` is still asked of the supervisor on every call rather
+    /// than snapshotted alongside this.
+    carrier: Option<CarrierKind>,
     /// The chain directory, so the node list can read back what the
     /// subscriptions actually contained. mihomo's API reports a protocol and a
     /// name and nothing about REALITY, and REALITY is the one thing this
@@ -209,7 +221,7 @@ impl Chain {
         self.stop();
 
         let settings = request.settings;
-        let tunnel = request.tunnel;
+        let carrier = request.carrier;
         let usable: Vec<&ChainSource> = settings
             .sources
             .iter()
@@ -219,17 +231,18 @@ impl Chain {
             if usable.is_empty() && settings.manual.trim().is_empty() {
                 return Err("add a subscription or a config before turning the chain on".into());
             }
-            if settings.through_tunnel && tunnel.is_none() {
+            if settings.through_tunnel && carrier.is_none() {
                 return Err("connect first, or turn off \"dial nodes through the tunnel\"".into());
             }
-        } else if !request.tun {
-            // Nothing to do: no second hop wanted and no device to hold up.
+        } else if !request.has_something_to_do() {
+            // No second hop wanted, no device to hold up, and Aether needs no
+            // help routing its own listener.
             return Err("the chain has nothing to carry".into());
         }
-        // Full tunnel forwards everything to the tunnel's listener, so without
+        // Full tunnel forwards everything to the carrier's listener, so without
         // one it would capture the machine's traffic and have nowhere to send
         // it -- which is worse than not capturing it.
-        if request.tun && tunnel.is_none() {
+        if request.tun && carrier.is_none() {
             return Err("connect first: full tunnel has nothing to forward to".into());
         }
 
@@ -253,7 +266,9 @@ impl Chain {
         // to be the same one tomorrow. An ephemeral port meant every launch
         // moved it, and anything configured against the last run quietly went
         // out past the hop with the old exit address.
-        let mixed = preferred_port(tunnel.map_or(DEFAULT_MIXED_PORT, next_port))?;
+        let mixed = preferred_port(
+            carrier.map_or(DEFAULT_MIXED_PORT, |carrier| next_port(carrier.socks)),
+        )?;
         // The API stays ephemeral: only this process ever speaks to it.
         let api = free_port()?;
         let secret = secret();
@@ -276,7 +291,7 @@ impl Chain {
         }
 
         let config = render(&RenderPlan {
-            tunnel,
+            carrier,
             mixed,
             api,
             secret: &secret,
@@ -285,7 +300,6 @@ impl Chain {
             bypass_iran_sites: request.bypass_iran_sites,
             exit_chain: request.wants_exit_chain(),
             tun: request.tun,
-            endpoint: request.endpoint,
         });
         let config_path = home.join("config.yaml");
         std::fs::write(&config_path, config)
@@ -367,6 +381,7 @@ impl Chain {
             api: api_address,
             secret,
             through_tunnel: settings.through_tunnel,
+            carrier: carrier.map(|carrier| carrier.kind),
             home: home.clone(),
         });
         Ok(mixed_address)
@@ -385,11 +400,13 @@ impl Chain {
     /// Every node from every source, with the delay each last recorded.
     pub fn nodes(&self, carries_quic: bool) -> Result<Vec<ChainNode>, String> {
         let (api, secret) = self.control()?;
-        let (through_tunnel, home) = {
+        let (through_tunnel, carrier, home) = {
             let guard = self.running.lock().map_err(|_| "the chain lock is poisoned")?;
             match guard.as_ref() {
-                Some(running) => (running.through_tunnel, Some(running.home.clone())),
-                None => (false, None),
+                Some(running) => {
+                    (running.through_tunnel, running.carrier, Some(running.home.clone()))
+                }
+                None => (false, None, None),
             }
         };
         // Read once for the whole list rather than per node: it is one small
@@ -420,7 +437,7 @@ impl Chain {
                 let blocked = if reality.contains(name) {
                     Some(REALITY_UNSUPPORTED.to_string())
                 } else if through_tunnel && !carries_quic {
-                    unusable_behind_the_tunnel(&kind)
+                    unusable_behind_the_carrier(&kind, carrier)
                 } else {
                     None
                 };
@@ -622,28 +639,50 @@ fn base64_decode(input: &str) -> Option<Vec<u8>> {
 }
 
 /// Why a protocol cannot be carried when the nodes are dialled through the
-/// tunnel, or `None` when it can.
+/// carrier, or `None` when it can.
 ///
 /// QUIC is the whole of it. A QUIC handshake opens with a datagram padded to
 /// 1280 bytes, which is 1308 bytes once the IP and UDP headers are on it, and
-/// the tunnel cannot carry a packet that size: Cloudflare's connect-ip capsule
-/// tops out at 1306 bytes of inner packet, measured on a live connection. Every
-/// handshake attempt is therefore dropped before it leaves, which shows up as a
-/// node that "does not answer" no matter how healthy it is -- both ends were
-/// checked here, and the same node answers in 800ms when it is dialled
-/// directly.
+/// the carrier cannot carry a packet that size. Every handshake attempt is
+/// therefore dropped before it leaves, which shows up as a node that "does not
+/// answer" no matter how healthy it is -- both ends were checked here, and the
+/// same node answers in 800ms when it is dialled directly.
+///
+/// The reason differs by carrier and so does the way out of it, which is why
+/// the advice is not one sentence for everybody. Aether over MASQUE is 28 bytes
+/// short: Cloudflare's connect-ip capsule tops out at 1306 bytes of inner
+/// packet, measured on a live connection, and switching that one profile to
+/// WireGuard fixes it. Tor carries no datagrams at all and no setting changes
+/// that -- telling someone to switch a transport that does not exist is worse
+/// than saying nothing.
 ///
 /// Matched on the protocol names mihomo reports, lowercased.
-fn unusable_behind_the_tunnel(kind: &str) -> Option<String> {
-    matches!(
+fn unusable_behind_the_carrier(kind: &str, carrier: Option<CarrierKind>) -> Option<String> {
+    if !matches!(
         kind.to_ascii_lowercase().as_str(),
         "hysteria" | "hysteria2" | "tuic"
-    )
-    .then(|| {
-        format!(
-            "{kind} runs over QUIC, which needs a bigger packet than a MASQUE tunnel can carry. Switch the protocol to WireGuard under Routes and transports, or turn off \"Dial nodes through the tunnel\" there."
-        )
-    })
+    ) {
+        return None;
+    }
+    let remedy = match carrier {
+        Some(CarrierKind::Tor) => {
+            "Tor carries no datagrams at all, so no setting here will change it -- \
+             choose a node on another protocol, or turn off \"Dial nodes through the tunnel\" \
+             under Routes and transports."
+        }
+        Some(CarrierKind::Psiphon) => {
+            "Choose a node on another protocol, or turn off \"Dial nodes through the tunnel\" \
+             under Routes and transports."
+        }
+        // Aether, and the no-carrier case that only arises before one is up.
+        _ => {
+            "Switch the protocol to WireGuard under Routes and transports, or turn off \
+             \"Dial nodes through the tunnel\" there."
+        }
+    };
+    Some(format!(
+        "{kind} runs over QUIC, which needs a bigger packet than this connection can carry. {remedy}"
+    ))
 }
 
 impl Drop for Chain {
@@ -674,7 +713,7 @@ impl Drop for Chain {
 /// these are bools and Options of the same shape, and transposing two of them
 /// would produce a config that is valid, silently wrong, and routes traffic.
 struct RenderPlan<'a> {
-    tunnel: Option<SocketAddr>,
+    carrier: Option<Carrier>,
     mixed: u16,
     api: u16,
     secret: &'a str,
@@ -682,16 +721,15 @@ struct RenderPlan<'a> {
     manual: &'a str,
     bypass_iran_sites: bool,
     /// Whether a second hop is being set up, or the engine is only holding up
-    /// a TUN device in front of the tunnel.
+    /// a TUN device in front of the carrier.
     exit_chain: bool,
     tun: bool,
-    endpoint: Option<IpAddr>,
 }
 
 impl Default for RenderPlan<'_> {
     fn default() -> Self {
         Self {
-            tunnel: None,
+            carrier: None,
             mixed: DEFAULT_MIXED_PORT,
             api: 1821,
             secret: "",
@@ -700,14 +738,13 @@ impl Default for RenderPlan<'_> {
             bypass_iran_sites: false,
             exit_chain: true,
             tun: false,
-            endpoint: None,
         }
     }
 }
 
 fn render(plan: &RenderPlan) -> String {
     let RenderPlan {
-        tunnel,
+        carrier,
         mixed,
         api,
         secret,
@@ -716,7 +753,6 @@ fn render(plan: &RenderPlan) -> String {
         bypass_iran_sites,
         exit_chain,
         tun,
-        endpoint,
     } = *plan;
     let mut config = String::new();
     config.push_str(&format!("mixed-port: {mixed}\n"));
@@ -792,18 +828,25 @@ fn render(plan: &RenderPlan) -> String {
     // countries -- which is both a leak and a mismatch anyone can see.
     config.push_str("  respect-rules: true\n");
 
-    // Declared only when there is a tunnel to declare. A socks5 proxy pointing
+    // Declared only when there is a carrier to declare. A socks5 proxy pointing
     // at a port nothing is listening on would fail every node it fronted.
-    let (through, fetch_through) = match tunnel {
-        Some(address) => {
+    let (through, fetch_through) = match carrier {
+        Some(carrier) => {
+            let name = carrier.proxy_name();
+            // `udp` is the carrier's answer, not a constant. A carrier that
+            // cannot carry datagrams and is declared as though it can swallows
+            // every one of them: DNS and QUIC hang rather than failing, and
+            // neither falls back because nothing told them to. The REJECT rule
+            // below is the other half of the same statement.
             config.push_str(&format!(
-                "proxies:\n  - {{name: {TUNNEL_PROXY}, type: socks5, server: {}, port: {}, udp: true}}\n",
-                address.ip(),
-                address.port()
+                "proxies:\n  - {{name: {name}, type: socks5, server: {}, port: {}, udp: {}}}\n",
+                carrier.socks.ip(),
+                carrier.socks.port(),
+                carrier.carries_udp(),
             ));
             (
-                format!("\n    dialer-proxy: {TUNNEL_PROXY}"),
-                format!("\n    proxy: {TUNNEL_PROXY}"),
+                format!("\n    dialer-proxy: {name}"),
+                format!("\n    proxy: {name}"),
             )
         }
         None => (String::new(), String::new()),
@@ -842,9 +885,17 @@ fn render(plan: &RenderPlan) -> String {
     }
 
     // Where everything that matches nothing else ends up: the second hop when
-    // there is one, otherwise the tunnel itself. A rule that let it take a
+    // there is one, otherwise the carrier itself. A rule that let it take a
     // direct route would put that traffic on the local network in the clear.
-    let catch_all = if exit_chain { EXIT_GROUP } else { TUNNEL_PROXY };
+    //
+    // With neither -- no exit chain and no carrier -- there is nothing to name,
+    // and DIRECT is the only honest answer. `start` refuses that combination
+    // before it can be rendered, so this is a floor rather than a path.
+    let catch_all = match (exit_chain, carrier) {
+        (true, _) => EXIT_GROUP,
+        (false, Some(carrier)) => carrier.proxy_name(),
+        (false, None) => "DIRECT",
+    };
 
     if bypass_iran_sites {
         // Written line by line rather than as one long literal: this is YAML,
@@ -864,24 +915,31 @@ fn render(plan: &RenderPlan) -> String {
 
     config.push_str("rules:\n");
 
-    // First, before anything else can claim it: the tunnel's own traffic.
+    // First, before anything else can claim it: the carrier's own traffic.
     //
-    // `auto-route` points the default route at the TUN device, and the tunnel
-    // is an ordinary program on this machine -- so its packets to Cloudflare
-    // would be captured and handed back to the tunnel that produced them. The
+    // `auto-route` points the default route at the TUN device, and the carrier
+    // is an ordinary program on this machine -- so its packets to the network
+    // would be captured and handed back to the carrier that produced them. The
     // loop is silent and total: nothing reaches the network, including the
     // traffic that would have told anyone why.
     //
     // Matched on the process rather than on the gateway address, because the
     // address is the wrong thing to key on twice over: it is not known at all
-    // until the tunnel has picked one, and it changes under us every time the
-    // tunnel reconnects somewhere else -- either of which leaves the rule
+    // until the carrier has picked one, and it changes under us every time the
+    // carrier reconnects somewhere else -- either of which leaves the rule
     // matching nothing and the loop closed. The process is the same process
     // throughout. The address rule stays as a second line of defence for a
-    // platform where process matching is unavailable.
+    // platform where process matching is unavailable, and only Aether has one
+    // address to name at all: Psiphon and Tor reach many relays, so there the
+    // process rule is the whole of it.
     if tun {
-        config.push_str(&format!("  - PROCESS-NAME,{TUNNEL_PROCESS},DIRECT\n"));
-        if let Some(address) = endpoint {
+        if let Some(carrier) = carrier {
+            config.push_str(&format!(
+                "  - PROCESS-NAME,{},DIRECT\n",
+                carrier.process_name()
+            ));
+        }
+        if let Some(address) = carrier.and_then(|carrier| carrier.endpoint) {
             let prefix = if address.is_ipv4() { 32 } else { 128 };
             // `no-resolve` because the address is already an address, and
             // resolving it would be one more DNS query going through the
@@ -934,6 +992,26 @@ fn render(plan: &RenderPlan) -> String {
         config.push_str("  - DOMAIN-SUFFIX,ir,DIRECT\n");
         config.push_str(&format!("  - RULE-SET,{IRAN_DOMAIN_PROVIDER},DIRECT\n"));
         config.push_str(&format!("  - RULE-SET,{IRAN_IP_PROVIDER},DIRECT\n"));
+    }
+
+    // A carrier that carries no datagrams says so here as well as on the proxy
+    // above, and the two together are what make the failure survivable.
+    //
+    // Declared `udp: false` alone, mihomo has nowhere to send a datagram that
+    // reaches the catch-all and drops it. The application waits: DNS and QUIC
+    // hang while TCP works, which is the hardest shape of broken to recognise
+    // and reads as "the internet is slow" rather than as anything to report.
+    // Refused outright, a resolver retries the same query over TCP and a
+    // browser drops off QUIC, both within a round trip.
+    //
+    // Last before the catch-all, so everything already sent DIRECT above --
+    // the carrier's own traffic, the local network, Iranian sites -- keeps its
+    // datagrams. Only what would have crossed the carrier is refused.
+    //
+    // DNS still resolves throughout: the resolvers configured above are
+    // DNS-over-HTTPS, which is TCP.
+    if carrier.is_some_and(|carrier| !carrier.carries_udp()) {
+        config.push_str("  - NETWORK,udp,REJECT\n");
     }
 
     config.push_str(&format!("  - MATCH,{catch_all}\n"));
@@ -1254,8 +1332,30 @@ mod tests {
         ChainSource { name: name.into(), url: url.into(), enabled: true }
     }
 
-    fn tunnel() -> Option<SocketAddr> {
-        Some("127.0.0.1:1819".parse().unwrap())
+    /// The Aether engine, up and carrying, with no gateway picked yet.
+    fn tunnel() -> Option<Carrier> {
+        Some(Carrier {
+            kind: CarrierKind::Aether,
+            socks: "127.0.0.1:1819".parse().unwrap(),
+            endpoint: None,
+            carries_quic: false,
+        })
+    }
+
+    /// The same, once a gateway is known.
+    fn tunnel_via(endpoint: &str) -> Option<Carrier> {
+        Some(Carrier {
+            endpoint: Some(endpoint.parse().unwrap()),
+            ..tunnel().unwrap()
+        })
+    }
+
+    /// A carrier that is not Aether, for the properties that differ by kind.
+    fn carrier_of(kind: CarrierKind) -> Option<Carrier> {
+        Some(Carrier {
+            kind,
+            ..tunnel().unwrap()
+        })
     }
 
     #[test]
@@ -1265,7 +1365,7 @@ mod tests {
         // local network and leaving the exit address unchanged.
         let sources = [source("ours", "https://example.com/a"), source("theirs", "https://example.com/b")];
         let refs: Vec<&ChainSource> = sources.iter().collect();
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, manual: "vless://pasted", ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, manual: "vless://pasted", ..Default::default() });
 
         let providers = config.matches("dialer-proxy: aether").count();
         assert_eq!(providers, 3, "two subscriptions and the pasted block, all behind the tunnel");
@@ -1279,7 +1379,7 @@ mod tests {
         // cache, and the screen showed one stale node out of seven.
         let sources = [source("ours", "https://example.com/a")];
         let refs: Vec<&ChainSource> = sources.iter().collect();
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
         assert!(config.contains("\n    proxy: aether"), "the fetch must name the tunnel");
         // And the nodes it carries still dial through the tunnel: these are two
         // different routes and setting one must not have replaced the other.
@@ -1301,8 +1401,8 @@ mod tests {
         // could not refresh.
         let old = [source("ours", "https://example.com/old")];
         let new = [source("ours", "https://example.com/new")];
-        let old_config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &old.iter().collect::<Vec<_>>(), ..Default::default() });
-        let new_config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &new.iter().collect::<Vec<_>>(), ..Default::default() });
+        let old_config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &old.iter().collect::<Vec<_>>(), ..Default::default() });
+        let new_config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &new.iter().collect::<Vec<_>>(), ..Default::default() });
         let path_of = |config: &str| {
             config
                 .lines()
@@ -1321,7 +1421,7 @@ mod tests {
         // nothing which could actually leave this network is: the catch-all
         // must be the exit, and every direct rule must name a range that is
         // unroutable from outside.
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://pasted", ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://pasted", ..Default::default() });
         assert!(config.contains("MATCH,exit"));
         assert!(!config.contains("MATCH,DIRECT"), "the catch-all must never be direct");
 
@@ -1341,7 +1441,7 @@ mod tests {
     fn dns_resolves_inside_the_chain() {
         // A query that escapes names the destination even when the traffic does
         // not, which is the most common way a chain like this leaks.
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
         assert!(config.contains("enhanced-mode: fake-ip"));
         assert!(config.contains("https://1.1.1.1/dns-query"));
         assert!(!config.contains("\n    - 8.8.8.8"), "a plain resolver would leave the chain");
@@ -1349,7 +1449,7 @@ mod tests {
 
     #[test]
     fn the_control_api_is_never_exposed() {
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s3cret", manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s3cret", manual: "vless://x", ..Default::default() });
         assert!(config.contains("external-controller: 127.0.0.1:1821"));
         assert!(config.contains("secret: \"s3cret\""));
     }
@@ -1360,7 +1460,7 @@ mod tests {
         off.enabled = false;
         let on = source("on", "https://example.com/on");
         let refs: Vec<&ChainSource> = vec![&on];
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
         assert!(config.contains("example.com/on"));
         assert!(!config.contains("example.com/off"));
         let _ = off;
@@ -1369,7 +1469,7 @@ mod tests {
     #[test]
     fn full_tunnel_declares_a_device_and_hijacks_dns() {
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1389,7 +1489,7 @@ mod tests {
         // hijacking is what stops the query leaving in the clear beside a
         // tunnelled connection.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1405,7 +1505,7 @@ mod tests {
         // Without this, those queries take a direct route whatever the traffic
         // does -- so the resolver and the exit end up in different countries,
         // which is both a leak and a mismatch anyone can see on a leak test.
-        let config = render(&RenderPlan { tunnel: tunnel(), manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), manual: "vless://x", ..Default::default() });
         assert!(config.contains("respect-rules: true"), "{config}");
         // Resolving the proxies' own names cannot go through the proxies.
         assert!(config.contains("proxy-server-nameserver:"), "{config}");
@@ -1418,7 +1518,7 @@ mod tests {
     #[test]
     fn without_full_tunnel_no_device_is_declared() {
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             manual: "vless://x",
             ..Default::default()
         });
@@ -1434,10 +1534,9 @@ mod tests {
         // handed back to the tunnel that produced them -- taking everything
         // down including whatever would have explained why.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel_via("162.159.198.2"),
             manual: "vless://x",
             tun: true,
-            endpoint: Some("162.159.198.2".parse().unwrap()),
             ..Default::default()
         });
         assert!(
@@ -1448,7 +1547,7 @@ mod tests {
         // until a gateway has been picked and changes on every reconnect, so a
         // rule keyed on it alone leaves the loop closed exactly when it matters.
         assert!(
-            config.contains(&format!("- PROCESS-NAME,{TUNNEL_PROCESS},DIRECT")),
+            config.contains(&format!("- PROCESS-NAME,{},DIRECT", CarrierKind::Aether.process_name())),
             "{config}"
         );
         // And it has to be the first rule, or a rule above it could claim the
@@ -1466,7 +1565,7 @@ mod tests {
         // there and is retried by Windows on some other adapter -- which is
         // how a query escapes a tunnel that looked complete.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1500,14 +1599,13 @@ mod tests {
         // matches nothing, and every packet the tunnel sends is handed back to
         // the tunnel -- so the exemption cannot depend on knowing it.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             manual: "vless://x",
             tun: true,
-            endpoint: None,
             ..Default::default()
         });
         assert!(
-            config.contains(&format!("- PROCESS-NAME,{TUNNEL_PROCESS},DIRECT")),
+            config.contains(&format!("- PROCESS-NAME,{},DIRECT", CarrierKind::Aether.process_name())),
             "{config}"
         );
         // The gateway rule is the one that cannot be written without an
@@ -1531,10 +1629,9 @@ mod tests {
         // reach a gateway on the open internet. With it on, the connection
         // went away entirely once the exit chain was in the path.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel_via("162.159.198.2"),
             manual: "vless://x",
             tun: true,
-            endpoint: Some("162.159.198.2".parse().unwrap()),
             ..Default::default()
         });
         assert!(!config.contains("strict-route"), "{config}");
@@ -1545,10 +1642,9 @@ mod tests {
         // /32 on an IPv6 address would silently exempt a sixteenth of the
         // internet rather than one host.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel_via("2606:4700:d0::a29f:c602"),
             manual: "vless://x",
             tun: true,
-            endpoint: Some("2606:4700:d0::a29f:c602".parse().unwrap()),
             ..Default::default()
         });
         assert!(config.contains("- IP-CIDR,2606:4700:d0::a29f:c602/128,DIRECT,no-resolve"), "{config}");
@@ -1561,7 +1657,7 @@ mod tests {
         // the tunnel itself -- pointing at a group that was never declared
         // would be a config mihomo rejects.
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             exit_chain: false,
             tun: true,
             ..Default::default()
@@ -1576,7 +1672,7 @@ mod tests {
         let source = source("ours", "https://example.com/a");
         let refs: Vec<&ChainSource> = vec![&source];
         let config = render(&RenderPlan {
-            tunnel: tunnel(),
+            carrier: tunnel(),
             sources: &refs,
             tun: true,
             ..Default::default()
@@ -1600,7 +1696,7 @@ mod tests {
 
     #[test]
     fn iran_bypass_adds_rule_providers_ahead_of_the_exit_group() {
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", bypass_iran_sites: true, ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", bypass_iran_sites: true, ..Default::default() });
         assert!(config.contains("DOMAIN-SUFFIX,ir,DIRECT"));
         assert!(config.contains("RULE-SET,iran-domain,DIRECT"));
         assert!(config.contains("RULE-SET,iran-ip,DIRECT"));
@@ -1617,7 +1713,7 @@ mod tests {
     fn without_the_iran_bypass_no_rule_provider_is_declared() {
         // The default: nothing here should change for someone who never
         // touched the setting.
-        let config = render(&RenderPlan { tunnel: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
         assert!(!config.contains("rule-providers"));
         assert!(!config.contains("DOMAIN-SUFFIX,ir"));
         assert_eq!(config.matches("MATCH,exit").count(), 1);
@@ -1659,17 +1755,227 @@ mod tests {
     }
 
     #[test]
-    fn quic_protocols_are_named_as_unusable_behind_the_tunnel() {
+    fn quic_protocols_are_named_as_unusable_behind_the_carrier() {
         // Measured on a live connection: Cloudflare's connect-ip capsule carries
         // 1306 bytes of inner packet, and a QUIC handshake needs 1308. The node
         // is fine -- the same one answers in under a second dialled directly --
         // so reporting it as unreachable sends people looking for a fault that
         // is not there.
         for kind in ["Hysteria2", "hysteria", "Tuic"] {
-            let reason = unusable_behind_the_tunnel(kind).expect("QUIC cannot be carried");
+            let reason = unusable_behind_the_carrier(kind, Some(CarrierKind::Aether)).expect("QUIC cannot be carried");
             assert!(reason.contains(kind), "the reason should name the protocol: {reason}");
             assert!(reason.contains("Dial nodes through the tunnel"), "say what to do: {reason}");
         }
+    }
+
+    /// The gate for making the carrier a parameter: the config rendered for
+    /// Aether has to be exactly what it was when its name was three constants.
+    ///
+    /// Written out in full rather than checked property by property, because
+    /// the risk being guarded against is not a rule that changed meaning -- the
+    /// other tests cover those -- it is a line that moved, vanished, or gained
+    /// a space while the constants were being threaded through. YAML notices
+    /// all three and none of them would fail an assertion about content.
+    ///
+    /// Update it deliberately when the rendering is meant to change.
+    #[test]
+    fn the_aether_path_renders_exactly_what_it_did_before_carriers() {
+        let source = ChainSource {
+            name: "ours".into(),
+            url: "https://example.com/sub".into(),
+            enabled: true,
+        };
+        let refs: Vec<&ChainSource> = vec![&source];
+        let config = render(&RenderPlan {
+            carrier: tunnel_via("162.159.198.2"),
+            mixed: 1820,
+            api: 1821,
+            secret: "s3cret",
+            sources: &refs,
+            manual: "vless://pasted",
+            bypass_iran_sites: false,
+            exit_chain: true,
+            tun: true,
+        });
+        let expected = concat!(
+            "mixed-port: 1820\n",
+            "external-controller: 127.0.0.1:1821\n",
+            "secret: \"s3cret\"\n",
+            "mode: rule\nlog-level: info\nipv6: true\n",
+            "tun:\n",
+            "  enable: true\n",
+            "  stack: gvisor\n",
+            "  device: WhiteAesther\n",
+            "  auto-route: true\n",
+            "  auto-detect-interface: true\n",
+            "  dns-hijack:\n    - any:53\n    - tcp://any:53\n",
+            "dns:\n",
+            "  enable: true\n",
+            "  ipv6: true\n",
+            "  enhanced-mode: fake-ip\n",
+            "  fake-ip-range: 198.18.0.1/16\n",
+            "  fake-ip-filter:\n    - \"*.lan\"\n    - \"*.local\"\n    - \"*.home.arpa\"\n",
+            "  default-nameserver:\n    - 1.1.1.1\n    - 9.9.9.9\n",
+            "  nameserver:\n    - https://1.1.1.1/dns-query\n    - https://dns.google/dns-query\n",
+            "  proxy-server-nameserver:\n    - https://1.1.1.1/dns-query\n",
+            "  respect-rules: true\n",
+            "proxies:\n  - {name: aether, type: socks5, server: 127.0.0.1, port: 1819, udp: true}\n",
+            "proxy-providers:\n",
+            "  source0:\n    type: http\n    url: \"https://example.com/sub\"\n    interval: 3600\n    ",
+            "path: ./providers/be832933271178f6.yaml\n    proxy: aether\n    dialer-proxy: aether\n    ",
+            "health-check: {enable: true, url: \"http://www.gstatic.com/generate_204\", interval: 300, lazy: true}\n",
+            "  manual:\n    type: file\n    path: ./providers/manual.txt\n    dialer-proxy: aether\n    ",
+            "health-check: {enable: true, url: \"http://www.gstatic.com/generate_204\", interval: 300, lazy: true}\n",
+            "proxy-groups:\n  - name: exit\n    type: select\n    use: [source0, manual]\n",
+            "rules:\n",
+            "  - PROCESS-NAME,aether.exe,DIRECT\n",
+            "  - IP-CIDR,162.159.198.2/32,DIRECT,no-resolve\n",
+            "  - IP-CIDR,10.0.0.0/8,DIRECT,no-resolve\n",
+            "  - IP-CIDR,172.16.0.0/12,DIRECT,no-resolve\n",
+            "  - IP-CIDR,192.168.0.0/16,DIRECT,no-resolve\n",
+            "  - IP-CIDR,127.0.0.0/8,DIRECT,no-resolve\n",
+            "  - IP-CIDR,169.254.0.0/16,DIRECT,no-resolve\n",
+            "  - IP-CIDR,100.64.0.0/10,DIRECT,no-resolve\n",
+            "  - IP-CIDR,224.0.0.0/4,DIRECT,no-resolve\n",
+            "  - IP-CIDR6,fc00::/7,DIRECT,no-resolve\n",
+            "  - IP-CIDR6,fe80::/10,DIRECT,no-resolve\n",
+            "  - MATCH,exit\n",
+        );
+        assert_eq!(config, expected, "the Aether path must render unchanged");
+    }
+
+    #[test]
+    fn the_remedy_offered_matches_the_carrier_that_cannot_carry_it() {
+        // Aether over MASQUE is 28 bytes short and WireGuard closes the gap, so
+        // there is something to switch. Tor carries no datagrams at all and no
+        // setting changes that -- offering the same advice there sends someone
+        // to a control that cannot help them, which is the same fault as a
+        // control that saves and does nothing.
+        let aether = unusable_behind_the_carrier("Hysteria2", Some(CarrierKind::Aether))
+            .expect("QUIC cannot be carried");
+        assert!(aether.contains("WireGuard"), "{aether}");
+
+        let tor = unusable_behind_the_carrier("Hysteria2", Some(CarrierKind::Tor))
+            .expect("QUIC cannot be carried");
+        assert!(!tor.contains("WireGuard"), "Tor has no transport to switch to: {tor}");
+        assert!(tor.contains("no datagrams"), "say why it cannot: {tor}");
+    }
+
+    #[test]
+    fn a_carrier_that_cannot_carry_datagrams_says_so_twice() {
+        // Once on the proxy and once in the rules, and both are needed. The
+        // declaration alone leaves mihomo dropping datagrams that reach the
+        // catch-all, and the application waits rather than failing -- DNS and
+        // QUIC hang while TCP works. Refused, a resolver retries over TCP and a
+        // browser drops off QUIC, both within a round trip.
+        let config = render(&RenderPlan {
+            carrier: carrier_of(CarrierKind::Tor),
+            manual: "vless://x",
+            ..Default::default()
+        });
+        assert!(config.contains("udp: false"), "the proxy must not claim UDP: {config}");
+        assert!(config.contains("  - NETWORK,udp,REJECT\n"), "{config}");
+
+        // And the refusal has to come after everything sent DIRECT and before
+        // the catch-all, or it takes the local network and the carrier's own
+        // traffic down with it.
+        let rules = config.split("rules:\n").nth(1).expect("a rules section");
+        let private = rules.find("192.168.0.0/16").expect("the private rule");
+        let reject = rules.find("NETWORK,udp,REJECT").expect("the refusal");
+        let catch_all = rules.find("MATCH,").expect("the catch-all");
+        assert!(private < reject, "the local network keeps its datagrams");
+        assert!(reject < catch_all, "the refusal must precede the default route");
+    }
+
+    #[test]
+    fn a_carrier_that_carries_datagrams_refuses_none_of_them() {
+        for kind in [CarrierKind::Aether, CarrierKind::Psiphon] {
+            let config = render(&RenderPlan {
+                carrier: carrier_of(kind),
+                manual: "vless://x",
+                ..Default::default()
+            });
+            assert!(config.contains("udp: true"), "{kind:?}: {config}");
+            assert!(
+                !config.contains("NETWORK,udp,REJECT"),
+                "{kind:?} carries datagrams and must not refuse them: {config}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_carrier_is_named_by_its_own_proxy_and_exempts_its_own_process() {
+        // The proxy name is what every node's dialer-proxy points at, and the
+        // process is what stays out of the TUN device. Rendering Aether's names
+        // under another carrier would put every node behind a proxy that does
+        // not exist, and feed that carrier's own packets back into itself.
+        for kind in [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor] {
+            let config = render(&RenderPlan {
+                carrier: carrier_of(kind),
+                manual: "vless://x",
+                tun: true,
+                ..Default::default()
+            });
+            assert!(
+                config.contains(&format!("name: {}, type: socks5", kind.proxy_name())),
+                "{kind:?}: {config}"
+            );
+            assert!(
+                config.contains(&format!("dialer-proxy: {}", kind.proxy_name())),
+                "{kind:?}: {config}"
+            );
+            assert!(
+                config.contains(&format!("- PROCESS-NAME,{},DIRECT", kind.process_name())),
+                "{kind:?}: {config}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_carrier_with_no_second_hop_is_still_where_everything_goes() {
+        // Without an exit chain the catch-all names the carrier itself. Under
+        // Psiphon or Tor that is the only thing carrying traffic, so a
+        // catch-all that named DIRECT -- or Aether, by leftover constant --
+        // would put the whole machine on the local network in the clear.
+        for kind in [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor] {
+            let config = render(&RenderPlan {
+                carrier: carrier_of(kind),
+                exit_chain: false,
+                tun: true,
+                ..Default::default()
+            });
+            assert!(
+                config.contains(&format!("  - MATCH,{}\n", kind.proxy_name())),
+                "{kind:?}: {config}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_carrier_with_a_gateway_gets_an_address_exemption() {
+        // Aether connects to one gateway and it is worth naming as a second
+        // line of defence. Psiphon and Tor reach many relays and have no one
+        // address to write, so there the process rule is the whole of it --
+        // and an exemption invented for them would name the wrong host.
+        let aether = render(&RenderPlan {
+            carrier: tunnel_via("162.159.198.2"),
+            manual: "vless://x",
+            tun: true,
+            ..Default::default()
+        });
+        assert!(aether.contains("- IP-CIDR,162.159.198.2/32,DIRECT,no-resolve"), "{aether}");
+
+        let tor = render(&RenderPlan {
+            carrier: carrier_of(CarrierKind::Tor),
+            manual: "vless://x",
+            tun: true,
+            ..Default::default()
+        });
+        assert!(!tor.contains("162.159.198.2"), "{tor}");
+        assert!(
+            tor.contains(&format!("- PROCESS-NAME,{},DIRECT", CarrierKind::Tor.process_name())),
+            "the process rule carries it alone: {tor}"
+        );
     }
 
     #[test]
@@ -1721,14 +2027,14 @@ mod tests {
         // WireGuard has 60 bytes of room the MASQUE path does not, which is the
         // whole difference between a hysteria2 node that works behind the
         // tunnel and one that never completes a handshake.
-        let reason = unusable_behind_the_tunnel("Hysteria2").expect("QUIC needs the bigger MTU");
+        let reason = unusable_behind_the_carrier("Hysteria2", Some(CarrierKind::Aether)).expect("QUIC needs the bigger MTU");
         assert!(reason.contains("WireGuard"), "say which way out there is: {reason}");
     }
 
     #[test]
     fn everything_that_runs_over_tcp_is_left_alone() {
         for kind in ["Vless", "Trojan", "Vmess", "Shadowsocks", "?"] {
-            assert!(unusable_behind_the_tunnel(kind).is_none(), "{kind} works behind the tunnel");
+            assert!(unusable_behind_the_carrier(kind, Some(CarrierKind::Aether)).is_none(), "{kind} works behind the tunnel");
         }
     }
 
@@ -1808,17 +2114,27 @@ mod config_dump {
         };
         let refs: Vec<&ChainSource> = vec![&source];
         let config = render(&RenderPlan {
-            tunnel: Some("127.0.0.1:1819".parse().unwrap()),
+            // All three set from the environment so one dump can cover any
+            // shape: which carrier, whether a device is held up, and whether a
+            // gateway has been picked.
+            carrier: Some(Carrier {
+                kind: match std::env::var("WHITEAESTHER_CONFIG_DUMP_CARRIER").as_deref() {
+                    Ok("psiphon") => CarrierKind::Psiphon,
+                    Ok("tor") => CarrierKind::Tor,
+                    _ => CarrierKind::Aether,
+                },
+                socks: "127.0.0.1:1819".parse().unwrap(),
+                endpoint: std::env::var("WHITEAESTHER_CONFIG_DUMP_ENDPOINT")
+                    .ok()
+                    .and_then(|value| value.parse().ok()),
+                carries_quic: false,
+            }),
             mixed: 1820,
             api: 1821,
             secret: "secret",
             sources: &refs,
             bypass_iran_sites: true,
-            // Set from the environment so one dump can cover either shape.
             tun: std::env::var("WHITEAESTHER_CONFIG_DUMP_TUN").is_ok(),
-            endpoint: std::env::var("WHITEAESTHER_CONFIG_DUMP_ENDPOINT")
-                .ok()
-                .and_then(|value| value.parse().ok()),
             ..Default::default()
         });
         std::fs::write(&out, config).unwrap();

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -1797,7 +1797,15 @@ mod tests {
             exit_chain: true,
             tun: true,
         });
-        let expected = concat!(
+        // The process name is the one line here that differs by platform --
+        // `aether.exe` on Windows and `aether` everywhere else -- so it is
+        // asked for rather than written in. Hardcoded, this test passed on
+        // Windows and failed on macOS and Linux for a reason that had nothing
+        // to do with what it is checking.
+        let expected = format!(
+            "{head}  - PROCESS-NAME,{process},DIRECT\n{tail}",
+            process = CarrierKind::Aether.process_name(),
+            head = concat!(
             "mixed-port: 1820\n",
             "external-controller: 127.0.0.1:1821\n",
             "secret: \"s3cret\"\n",
@@ -1828,7 +1836,8 @@ mod tests {
             "health-check: {enable: true, url: \"http://www.gstatic.com/generate_204\", interval: 300, lazy: true}\n",
             "proxy-groups:\n  - name: exit\n    type: select\n    use: [source0, manual]\n",
             "rules:\n",
-            "  - PROCESS-NAME,aether.exe,DIRECT\n",
+            ),
+            tail = concat!(
             "  - IP-CIDR,162.159.198.2/32,DIRECT,no-resolve\n",
             "  - IP-CIDR,10.0.0.0/8,DIRECT,no-resolve\n",
             "  - IP-CIDR,172.16.0.0/12,DIRECT,no-resolve\n",
@@ -1840,6 +1849,7 @@ mod tests {
             "  - IP-CIDR6,fc00::/7,DIRECT,no-resolve\n",
             "  - IP-CIDR6,fe80::/10,DIRECT,no-resolve\n",
             "  - MATCH,exit\n",
+            ),
         );
         assert_eq!(config, expected, "the Aether path must render unchanged");
     }

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -12,6 +12,7 @@ use std::{
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use crate::carrier::{Carrier, CarrierKind};
 use crate::chain::{Chain, ChainRequest, ChainSettings};
 use crate::http_bridge::{self, HttpBridge};
 use crate::lan_share::{LanDoor, LanSettings, LanStatus};
@@ -35,6 +36,13 @@ const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 #[serde(default, rename_all = "camelCase")]
 pub struct CoreProfile {
     pub name: String,
+    /// Which way out of the network to use.
+    ///
+    /// Everything below it describes the Aether engine and applies only when
+    /// this is `Aether`. A profile saved before carriers existed names none,
+    /// which reads as `Aether` -- see [`CarrierKind`].
+    #[serde(default)]
+    pub carrier: CarrierKind,
     pub protocol: String,
     pub masque_transport: String,
     pub scan_mode: String,
@@ -124,6 +132,12 @@ pub struct CoreProfile {
     pub auto_reconnect: bool,
     /// The second hop, and where its nodes come from.
     pub chain: ChainSettings,
+    /// How the Psiphon carrier should run. Ignored unless `carrier` selects it.
+    #[serde(default)]
+    pub psiphon: crate::psiphon::PsiphonSettings,
+    /// How the Tor carrier should run. Ignored unless `carrier` selects it.
+    #[serde(default)]
+    pub tor: crate::tor::TorSettings,
     /// Whether other devices on this network may use the tunnel, and on what
     /// terms.
     #[serde(default)]
@@ -148,6 +162,7 @@ impl Default for CoreProfile {
     fn default() -> Self {
         Self {
             name: "Adaptive · Iran".into(),
+            carrier: CarrierKind::Aether,
             protocol: "masque".into(),
             masque_transport: "h2".into(),
             scan_mode: "balanced".into(),
@@ -169,6 +184,8 @@ impl Default for CoreProfile {
             keepalive_secs: 25,
             auto_reconnect: true,
             chain: ChainSettings::default(),
+            psiphon: crate::psiphon::PsiphonSettings::default(),
+            tor: crate::tor::TorSettings::default(),
             lan_share: LanSettings::default(),
             kill_switch: false,
             noize: "balanced".into(),
@@ -541,30 +558,26 @@ impl CoreSupervisor {
         (snapshot.state == "connected").then(|| snapshot.socks_address.clone())
     }
 
-    /// The gateway the tunnel is connected to, as an address.
-    ///
-    /// Full tunnel needs it: with the default route pointing into the TUN
-    /// device, the tunnel's own packets to this address would be captured and
-    /// handed back to the tunnel that produced them.
-    pub fn endpoint_address(&self) -> Option<IpAddr> {
-        let snapshot = lock(&self.inner.snapshot);
-        snapshot
-            .endpoint
-            .as_deref()?
-            .parse::<SocketAddr>()
-            .ok()
-            .map(|address| address.ip())
-    }
-
     /// Whether the first hop can carry a QUIC handshake.
     ///
     /// MASQUE cannot and WireGuard can, and the difference is 28 bytes: see
-    /// [`crate::chain::unusable_behind_the_tunnel`]. Reported rather than
+    /// [`crate::chain::unusable_behind_the_carrier`]. Reported rather than
     /// worked out in the chain, because only the supervisor knows which
     /// transport actually came up -- a profile set to MASQUE can fall back.
     pub fn carries_quic(&self) -> bool {
         let snapshot = lock(&self.inner.snapshot);
         !matches!(snapshot.transport.as_deref(), Some("masque-h2") | Some("masque-h3"))
+    }
+
+    /// This engine as a carrier, or `None` when it is not carrying anything.
+    ///
+    /// One reader instead of three. The listener, the gateway and whether QUIC
+    /// fits were previously asked for separately at every call site and
+    /// assembled there, which meant each one could be taken from a different
+    /// moment -- and one of them, the gateway, was read under a second lock
+    /// after the first had been dropped. Here they come from one snapshot.
+    pub fn carrier(&self, app: &AppHandle) -> Option<Carrier> {
+        current_carrier(app, &self.inner)
     }
 
     /// Records a line from something the app runs alongside the core.
@@ -719,6 +732,27 @@ fn start_core_blocking(
         attempt: 0,
     });
 
+    // A carrier that is not the engine takes an entirely different path: there
+    // is no gateway to hunt, no transport to alternate, and nothing to read out
+    // of log prose. The session above is still claimed first, so a stop and a
+    // second connect behave the same way whichever carrier is running.
+    if profile.carrier != CarrierKind::Aether {
+        return match start_carrier_blocking(app, inner, &profile, generation) {
+            Ok(snapshot) => Ok(snapshot),
+            Err(error) => {
+                *lock(&inner.session) = None;
+                stop_carriers(app);
+                let mut snapshot = lock(&inner.snapshot);
+                snapshot.state = "error".into();
+                snapshot.pid = None;
+                snapshot.status_message = None;
+                snapshot.last_error = Some(error.clone());
+                mark_snapshot_dirty(inner);
+                Err(error)
+            }
+        };
+    }
+
     match launch(app, inner, &profile, 0, generation) {
         Ok(()) => Ok(lock(&inner.snapshot).clone()),
         Err(error) => {
@@ -726,6 +760,139 @@ fn start_core_blocking(
             Err(error)
         }
     }
+}
+
+/// Brings up a carrier that is not the Aether engine, and everything behind it.
+///
+/// Blocking to the same point the engine path is: it returns once there is a
+/// route or a reason there is not. The order matters and is the same order the
+/// engine path settled on -- the carrier first, then mihomo pointed at it, then
+/// the system proxy pointed at whichever listener ended up carrying traffic.
+/// Pointing the machine anywhere before the chain is ready is what once sent
+/// traffic out of the wrong exit at the exact moment the user believed
+/// otherwise.
+fn start_carrier_blocking(
+    app: &AppHandle,
+    inner: &Arc<SupervisorInner>,
+    profile: &CoreProfile,
+    generation: u64,
+) -> Result<CoreSnapshot, String> {
+    {
+        let mut snapshot = lock(&inner.snapshot);
+        *snapshot = CoreSnapshot {
+            state: "connecting".into(),
+            transport: Some(profile.carrier.proxy_name().into()),
+            status_message: Some(format!("Starting {}", profile.carrier.label())),
+            started_at: Some(now_millis()),
+            ..CoreSnapshot::default()
+        };
+        mark_snapshot_dirty(inner);
+    }
+    supervisor_log(
+        inner,
+        "info",
+        format!("carrier {} is starting", profile.carrier.label()),
+    );
+
+    // Each carrier brings itself up its own way and they share nothing but the
+    // shape of the answer: a listener, and something to say about where traffic
+    // is leaving from.
+    let (listener, leaving_from) = match profile.carrier {
+        CarrierKind::Psiphon => {
+            let psiphon = app.state::<crate::psiphon::Psiphon>();
+            let listener = psiphon.start(app, &profile.psiphon)?;
+            // The exit country, when Psiphon has said one.
+            (listener, psiphon.snapshot().exit_region)
+        }
+        CarrierKind::Tor => {
+            let tor = app.state::<crate::tor::Tor>();
+            let listener = tor.start(app, &profile.tor)?;
+            // Tor has no one exit to name -- the relay changes per circuit and
+            // per destination -- so nothing is claimed here rather than a
+            // guess being put in front of someone who would act on it.
+            (listener, None)
+        }
+        // Guarded by the caller, which only reaches this for a non-Aether
+        // carrier. Named rather than left to a wildcard so adding a fourth
+        // carrier fails to compile here instead of silently doing nothing.
+        CarrierKind::Aether => {
+            return Err("the Aether engine does not start through the carrier path".into())
+        }
+    };
+
+    if !inner.is_current(generation) {
+        stop_carriers(app);
+        return Err("the connection was stopped while it was starting".into());
+    }
+
+    {
+        let mut snapshot = lock(&inner.snapshot);
+        snapshot.state = "connected".into();
+        snapshot.socks_address = listener.to_string();
+        snapshot.status_message = None;
+        snapshot.started_at = Some(now_millis());
+        // Reported in the field the engine uses for its gateway, because it
+        // answers the same question the screen is asking: where is this
+        // leaving from.
+        snapshot.endpoint = leaving_from;
+        mark_snapshot_dirty(inner);
+    }
+
+    // mihomo always runs for a carrier, whether or not a second hop was asked
+    // for: it is what owns the interface and routes it into the carrier.
+    let carrier = current_carrier(app, inner)
+        .ok_or("the carrier reported a listener and then stopped carrying traffic")?;
+    let tun = tun_is_possible(inner, profile.full_tunnel);
+    let chain = app.state::<Chain>();
+    let chain_listener = match chain.start(
+        app,
+        &ChainRequest {
+            carrier: Some(carrier),
+            settings: &profile.chain,
+            bypass_iran_sites: profile.bypass_iran_sites,
+            tun,
+        },
+    ) {
+        Ok(address) => {
+            supervisor_log(inner, "info", format!("chain listening on {address}"));
+            Some(address)
+        }
+        Err(error) => {
+            // Fatal here, unlike on the engine path. There the tunnel's own
+            // listener is directly usable, so a chain that fails still leaves a
+            // working route; here mihomo *is* the route, and carrying on would
+            // report connected with nothing carrying anything.
+            return Err(format!(
+                "{} is up but the routing engine did not start: {error}",
+                profile.carrier.label()
+            ));
+        }
+    };
+
+    if let Some(address) = chain_listener {
+        app.state::<LanDoor>().retarget(address);
+        if profile.lan_share.enabled {
+            match app.state::<LanDoor>().open(address, &profile.lan_share) {
+                Ok(_) => supervisor_log(inner, "info", "network sharing open".into()),
+                Err(error) => supervisor_log(
+                    inner,
+                    "warn",
+                    format!("could not share on this network: {error}"),
+                ),
+            }
+        }
+        if profile.system_proxy {
+            apply_proxy_route(app, inner, ProxyRoute::Chain(address));
+        }
+    }
+
+    // Nothing was watching the carrier at all until this. Both of them recover
+    // from a dropped connection themselves, so the only failure left to catch
+    // is the process going away -- and when it does, everything above is
+    // pointing at a listener that no longer exists.
+    spawn_carrier_watch(app, inner, generation);
+
+    Ok(lock(&inner.snapshot).clone())
 }
 
 /// Starts one Aether process for `profile` and wires its output back.
@@ -1122,12 +1289,9 @@ pub async fn set_full_tunnel(
         return Err(NEEDS_ADMINISTRATOR.into());
     }
 
-    let Some(socks) = supervisor.connected_socks() else {
+    let Some(carrier) = supervisor.carrier(&app) else {
         return Ok(false);
     };
-    let tunnel = socks
-        .parse::<SocketAddr>()
-        .map_err(|_| format!("the proxy address {socks} cannot be parsed"))?;
 
     if !enabled && !chain_settings.enabled {
         // The engine was only running to hold the device up.
@@ -1139,11 +1303,10 @@ pub async fn set_full_tunnel(
     let address = chain.start(
         &app,
         &ChainRequest {
-            tunnel: Some(tunnel),
+            carrier: Some(carrier),
             settings: &chain_settings,
             bypass_iran_sites,
             tun: enabled,
-            endpoint: supervisor.endpoint_address(),
         },
     )?;
     supervisor_log(
@@ -1196,19 +1359,12 @@ pub async fn set_chain(
     };
 
     let socks = supervisor.connected_socks();
-    let tunnel = match socks.as_deref() {
-        Some(address) => Some(
-            address
-                .parse::<SocketAddr>()
-                .map_err(|_| format!("the proxy address {address} cannot be parsed"))?,
-        ),
-        None => None,
-    };
-    // Without a tunnel the chain can still carry traffic straight to the nodes.
-    // Refusing outright is what left this unusable on a network that resets
-    // MASQUE: the tunnel never came up, so the chain never ran, so nothing the
-    // user configured did anything at all.
-    if tunnel.is_none() && (!settings.enabled || settings.through_tunnel) {
+    let carrier = supervisor.carrier(&app);
+    // Without a carrier the chain can still carry traffic straight to the
+    // nodes. Refusing outright is what left this unusable on a network that
+    // resets MASQUE: the tunnel never came up, so the chain never ran, so
+    // nothing the user configured did anything at all.
+    if carrier.is_none() && (!settings.enabled || settings.through_tunnel) {
         chain.stop();
         return Ok(false);
     }
@@ -1216,15 +1372,14 @@ pub async fn set_chain(
     // The engine also runs to hold up a full-tunnel device, so "is a second hop
     // wanted" is no longer the same question as "should it be running".
     let tun = tun_is_possible(inner, full_tunnel);
-    let started = if settings.enabled || tun {
+    let started = if engine_is_wanted(settings.enabled, tun, carrier) {
         let address = chain.start(
             &app,
             &ChainRequest {
-                tunnel,
+                carrier,
                 settings: &settings,
                 bypass_iran_sites,
                 tun,
-                endpoint: supervisor.endpoint_address(),
             },
         )?;
         supervisor_log(
@@ -1241,8 +1396,8 @@ pub async fn set_chain(
     // Anything pointed at the old listener would go around the change the user
     // just made -- devices on the network included, which is why the shared
     // door is retargeted rather than left to be reconfigured by hand.
-    if let Some(carrier) = started.or_else(|| tunnel) {
-        app.state::<LanDoor>().retarget(carrier);
+    if let Some(listener) = started.or_else(|| carrier.map(|carrier| carrier.socks)) {
+        app.state::<LanDoor>().retarget(listener);
     }
 
     // The proxy has to follow whichever listener is now carrying traffic.
@@ -1268,6 +1423,91 @@ pub async fn set_chain(
         }
     }
     Ok(started.is_some())
+}
+
+/// Moves a live carrier to a different exit country.
+///
+/// Psiphon chooses its egress at handshake time and has no way to be told to
+/// move afterwards, so this is a restart rather than a setting change -- and it
+/// takes the chain with it, because mihomo holds a socks5 proxy pointed at a
+/// port that is about to stop existing.
+///
+/// The order is the same one the connect path uses and for the same reason: the
+/// carrier first, then the engine pointed at it, then the machine pointed at
+/// whichever listener ends up carrying traffic. Doing it the other way round
+/// would leave the system proxy aimed at a dead listener for as long as the new
+/// tunnel took to establish, which on a bad network is a minute of a machine
+/// that cannot reach anything.
+#[tauri::command]
+pub async fn set_psiphon_region(
+    app: AppHandle,
+    supervisor: State<'_, CoreSupervisor>,
+    region: String,
+) -> Result<CoreSnapshot, String> {
+    let inner = supervisor.inner.clone();
+    off_thread("changing the exit country", move || {
+        set_psiphon_region_blocking(&app, &inner, region)
+    })
+    .await
+}
+
+fn set_psiphon_region_blocking(
+    app: &AppHandle,
+    inner: &Arc<SupervisorInner>,
+    region: String,
+) -> Result<CoreSnapshot, String> {
+    let settings = crate::psiphon::PsiphonSettings { egress_region: region.trim().to_string() };
+    settings.validate()?;
+
+    // Remembered whether or not anything is running, so the choice survives to
+    // the next connect rather than being lost when it cannot be applied now.
+    let profile = {
+        let mut guard = lock(&inner.session);
+        match guard.as_mut() {
+            Some(session) => {
+                session.profile.psiphon = settings.clone();
+                Some(session.profile.clone())
+            }
+            None => None,
+        }
+    };
+
+    // Nothing is connected, so there is nothing to move. Not an error: the
+    // screen offers the choice while disconnected too, and it applies at the
+    // next connect.
+    let Some(profile) = profile else {
+        return Ok(lock(&inner.snapshot).clone());
+    };
+    if profile.carrier == CarrierKind::Aether {
+        return Err("the exit country is a Psiphon setting; this connection is using Aether".into());
+    }
+
+    let generation = inner.generation.load(Ordering::SeqCst);
+    {
+        let mut snapshot = lock(&inner.snapshot);
+        snapshot.state = "reconnecting".into();
+        snapshot.status_message = Some(match settings.egress_region.as_str() {
+            "" => "Moving to the best available exit".into(),
+            region => format!("Moving the exit to {region}"),
+        });
+        mark_snapshot_dirty(inner);
+    }
+    supervisor_log(
+        inner,
+        "info",
+        match settings.egress_region.as_str() {
+            "" => "moving the exit to the best available country".into(),
+            region => format!("moving the exit to {region}"),
+        },
+    );
+
+    // The chain goes down with the carrier it points at, and the proxy comes
+    // off the listener that is about to disappear. Both are put back below, on
+    // whatever the new run produces.
+    app.state::<Chain>().stop();
+    clear_system_proxy(app, inner);
+
+    start_carrier_blocking(app, inner, &profile, generation)
 }
 
 #[tauri::command]
@@ -2060,44 +2300,36 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
         // Full tunnel needs the engine running whether or not a second hop was
         // asked for, because the device it holds up is the engine's.
         let full_tunnel = tun_is_possible(inner, full_tunnel);
-        let engine_wanted = chain_settings.enabled || full_tunnel;
-        let carrier = if engine_wanted && !chain.is_running() {
-            let endpoint = lock(&inner.snapshot)
-                .endpoint
-                .as_deref()
-                .and_then(|value| value.parse::<SocketAddr>().ok())
-                .map(|address| address.ip());
-            match socks.parse::<SocketAddr>() {
-                Ok(tunnel) => match chain.start(
-                    app,
-                    &ChainRequest {
-                        tunnel: Some(tunnel),
-                        settings: &chain_settings,
-                        bypass_iran_sites,
-                        tun: full_tunnel,
-                        endpoint,
-                    },
-                ) {
-                    Ok(address) => {
-                        supervisor_log(
-                            inner,
-                            "info",
-                            format!("chain listening on {address}; every node dials through the tunnel"),
-                        );
-                        Some(address)
-                    }
-                    Err(error) => {
-                        // Say which hop failed. "No route" would be a lie: the
-                        // tunnel is up and it is the second hop that did not.
-                        supervisor_log(
-                            inner,
-                            "error",
-                            format!("the tunnel is up but the chain did not start: {error}"),
-                        );
-                        None
-                    }
+        let carrier = current_carrier(app, inner);
+        let engine_wanted = engine_is_wanted(chain_settings.enabled, full_tunnel, carrier);
+        let chain_listener = if engine_wanted && !chain.is_running() {
+            match chain.start(
+                app,
+                &ChainRequest {
+                    carrier,
+                    settings: &chain_settings,
+                    bypass_iran_sites,
+                    tun: full_tunnel,
                 },
-                Err(_) => None,
+            ) {
+                Ok(address) => {
+                    supervisor_log(
+                        inner,
+                        "info",
+                        format!("chain listening on {address}; every node dials through the tunnel"),
+                    );
+                    Some(address)
+                }
+                Err(error) => {
+                    // Say which hop failed. "No route" would be a lie: the
+                    // tunnel is up and it is the second hop that did not.
+                    supervisor_log(
+                        inner,
+                        "error",
+                        format!("the tunnel is up but the chain did not start: {error}"),
+                    );
+                    None
+                }
             }
         } else {
             None
@@ -2106,7 +2338,10 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
         // Whether or not this machine's own proxy is being pointed anywhere,
         // a device on the network that was already sharing must not be left
         // aimed at the listener from the previous session.
-        if let Some(address) = carrier.or_else(|| chain.address()).or_else(|| socks.parse().ok()) {
+        if let Some(address) = chain_listener
+            .or_else(|| chain.address())
+            .or_else(|| socks.parse().ok())
+        {
             let door = app.state::<LanDoor>();
             door.retarget(address);
             // Reconnecting, or starting the app with sharing already switched
@@ -2133,7 +2368,7 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
         }
 
         if wanted {
-            match carrier.or_else(|| chain.address()) {
+            match chain_listener.or_else(|| chain.address()) {
                 // mihomo's mixed listener speaks HTTP itself, so it is what the
                 // system proxy points at and the bridge is not needed at all.
                 Some(address) => apply_proxy_route(app, inner, ProxyRoute::Chain(address)),
@@ -2164,6 +2399,194 @@ fn tunnel_proxy_route(socks: &str, inner: &SupervisorInner) -> Option<ProxyRoute
             None
         }
     }
+}
+
+/// How often to check that the carrier is still there.
+///
+/// Slower than the engine's 350ms exit monitor, and that is proportionate: both
+/// carriers reconnect internally and neither exits on an ordinary network
+/// wobble, so this is watching for a process that has actually gone.
+const CARRIER_WATCH: Duration = Duration::from_secs(2);
+
+/// Notices when a carrier's process dies, and does something about it.
+///
+/// Without this nothing was watching at all. Psiphon and Tor both recover from
+/// a dropped connection on their own, which is exactly why they need a watcher
+/// rather than a retry loop: the only failure left for us to handle is the
+/// process being *gone*, and when that happens the chain goes on pointing at a
+/// SOCKS port nothing is listening on while the screen says connected.
+///
+/// The traffic itself is not leaking in that state -- mihomo has nowhere to
+/// send it, so it fails closed -- but "connected and carrying nothing" is the
+/// exact fault this whole port was written to avoid.
+fn spawn_carrier_watch(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u64) {
+    let app = app.clone();
+    let inner = inner.clone();
+    thread::spawn(move || loop {
+        thread::sleep(CARRIER_WATCH);
+        if !inner.is_current(generation) {
+            return;
+        }
+        let kind = {
+            let session = lock(&inner.session);
+            match session.as_ref() {
+                Some(session) => session.profile.carrier,
+                None => return,
+            }
+        };
+        let alive = match kind {
+            CarrierKind::Psiphon => app.state::<crate::psiphon::Psiphon>().is_alive(),
+            CarrierKind::Tor => app.state::<crate::tor::Tor>().is_alive(),
+            CarrierKind::Aether => return,
+        };
+        if alive {
+            continue;
+        }
+        carrier_died(&app, &inner, generation, kind);
+        return;
+    });
+}
+
+/// Reports a carrier that has gone, and decides what happens to the traffic.
+fn carrier_died(
+    app: &AppHandle,
+    inner: &Arc<SupervisorInner>,
+    generation: u64,
+    kind: CarrierKind,
+) {
+    let holding = {
+        let session = lock(&inner.session);
+        session
+            .as_ref()
+            .is_some_and(|current| current.profile.kill_switch)
+            && proxy_is_applied(inner)
+    };
+
+    {
+        let mut snapshot = lock(&inner.snapshot);
+        if !inner.is_current(generation) {
+            return;
+        }
+        snapshot.state = "error".into();
+        snapshot.pid = None;
+        snapshot.status_message = None;
+        snapshot.blocking = holding;
+        snapshot.last_error = Some(if holding {
+            format!(
+                "{} stopped. Traffic is being held rather than sent in the clear -- disconnect to \
+                 put your system proxy back.",
+                kind.label()
+            )
+        } else {
+            format!("{} stopped.", kind.label())
+        });
+        mark_snapshot_dirty(inner);
+    }
+    supervisor_log(inner, "error", format!("{} stopped unexpectedly", kind.label()));
+
+    // The chain exists only to carry this carrier's traffic; without it, it
+    // would sit there dialling a port nothing answers on. The door other
+    // devices come in through goes for the same reason.
+    app.state::<Chain>().stop();
+    app.state::<LanDoor>().close();
+
+    // The kill switch bites here exactly as it does on the engine path: the
+    // proxy is left pointing at a listener that is gone, so applications fail
+    // rather than falling back to the open network. An explicit disconnect
+    // still puts it back, which is the way out.
+    if holding {
+        supervisor_log(
+            inner,
+            "warn",
+            "the system proxy has been left pointing at the stopped carrier, so traffic fails \
+             instead of leaving in the clear. Disconnect to put it back."
+                .into(),
+        );
+        return;
+    }
+    clear_system_proxy(app, inner);
+}
+
+/// Stops every carrier that is not the engine.
+///
+/// Unconditional rather than keyed on what the profile currently says: the
+/// profile can be changed under a live session, and a carrier left running
+/// after a stop is a process holding a tunnel that nothing is routed into and
+/// nothing will ever stop. Stopping one that was not running costs nothing.
+fn stop_carriers(app: &AppHandle) {
+    app.state::<crate::psiphon::Psiphon>().stop();
+    app.state::<crate::tor::Tor>().stop();
+}
+
+/// The engine as a carrier, read from one snapshot.
+///
+/// A free function because the connect path reaches this from `record_log`,
+/// which holds `inner` and not the supervisor. Everything it reports comes from
+/// a single lock: taken separately, the listener and the gateway could be read
+/// from two different moments, and under a reconnect they were.
+fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> {
+    // Whose listener this is depends on what the session chose. Reading the
+    // engine's snapshot regardless is what would put `aether` in a config that
+    // is actually routing into Psiphon -- a chain pointed at a proxy name
+    // nothing declares, which fails every node with no clue why.
+    let kind = lock(&inner.session)
+        .as_ref()
+        .map_or(CarrierKind::Aether, |session| session.profile.carrier);
+    match kind {
+        CarrierKind::Psiphon => return app.state::<crate::psiphon::Psiphon>().carrier(),
+        CarrierKind::Tor => return app.state::<crate::tor::Tor>().carrier(),
+        CarrierKind::Aether => {}
+    }
+
+    let snapshot = lock(&inner.snapshot);
+    if snapshot.state != "connected" {
+        return None;
+    }
+    // A connected snapshot always has an address -- the only line that sets one
+    // has already parsed it. But "connected with nowhere to send anything" is
+    // the state every caller here reads as "not connected", and a silent
+    // disagreement between the screen and the router is the shape of bug that
+    // costs an afternoon. Say it rather than leave it to be deduced.
+    let Ok(socks) = snapshot.socks_address.parse() else {
+        let address = snapshot.socks_address.clone();
+        drop(snapshot);
+        supervisor_log(
+            inner,
+            "error",
+            format!(
+                "the tunnel reports itself connected on {address}, which is not an address \
+                 anything can be pointed at; treating it as not carrying traffic"
+            ),
+        );
+        return None;
+    };
+    Some(Carrier {
+        kind: CarrierKind::Aether,
+        socks,
+        endpoint: snapshot
+            .endpoint
+            .as_deref()
+            .and_then(|value| value.parse::<SocketAddr>().ok())
+            .map(|address| address.ip()),
+        // Which transport actually came up, not which one was configured: a
+        // profile set to MASQUE can fall back, and the 28-byte shortfall that
+        // stops a QUIC handshake belongs to MASQUE alone.
+        carries_quic: !matches!(
+            snapshot.transport.as_deref(),
+            Some("masque-h2") | Some("masque-h3")
+        ),
+    })
+}
+
+/// Whether mihomo should be running at all.
+///
+/// Three separate reasons, and it used to know two. A carrier that is not
+/// Aether needs the engine even with no second hop and no device: mihomo is
+/// what owns the interface and routes it into the carrier's listener, so
+/// stopping it when the user turns the exit chain off would leave Psiphon or
+/// Tor connected and carrying nothing at all.
+fn engine_is_wanted(chain_enabled: bool, tun: bool, carrier: Option<Carrier>) -> bool {
+    chain_enabled || tun || carrier.is_some_and(|carrier| carrier.kind != CarrierKind::Aether)
 }
 
 /// Whether a second hop is what traffic should be following right now.
@@ -2457,6 +2880,11 @@ fn stop_inner(inner: &SupervisorInner, app: &AppHandle) -> Result<(), String> {
     // fails every one of them.
     app.state::<Chain>().stop();
     app.state::<LanDoor>().close();
+    // Whichever carrier was running. Stopping unconditionally rather than only
+    // when the profile named it: a profile can be changed under a live session,
+    // and a carrier left running after a stop is a process holding a tunnel
+    // nothing is routed into and nothing will ever stop.
+    stop_carriers(app);
     // Invalidate first. A retry sleeping out its backoff has no child to kill,
     // and would otherwise launch a process after the user asked it to stop.
     inner.generation.fetch_add(1, Ordering::SeqCst);
@@ -3263,6 +3691,70 @@ mod tests {
             strip_logger_prefix("ERROR gateway rejected - retrying without encryption - done"),
             "retrying without encryption - done"
         );
+    }
+
+    fn carrier(kind: CarrierKind) -> Option<Carrier> {
+        Some(Carrier {
+            kind,
+            socks: "127.0.0.1:1819".parse().unwrap(),
+            endpoint: None,
+            carries_quic: false,
+        })
+    }
+
+    #[test]
+    fn a_carrier_that_dies_is_not_reported_as_still_carrying_traffic() {
+        // The state the watcher exists for. Both carriers reconnect internally,
+        // so the only failure left is the process being gone -- and nothing
+        // else notices, because the reader thread simply ends when the pipe
+        // closes and leaves the last healthy snapshot sitting there.
+        //
+        // A carrier with no live child is not carrying anything, whatever it
+        // last said about itself.
+        let psiphon = crate::psiphon::Psiphon::new();
+        assert!(!psiphon.is_alive(), "a carrier that was never started is not alive");
+        assert!(psiphon.carrier().is_none());
+
+        let tor = crate::tor::Tor::new();
+        assert!(!tor.is_alive());
+        assert!(tor.carrier().is_none());
+    }
+
+    #[test]
+    fn a_profile_saved_before_carriers_reads_as_aether() {
+        // Every profile on disk predates the field. Reading a missing carrier
+        // as anything else would move existing users onto a way out of the
+        // network they never chose, silently, at the next launch.
+        let stored = serde_json::json!({ "name": "Adaptive · Iran" });
+        let profile: CoreProfile = serde_json::from_value(stored).unwrap();
+        assert_eq!(profile.carrier, CarrierKind::Aether);
+    }
+
+    #[test]
+    fn the_engine_runs_for_a_carrier_with_no_second_hop_and_no_device() {
+        // The arrangement a carrier depends on: mihomo owns the interface and
+        // routes it into whichever carrier is up. Asking only "is an exit chain
+        // wanted" would stop the engine the moment someone turned the second
+        // hop off, leaving Psiphon or Tor connected and carrying nothing.
+        for kind in [CarrierKind::Psiphon, CarrierKind::Tor] {
+            assert!(
+                engine_is_wanted(false, false, carrier(kind)),
+                "{kind:?} needs the engine to carry anything at all"
+            );
+        }
+    }
+
+    #[test]
+    fn aether_alone_still_needs_a_reason_to_run_the_engine() {
+        // Aether's listener is directly usable, so with no second hop and no
+        // device there is nothing for mihomo to do. Starting it regardless
+        // would put a second process and a second port in the path of every
+        // connection that did not ask for one.
+        assert!(!engine_is_wanted(false, false, carrier(CarrierKind::Aether)));
+        assert!(!engine_is_wanted(false, false, None));
+        // The two reasons it did already know about still hold.
+        assert!(engine_is_wanted(true, false, carrier(CarrierKind::Aether)));
+        assert!(engine_is_wanted(false, true, carrier(CarrierKind::Aether)));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod carrier;
 mod chain;
 mod core_supervisor;
 mod elevation;
@@ -5,8 +6,11 @@ mod http_bridge;
 mod iran_routes;
 mod lan_share;
 mod latency;
+mod moat;
+mod psiphon;
 mod scanner;
 mod system_proxy;
+mod tor;
 
 use chain::Chain;
 use core_supervisor::CoreSupervisor;
@@ -48,6 +52,80 @@ async fn chain_status(chain: tauri::State<'_, Chain>) -> Result<ChainStatus, Str
         running: chain.is_running(),
         address: chain.address().map(|value| value.to_string()),
     })
+}
+
+/// What the Psiphon carrier is doing, including the exit countries it has.
+///
+/// The country list is Psiphon's own answer rather than a table of ours, so it
+/// is empty until the first successful connect -- which is honest: we do not
+/// know what it has until it tells us. The screen says "best available" until
+/// then rather than offering countries it cannot promise.
+#[tauri::command]
+fn psiphon_status(psiphon: tauri::State<'_, psiphon::Psiphon>) -> psiphon::PsiphonSnapshot {
+    psiphon.snapshot()
+}
+
+/// The carrier's raw notice stream, for a diagnostics report.
+#[tauri::command]
+fn psiphon_notices(psiphon: tauri::State<'_, psiphon::Psiphon>) -> Vec<String> {
+    psiphon.notices()
+}
+
+/// What Tor is doing, including how far bootstrapping has got.
+///
+/// The progress is worth showing rather than hiding behind a spinner: building
+/// a circuit through a bridge can take tens of seconds, and a percentage that
+/// is visibly moving is the difference between waiting and giving up.
+#[tauri::command]
+fn tor_status(tor: tauri::State<'_, tor::Tor>) -> tor::TorSnapshot {
+    tor.snapshot()
+}
+
+/// Tor's own output, for a diagnostics report.
+#[tauri::command]
+fn tor_log(tor: tauri::State<'_, tor::Tor>) -> Vec<String> {
+    tor.lines()
+}
+
+/// Which carriers this build can actually run.
+///
+/// Not every build ships every carrier: Tor publishes no expert bundle for
+/// arm64 Windows or Linux, so a build for those targets has Aether and Psiphon
+/// and nothing else. The screen reads this rather than offering a way out that
+/// cannot start — a control that saves and does nothing is worse than one that
+/// is absent.
+#[tauri::command]
+fn carriers_available(app: AppHandle) -> Vec<String> {
+    let mut available = vec!["aether".to_string()];
+    if psiphon::is_available(&app) {
+        available.push("psiphon".into());
+    }
+    if tor::is_available(&app) {
+        available.push("tor".into());
+    }
+    available
+}
+
+/// Asks Tor's circumvention service which bridges work in a given country.
+///
+/// Goes out through whichever carrier is up, when one is: the service is itself
+/// blocked in most of the places its answer is wanted, so asking directly there
+/// returns nothing and reads as the service being down.
+///
+/// The country is the user's own, and is asked for rather than inferred. A
+/// desktop has no SIM to read one from, and guessing from the current exit
+/// address would ask about whichever country the carrier is leaving from —
+/// which is the one place the answer does not apply.
+#[tauri::command]
+async fn fetch_bridges(
+    app: AppHandle,
+    supervisor: tauri::State<'_, CoreSupervisor>,
+    country: String,
+) -> Result<Vec<String>, String> {
+    let carrier = supervisor.carrier(&app).map(|carrier| carrier.socks);
+    tauri::async_runtime::spawn_blocking(move || moat::fetch_bridges(&country, carrier))
+        .await
+        .map_err(|error| format!("the bridge request did not finish: {error}"))?
 }
 
 /// Every node the chain knows about, with the delay each last recorded.
@@ -110,6 +188,8 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .manage(CoreSupervisor::new())
         .manage(Chain::new())
+        .manage(psiphon::Psiphon::new())
+        .manage(tor::Tor::new())
         .manage(lan_share::LanDoor::default())
         .setup(|app| {
             // A previous run that was killed rather than closed may have left
@@ -237,6 +317,7 @@ pub fn run() {
             core_supervisor::resuming_full_tunnel,
             core_supervisor::restart_as_administrator,
             core_supervisor::set_lan_share,
+            core_supervisor::set_psiphon_region,
             core_supervisor::lan_share_status,
             scanner::scan_endpoints,
             scanner::test_endpoint,
@@ -248,6 +329,12 @@ pub fn run() {
             chain_nodes,
             chain_test,
             chain_select,
+            psiphon_status,
+            psiphon_notices,
+            tor_status,
+            tor_log,
+            carriers_available,
+            fetch_bridges,
         ])
         .build(tauri::generate_context!())
         .expect("error while running WhiteAesther")

--- a/src-tauri/src/moat.rs
+++ b/src-tauri/src/moat.rs
@@ -1,0 +1,298 @@
+//! Asking Tor's circumvention service which bridges work in a given country.
+//!
+//! The one-tap fetch, and the only thing in this crate that speaks TLS.
+//!
+//! Two properties decide the whole design, and both are the reason this is not
+//! simply a `fetch()` in the window:
+//!
+//! - **It has to go through whichever carrier is up.**
+//!   `bridges.torproject.org` is blocked in most of the places its answer is
+//!   wanted, so asking directly returns nothing and reads as the service being
+//!   down. The webview cannot be pointed at a loopback SOCKS listener per
+//!   request; this can.
+//! - **It asks about the *user's* country, not the exit's.** There is no SIM to
+//!   read one from on a desktop, so the caller passes what the person chose.
+//!   Guessing from the current exit address would ask about whichever country
+//!   the carrier happens to be leaving from, which is the one place the answer
+//!   does not apply.
+
+use std::{
+    io::{Read, Write},
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
+
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+
+use crate::http_bridge::socks5_connect;
+
+const HOST: &str = "bridges.torproject.org";
+const PATH: &str = "/moat/circumvention/settings";
+const TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Bridge lines for `country`, fetched through `carrier` when one is up.
+pub fn fetch_bridges(country: &str, carrier: Option<SocketAddr>) -> Result<Vec<String>, String> {
+    let country = country.trim().to_ascii_lowercase();
+    if country.len() != 2 || !country.chars().all(|c| c.is_ascii_lowercase()) {
+        return Err("choose the country you are connecting from".into());
+    }
+
+    // Plain `{"country": "xx"}`, not the JSON-API envelope the older `/moat`
+    // endpoints take. Measured: sending the envelope to this endpoint gets a
+    // 200 with `{"settings":[],"country":"th"}` -- the country silently ignored
+    // and filled in from the source address instead, which is the one thing
+    // this request exists to override. An empty answer that looks like "no
+    // bridges needed here" is exactly how that mistake hides.
+    let body = serde_json::json!({ "country": country }).to_string();
+
+    let response = post(&body, carrier)?;
+    let parsed: serde_json::Value = serde_json::from_str(&response)
+        .map_err(|error| format!("the bridge service sent something unreadable: {error}"))?;
+    let lines = bridge_lines(&parsed);
+
+    if lines.is_empty() {
+        // A country the service has no answer for is not a failed request, and
+        // reporting it as one sends someone to check their network instead of
+        // trying another way in.
+        return Err(format!(
+            "Tor's bridge service had nothing for {}. Try the built-in bridges, or ask someone \
+             to send you a bridge line.",
+            country.to_uppercase()
+        ));
+    }
+    Ok(lines)
+}
+
+/// Pulls every bridge line out of a moat reply.
+///
+/// Split out so it can be tested against a recorded answer: the shape is
+/// `settings[].bridges.{type,bridge_strings[]}`, and a change to it would
+/// otherwise only show up as an empty list in front of someone who needs one.
+fn bridge_lines(parsed: &serde_json::Value) -> Vec<String> {
+    let mut lines = Vec::new();
+    let Some(settings) = parsed.get("settings").and_then(|value| value.as_array()) else {
+        return lines;
+    };
+    for setting in settings {
+        let Some(bridges) = setting.get("bridges") else {
+            continue;
+        };
+        let transport = bridges
+            .get("type")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default();
+        let Some(list) = bridges.get("bridge_strings").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for line in list.iter().filter_map(|value| value.as_str()) {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            // Some transports answer with the type already on the line and some
+            // do not. tor needs it exactly once: missing, the line is refused;
+            // doubled, so is the whole file.
+            if transport.is_empty() || line.split_whitespace().next() == Some(transport) {
+                lines.push(line.to_string());
+            } else {
+                lines.push(format!("{transport} {line}"));
+            }
+        }
+    }
+    lines
+}
+
+/// One HTTPS POST, over a carrier's SOCKS listener when there is one.
+fn post(body: &str, carrier: Option<SocketAddr>) -> Result<String, String> {
+    let tcp = match carrier {
+        // Domain-name addressing, so the name is resolved at the far end of the
+        // carrier rather than here -- a lookup made locally would name the host
+        // to the network this is trying to get around.
+        Some(address) => socks5_connect(address, HOST, 443, TIMEOUT)
+            .map_err(|error| format!("the carrier refused the connection: {error}"))?,
+        None => {
+            let stream = std::net::TcpStream::connect((HOST, 443))
+                .map_err(|error| format!("cannot reach {HOST}: {error}"))?;
+            stream
+                .set_read_timeout(Some(TIMEOUT))
+                .map_err(|error| error.to_string())?;
+            stream
+        }
+    };
+    tcp.set_read_timeout(Some(TIMEOUT))
+        .map_err(|error| error.to_string())?;
+
+    let roots = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let server = ServerName::try_from(HOST)
+        .map_err(|error| format!("{HOST} is not a valid server name: {error}"))?;
+    let connection = ClientConnection::new(Arc::new(config), server)
+        .map_err(|error| format!("cannot start TLS: {error}"))?;
+    let mut tls = StreamOwned::new(connection, tcp);
+
+    let request = format!(
+        "POST {PATH} HTTP/1.1\r\n\
+         Host: {HOST}\r\n\
+         User-Agent: WhiteAesther\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n{body}",
+        body.len()
+    );
+    tls.write_all(request.as_bytes())
+        .map_err(|error| format!("could not ask the bridge service: {error}"))?;
+
+    let mut raw = Vec::new();
+    // A clean close from the far side arrives as an error in some TLS stacks;
+    // what matters is whether anything was read, so a short read with bytes in
+    // hand is treated as the end of the reply rather than as a failure.
+    if let Err(error) = tls.read_to_end(&mut raw) {
+        if raw.is_empty() {
+            return Err(format!("the bridge service did not answer: {error}"));
+        }
+    }
+
+    let text = String::from_utf8_lossy(&raw);
+    let (head, body) = text
+        .split_once("\r\n\r\n")
+        .ok_or("the bridge service sent an incomplete reply")?;
+    if !head.starts_with("HTTP/1.1 200") && !head.starts_with("HTTP/1.0 200") {
+        let status = head.lines().next().unwrap_or("(no status)");
+        return Err(format!("the bridge service refused the request: {status}"));
+    }
+    Ok(decode_body(head, body))
+}
+
+/// Undoes chunked transfer encoding when the server used it.
+///
+/// `Connection: close` usually gets an unchunked reply, but the header is a
+/// request and not a guarantee -- and a chunked body read as-is has hex length
+/// markers scattered through it, which fails to parse as JSON in a way that
+/// looks like the service returning nonsense.
+fn decode_body(head: &str, body: &str) -> String {
+    if !head.to_ascii_lowercase().contains("transfer-encoding: chunked") {
+        return body.to_string();
+    }
+    let mut out = String::new();
+    let mut rest = body;
+    loop {
+        let Some((size, remainder)) = rest.split_once("\r\n") else {
+            break;
+        };
+        let Ok(length) = usize::from_str_radix(size.trim().split(';').next().unwrap_or("").trim(), 16)
+        else {
+            break;
+        };
+        if length == 0 || remainder.len() < length {
+            break;
+        }
+        out.push_str(&remainder[..length]);
+        rest = remainder[length..].trim_start_matches("\r\n");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_country_is_two_letters_or_the_request_is_refused() {
+        for bad in ["", "irr", "1r", "I"] {
+            assert!(fetch_bridges(bad, None).is_err(), "{bad} should be refused");
+        }
+    }
+
+    #[test]
+    fn bridge_lines_are_pulled_out_of_a_moat_reply() {
+        // The shape the service answers with, recorded rather than imagined.
+        let reply = serde_json::json!({
+            "settings": [
+                { "bridges": { "type": "obfs4", "bridge_strings": [
+                    "obfs4 1.2.3.4:443 FINGERPRINT cert=abc iat-mode=0"
+                ] } },
+                { "bridges": { "type": "webtunnel", "bridge_strings": [
+                    "webtunnel 5.6.7.8:443 FINGERPRINT url=https://example.com/x"
+                ] } }
+            ]
+        });
+        let lines = bridge_lines(&reply);
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        assert!(lines[0].starts_with("obfs4 1.2.3.4"), "{lines:?}");
+        assert!(lines[1].starts_with("webtunnel 5.6.7.8"), "{lines:?}");
+    }
+
+    #[test]
+    fn a_transport_missing_from_the_line_is_put_back_exactly_once() {
+        // tor needs the keyword once. Missing, the line is refused; doubled, so
+        // is the whole torrc -- and the error names a line the user never
+        // typed, because we wrote it.
+        let reply = serde_json::json!({
+            "settings": [
+                { "bridges": { "type": "obfs4", "bridge_strings": ["1.2.3.4:443 FINGERPRINT cert=abc"] } }
+            ]
+        });
+        let lines = bridge_lines(&reply);
+        assert_eq!(lines, vec!["obfs4 1.2.3.4:443 FINGERPRINT cert=abc"]);
+
+        let already = serde_json::json!({
+            "settings": [
+                { "bridges": { "type": "obfs4", "bridge_strings": ["obfs4 1.2.3.4:443 FINGERPRINT"] } }
+            ]
+        });
+        assert_eq!(bridge_lines(&already), vec!["obfs4 1.2.3.4:443 FINGERPRINT"]);
+    }
+
+    #[test]
+    fn an_answer_with_no_bridges_in_it_yields_nothing_rather_than_rubbish() {
+        for empty in [
+            serde_json::json!({}),
+            serde_json::json!({ "settings": [] }),
+            serde_json::json!({ "settings": [{ "bridges": { "type": "obfs4" } }] }),
+            serde_json::json!({ "errors": [{ "detail": "no settings" }] }),
+        ] {
+            assert!(bridge_lines(&empty).is_empty(), "{empty}");
+        }
+    }
+
+    #[test]
+    fn a_chunked_body_is_reassembled() {
+        // Connection: close usually avoids this, but the header is a request
+        // and not a guarantee. Read as-is, the hex markers sit inside the JSON
+        // and it fails to parse in a way that looks like the service being
+        // broken.
+        let head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked";
+        let body = "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n";
+        assert_eq!(decode_body(head, body), "hello world");
+    }
+
+    #[test]
+    fn an_unchunked_body_is_left_alone() {
+        let head = "HTTP/1.1 200 OK\r\nContent-Length: 11";
+        assert_eq!(decode_body(head, "hello world"), "hello world");
+    }
+}
+
+#[cfg(test)]
+mod live {
+    //! Ignored by default: it reaches the real service over the network.
+    //! `cargo test --lib moat::live -- --ignored --nocapture`
+    use super::*;
+
+    #[test]
+    #[ignore = "reaches bridges.torproject.org"]
+    fn iran_gets_a_real_answer() {
+        let lines = fetch_bridges("ir", None).expect("moat should answer for ir");
+        println!("{} lines", lines.len());
+        for line in &lines {
+            println!("  {line}");
+        }
+        assert!(!lines.is_empty());
+    }
+}

--- a/src-tauri/src/psiphon.rs
+++ b/src-tauri/src/psiphon.rs
@@ -1,0 +1,802 @@
+//! Psiphon as a carrier: a supervised child ending in a SOCKS5 listener.
+//!
+//! Deliberately not built on [`crate::core_supervisor`]. That file is a
+//! supervisor for the Aether engine specifically -- it reads connection state
+//! out of log prose, alternates H2 and H3 when a transport is blocked, kills a
+//! sweep that found nothing, and re-scans a gateway that went slow. None of it
+//! applies here. `psiphon-tunnel-core` finds its own way out, retries on its
+//! own, reconnects on its own, and says what it is doing in structured JSON.
+//! Reusing that machinery would mean fighting a second retry loop layered on
+//! one that is already better informed than we are.
+//!
+//! What is shared is the shape: spawn a child, drain both pipes so it cannot
+//! block on its own logging, watch for it to exit, and end in an address
+//! [`crate::chain`] can route into.
+//!
+//! ## The notices
+//!
+//! The console client writes one JSON object per line to **stderr**. Read from
+//! tunnel-core's own source rather than inferred, because two of them are easy
+//! to get subtly wrong:
+//!
+//! - `ListeningSocksProxyPort` is the listener, and it comes up *before* there
+//!   is a tunnel behind it. Reporting connected here would hand the chain a
+//!   proxy with nowhere to forward to, which swallows packets rather than
+//!   refusing them -- the same fault as reporting tor connected before its
+//!   circuit is built.
+//! - `Tunnels` carries the count, and that is the connected signal. Upstream's
+//!   own comment says "when count > 1, the core is connected"; that is an
+//!   off-by-one in their documentation, since one tunnel plainly is connected.
+//!   The code says `count > 0`, which is what the notice means.
+
+use std::{
+    collections::VecDeque,
+    io::{BufRead, BufReader},
+    net::{Ipv4Addr, SocketAddr},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+use crate::carrier::{Carrier, CarrierKind};
+use crate::core_supervisor::CoreSupervisor;
+
+/// How long to wait for a tunnel before calling it a failure.
+///
+/// Matches `EstablishTunnelTimeoutSeconds` in the config, plus a margin for the
+/// process to start and for the notice to reach us. Bounded on purpose:
+/// tunnel-core's own default is unlimited, and an unlimited establish is a
+/// carrier that never reports failure -- the screen would say "connecting"
+/// until the app was closed.
+const ESTABLISH_TIMEOUT: Duration = Duration::from_secs(135);
+
+/// What the config asks tunnel-core for. Kept just under [`ESTABLISH_TIMEOUT`]
+/// so the process gives up first and says why, rather than being killed by us
+/// with nothing to report.
+const ESTABLISH_TUNNEL_TIMEOUT_SECONDS: u64 = 120;
+
+/// Psiphon's documented values for a client that has not been issued its own.
+///
+/// `PropagationChannelId` and `SponsorId` say who distributed a client so that
+/// Psiphon can attribute usage and plan capacity. Real ones are issued by
+/// Psiphon Inc. to partners; these are the all-Fs and all-1s placeholders that
+/// appear throughout tunnel-core's own tests and in every open-source client
+/// that has not asked for a channel of its own.
+///
+/// They are not credentials and nothing is authenticated by them. What they
+/// cost is that our sessions are indistinguishable from every other
+/// unattributed client, so Psiphon cannot tell our users apart from anyone
+/// else's when planning capacity. If this carrier turns out to matter to the
+/// people using it, asking Psiphon for a channel is a conversation rather than
+/// a patch.
+const PROPAGATION_CHANNEL_ID: &str = "FFFFFFFFFFFFFFFF";
+const SPONSOR_ID: &str = "1111111111111111";
+
+#[cfg(windows)]
+const PSIPHON_FILENAME: &str = "psiphon-tunnel-core.exe";
+#[cfg(not(windows))]
+const PSIPHON_FILENAME: &str = "psiphon-tunnel-core";
+
+/// The bootstrap list, staged beside the binary by `scripts/stage-psiphon.mjs`.
+const SERVER_LIST_FILENAME: &str = "psiphon_server_entries.txt";
+
+/// How much of the notice stream to keep for diagnostics.
+///
+/// tunnel-core emits hundreds of notices while establishing -- 499 in one
+/// measured connect. Forwarding all of them to the shared log would evict the
+/// engine's own entries from its buffer, so the state changes and the failures
+/// go there and the rest is kept here, where a report can still reach it.
+const MAX_NOTICES: usize = 400;
+
+/// What the user chose about how Psiphon should run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct PsiphonSettings {
+    /// A two-letter country to exit from, or empty for whichever Psiphon
+    /// considers best.
+    ///
+    /// A preference and not a guarantee: tunnel-core treats an unreachable
+    /// region as a reason to keep trying rather than to substitute, so naming a
+    /// country with no capacity is a slow connect rather than a different exit
+    /// than the one asked for. Empty is the default for that reason.
+    pub egress_region: String,
+}
+
+impl PsiphonSettings {
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        let region = self.egress_region.trim();
+        if region.is_empty() {
+            return Ok(());
+        }
+        if region.len() == 2 && region.chars().all(|c| c.is_ascii_uppercase()) {
+            Ok(())
+        } else {
+            Err(format!(
+                "{region} is not a two-letter country code; leave it empty for the best available exit"
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PsiphonSnapshot {
+    /// "idle", "connecting", "connected", "error".
+    pub state: String,
+    pub pid: Option<u32>,
+    /// The loopback listener, once tunnel-core has bound one. Present while
+    /// still connecting, which is exactly why it is not the connected signal.
+    pub socks_port: Option<u16>,
+    /// The country the connected server is in, as Psiphon reports it.
+    pub exit_region: Option<String>,
+    /// Every country Psiphon last said it had. Read from its own notice rather
+    /// than a table of ours, which would go stale silently.
+    pub available_regions: Vec<String>,
+    pub last_error: Option<String>,
+    pub status_message: Option<String>,
+}
+
+impl Default for PsiphonSnapshot {
+    fn default() -> Self {
+        Self {
+            state: "idle".into(),
+            pid: None,
+            socks_port: None,
+            exit_region: None,
+            available_regions: Vec::new(),
+            last_error: None,
+            status_message: None,
+        }
+    }
+}
+
+/// One notice, as tunnel-core writes it.
+#[derive(Debug, Deserialize)]
+struct Notice {
+    #[serde(rename = "noticeType")]
+    notice_type: String,
+    #[serde(default)]
+    data: serde_json::Value,
+}
+
+struct Inner {
+    child: Mutex<Option<Child>>,
+    snapshot: Mutex<PsiphonSnapshot>,
+    notices: Mutex<VecDeque<String>>,
+    /// Bumped by every start and stop, so a reader or watcher belonging to a
+    /// superseded run does nothing rather than writing over the current one.
+    generation: AtomicU64,
+}
+
+#[derive(Clone)]
+pub struct Psiphon {
+    inner: Arc<Inner>,
+}
+
+impl Default for Psiphon {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Psiphon {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                child: Mutex::new(None),
+                snapshot: Mutex::new(PsiphonSnapshot::default()),
+                notices: Mutex::new(VecDeque::with_capacity(MAX_NOTICES)),
+                generation: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub fn snapshot(&self) -> PsiphonSnapshot {
+        lock(&self.inner.snapshot).clone()
+    }
+
+    /// This carrier, when it is actually carrying traffic.
+    ///
+    /// `None` until a tunnel exists, not merely until the listener does -- see
+    /// the note on `Tunnels` at the top of this file.
+    pub fn carrier(&self) -> Option<Carrier> {
+        let snapshot = lock(&self.inner.snapshot);
+        if snapshot.state != "connected" {
+            return None;
+        }
+        Some(Carrier {
+            kind: CarrierKind::Psiphon,
+            socks: SocketAddr::from((Ipv4Addr::LOCALHOST, snapshot.socks_port?)),
+            // Psiphon reaches many servers and replaces the one it uses without
+            // telling us to re-render anything. There is no single gateway
+            // address to exempt from the TUN device, so the process rule in
+            // `chain` carries that alone -- which is what it was already doing
+            // everywhere.
+            endpoint: None,
+            // It carries datagrams, but a QUIC handshake through a SOCKS5
+            // association is not something this has been measured doing, and
+            // claiming it would mark hysteria2 nodes usable on the strength of
+            // a guess. Reported false until measured, which costs a label on
+            // some nodes and risks nothing.
+            carries_quic: false,
+        })
+    }
+
+    /// The notice stream kept for a diagnostics report.
+    ///
+    /// Not forwarded to the shared log as it arrives: tunnel-core emitted 499
+    /// notices in one measured connect, which would evict the engine's own
+    /// entries from a bounded buffer. Kept here and collected only when a
+    /// report is being written.
+    pub fn notices(&self) -> Vec<String> {
+        lock(&self.inner.notices).iter().cloned().collect()
+    }
+
+    /// Starts Psiphon and waits for a tunnel.
+    ///
+    /// Blocking, and returns only once there is something to route into or a
+    /// reason there is not. The caller is about to point an interface at this:
+    /// a listener with no tunnel behind it swallows packets instead of refusing
+    /// them, which is worse for the person using it than an honest failure.
+    pub fn start(&self, app: &AppHandle, settings: &PsiphonSettings) -> Result<SocketAddr, String> {
+        settings.validate()?;
+        self.stop();
+
+        let inner = &self.inner;
+        let generation = inner.generation.fetch_add(1, Ordering::SeqCst) + 1;
+
+        let binary = locate(app)?;
+        let server_list = locate_server_list(app)?;
+        let home = app
+            .path()
+            .app_data_dir()
+            .map_err(|error| format!("no application data directory: {error}"))?
+            .join("psiphon");
+        std::fs::create_dir_all(&home)
+            .map_err(|error| format!("cannot prepare the Psiphon directory: {error}"))?;
+
+        let config_path = home.join("config.json");
+        std::fs::write(&config_path, render_config(settings, &home))
+            .map_err(|error| format!("cannot write the Psiphon config: {error}"))?;
+
+        {
+            let mut snapshot = lock(&inner.snapshot);
+            *snapshot = PsiphonSnapshot {
+                state: "connecting".into(),
+                status_message: Some(match settings.egress_region.trim() {
+                    "" => "Finding a way out".into(),
+                    region => format!("Finding a way out through {region}"),
+                }),
+                ..PsiphonSnapshot::default()
+            };
+        }
+
+        let mut command = Command::new(&binary);
+        command
+            .arg("-config")
+            .arg(&config_path)
+            .arg("-serverList")
+            .arg(&server_list)
+            .arg("-dataRootDirectory")
+            .arg(&home)
+            .current_dir(&home)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::core_supervisor::hide_console(&mut command);
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("cannot start Psiphon: {error}"))?;
+        let pid = child.id();
+        let stderr = child.stderr.take();
+        let stdout = child.stdout.take();
+
+        {
+            // Claimed under the same lock a stop takes, so a stop that landed
+            // while this was spawning cannot leave the child running
+            // unsupervised.
+            let mut guard = lock(&inner.child);
+            if inner.generation.load(Ordering::SeqCst) != generation {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("Psiphon was stopped while it was starting".into());
+            }
+            *guard = Some(child);
+        }
+        lock(&inner.snapshot).pid = Some(pid);
+
+        // The notices are the whole interface, and they arrive on stderr.
+        if let Some(stderr) = stderr {
+            spawn_notice_reader(app.clone(), inner.clone(), stderr, generation);
+        }
+        // Nothing is written to stdout, but a piped stream nobody drains is a
+        // process that blocks on its own output once the pipe fills.
+        if let Some(stdout) = stdout {
+            thread::spawn(move || {
+                for line in BufReader::new(stdout).lines() {
+                    if line.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+
+        match self.wait_for_tunnel(generation) {
+            Ok(address) => {
+                app.state::<CoreSupervisor>().record(
+                    "psiphon",
+                    "info",
+                    format!("Psiphon is carrying traffic; SOCKS listener on {address}"),
+                );
+                Ok(address)
+            }
+            Err(error) => {
+                // Never leave a half-started carrier behind: the chain would be
+                // pointed at a listener with no tunnel under it.
+                self.stop();
+                let mut snapshot = lock(&inner.snapshot);
+                snapshot.state = "error".into();
+                snapshot.status_message = None;
+                snapshot.last_error = Some(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    /// Waits for `Tunnels` to report at least one, or for the process to die.
+    fn wait_for_tunnel(&self, generation: u64) -> Result<SocketAddr, String> {
+        let inner = &self.inner;
+        let deadline = Instant::now() + ESTABLISH_TIMEOUT;
+        while Instant::now() < deadline {
+            if inner.generation.load(Ordering::SeqCst) != generation {
+                return Err("Psiphon was stopped while it was starting".into());
+            }
+            {
+                let snapshot = lock(&inner.snapshot);
+                if snapshot.state == "connected" {
+                    if let Some(port) = snapshot.socks_port {
+                        return Ok(SocketAddr::from((Ipv4Addr::LOCALHOST, port)));
+                    }
+                }
+                if let Some(error) = snapshot.last_error.clone() {
+                    return Err(error);
+                }
+            }
+            // The process can exit without ever emitting a failure notice --
+            // a missing server list does that. Noticing here is what turns a
+            // silent death into a message.
+            if let Some(child) = lock(&inner.child).as_mut() {
+                if matches!(child.try_wait(), Ok(Some(_))) {
+                    return Err("Psiphon stopped before it connected".into());
+                }
+            } else {
+                return Err("Psiphon was stopped while it was starting".into());
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        Err(format!(
+            "Psiphon did not find a way out in {}s",
+            ESTABLISH_TIMEOUT.as_secs()
+        ))
+    }
+
+    pub fn stop(&self) {
+        let inner = &self.inner;
+        inner.generation.fetch_add(1, Ordering::SeqCst);
+        if let Some(mut child) = lock(&inner.child).take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let mut snapshot = lock(&inner.snapshot);
+        // The regions survive a stop: they describe what Psiphon has, not what
+        // this run did, and re-asking would leave the screen with nothing to
+        // offer until the next successful connect.
+        let regions = std::mem::take(&mut snapshot.available_regions);
+        *snapshot = PsiphonSnapshot {
+            available_regions: regions,
+            ..PsiphonSnapshot::default()
+        };
+    }
+}
+
+impl Drop for Psiphon {
+    fn drop(&mut self) {
+        // Only the last handle owns the child; the rest are clones held by
+        // Tauri state and the readers.
+        if Arc::strong_count(&self.inner) == 1 {
+            self.stop();
+        }
+    }
+}
+
+/// Reads the notice stream and turns it into state.
+fn spawn_notice_reader(
+    app: AppHandle,
+    inner: Arc<Inner>,
+    stderr: std::process::ChildStderr,
+    generation: u64,
+) {
+    thread::spawn(move || {
+        for line in BufReader::new(stderr).lines() {
+            if inner.generation.load(Ordering::SeqCst) != generation {
+                return;
+            }
+            let Ok(line) = line else { break };
+            let line = line.trim().to_string();
+            if line.is_empty() {
+                continue;
+            }
+            {
+                let mut notices = lock(&inner.notices);
+                if notices.len() == MAX_NOTICES {
+                    notices.pop_front();
+                }
+                notices.push_back(line.clone());
+            }
+            let Ok(notice) = serde_json::from_str::<Notice>(&line) else {
+                // Not JSON, so not a notice. Kept above for diagnostics and
+                // otherwise ignored rather than treated as a failure: a
+                // panic trace or a Go runtime warning is worth having and is
+                // not something to act on.
+                continue;
+            };
+            apply_notice(&app, &inner, &notice);
+        }
+    });
+}
+
+/// Applies one notice, and forwards anything worth a line in the shared log.
+///
+/// Thin on purpose: everything that decides state lives in
+/// [`apply_notice_to_snapshot`], which needs no Tauri handle and is therefore
+/// the thing the tests exercise. Splitting it this way is not tidiness -- a
+/// test that reimplements the logic it is checking passes while production
+/// drifts away from it.
+fn apply_notice(app: &AppHandle, inner: &Arc<Inner>, notice: &Notice) {
+    let reportable = {
+        let mut snapshot = lock(&inner.snapshot);
+        apply_notice_to_snapshot(&mut snapshot, notice)
+    };
+    if let Some(message) = reportable {
+        app.state::<CoreSupervisor>()
+            .record("psiphon", "warn", message);
+    }
+}
+
+/// Applies one notice to the snapshot, returning anything the user should see.
+fn apply_notice_to_snapshot(snapshot: &mut PsiphonSnapshot, notice: &Notice) -> Option<String> {
+    match notice.notice_type.as_str() {
+        "ListeningSocksProxyPort" => {
+            if let Some(port) = notice.data.get("port").and_then(|v| v.as_u64()) {
+                snapshot.socks_port = u16::try_from(port).ok();
+            }
+        }
+        "Tunnels" => {
+            let count = notice.data.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+            // Upstream's comment says "count > 1"; one tunnel is connected, and
+            // this is what the notice actually means.
+            if count > 0 {
+                if snapshot.state != "connected" {
+                    snapshot.state = "connected".into();
+                    snapshot.status_message = None;
+                    snapshot.last_error = None;
+                }
+            } else if snapshot.state == "connected" {
+                // Psiphon reconnects on its own and the listener stays bound
+                // throughout, so this is reported rather than acted on --
+                // tearing the chain down here would turn a reconnection Psiphon
+                // handles into an outage we caused.
+                snapshot.state = "connecting".into();
+                snapshot.status_message = Some("Reconnecting".into());
+            }
+        }
+        "AvailableEgressRegions" => {
+            if let Some(regions) = notice.data.get("regions").and_then(|v| v.as_array()) {
+                let mut list: Vec<String> = regions
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .filter(|region| region.len() == 2)
+                    .map(str::to_string)
+                    .collect();
+                list.sort();
+                snapshot.available_regions = list;
+            }
+        }
+        "ConnectedServerRegion" => {
+            snapshot.exit_region = notice
+                .data
+                .get("serverRegion")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+        }
+        // Psiphon gave up. It says so before it exits, and the reason is worth
+        // far more than the exit itself: measured on a fresh data directory,
+        // asking for Japan left 13 candidate servers out of 430 and none of
+        // them answered, which is a country with no capacity rather than
+        // anything wrong with the network in front of it. Without this the user
+        // is told only that the process stopped.
+        "EstablishTunnelTimeout" => {
+            snapshot.state = "error".into();
+            snapshot.status_message = None;
+            snapshot.last_error = Some(
+                "Psiphon could not reach any server in time. If an exit country is chosen, it \
+                 may have no capacity right now -- try Best available, which can use every \
+                 server it knows about."
+                    .into(),
+            );
+        }
+        // The failures worth surfacing. Everything else is diagnostic and stays
+        // in the notice buffer.
+        "Alert" | "Error" => {
+            return notice
+                .data
+                .get("message")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+        }
+        _ => {}
+    }
+    None
+}
+
+/// The config tunnel-core is started with.
+///
+/// Small on purpose. Every field here is one this app has a reason to set;
+/// tunnel-core has dozens more whose defaults are chosen against live censored
+/// networks by people who measure them, which is not something to second-guess
+/// from here.
+fn render_config(settings: &PsiphonSettings, home: &Path) -> String {
+    serde_json::json!({
+        "PropagationChannelId": PROPAGATION_CHANNEL_ID,
+        "SponsorId": SPONSOR_ID,
+        // Our own version, as a string, which is what tunnel-core's sample says
+        // and what it rejects the config for getting wrong. Reporting one of
+        // Psiphon's own client versions would put our sessions in someone
+        // else's column.
+        "ClientVersion": env!("CARGO_PKG_VERSION").replace('.', ""),
+        "DataRootDirectory": home.to_string_lossy(),
+        "EgressRegion": settings.egress_region.trim(),
+        "EstablishTunnelTimeoutSeconds": ESTABLISH_TUNNEL_TIMEOUT_SECONDS,
+        // Zero means "pick a free one and tell me", and the port that comes
+        // back is what the chain is configured against. A fixed port is one
+        // more thing that can already be taken on a machine we do not control,
+        // and that failure would look like Psiphon not starting.
+        "LocalSocksProxyPort": 0,
+        // Nothing asks for an HTTP proxy, and a listener nobody uses is a
+        // listener on loopback that anything on this machine can reach.
+        "DisableLocalHTTPProxy": true,
+        // Without these a failed establish is a silent one. They stay on this
+        // machine unless the user sends a report.
+        "EmitDiagnosticNotices": true,
+        "EmitDiagnosticNetworkParameters": false,
+    })
+    .to_string()
+}
+
+fn locate(app: &AppHandle) -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+    if let Ok(path) = std::env::var("WHITEAESTHER_PSIPHON_PATH") {
+        if !path.trim().is_empty() {
+            candidates.push(PathBuf::from(path));
+        }
+    }
+    if let Ok(resources) = app.path().resource_dir() {
+        candidates.push(resources.join(PSIPHON_FILENAME));
+        candidates.push(resources.join("binaries").join(PSIPHON_FILENAME));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            candidates.push(parent.join(PSIPHON_FILENAME));
+        }
+    }
+    for candidate in candidates {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err("the Psiphon carrier is missing from this installation".into())
+}
+
+/// The bootstrap list, which tunnel-core needs to reach anything the first time.
+///
+/// Its absence is reported here rather than left to the process, which would
+/// otherwise spend two minutes dialling an empty list and report only that it
+/// could not connect.
+fn locate_server_list(app: &AppHandle) -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+    if let Ok(resources) = app.path().resource_dir() {
+        candidates.push(resources.join(SERVER_LIST_FILENAME));
+        candidates.push(resources.join("binaries").join(SERVER_LIST_FILENAME));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            candidates.push(parent.join(SERVER_LIST_FILENAME));
+        }
+    }
+    for candidate in candidates {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(
+        "the Psiphon server list is missing from this installation, so there is nothing to \
+         bootstrap from"
+            .into(),
+    )
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn notice(json: &str) -> Notice {
+        serde_json::from_str(json).expect("a notice")
+    }
+
+    /// Feeds one notice through the same function production uses.
+    fn apply(snapshot: &mut PsiphonSnapshot, json: &str) -> Option<String> {
+        apply_notice_to_snapshot(snapshot, &notice(json))
+    }
+
+    #[test]
+    fn a_listener_without_a_tunnel_is_not_connected() {
+        // The trap this carrier shares with tor: the SOCKS port is bound well
+        // before anything can be carried through it. Reporting connected here
+        // hands the chain a proxy with nowhere to forward to, which swallows
+        // packets rather than refusing them.
+        let mut snapshot = PsiphonSnapshot::default();
+        apply(&mut snapshot, r#"{"noticeType":"ListeningSocksProxyPort","data":{"port":64347}}"#);
+        assert_eq!(snapshot.socks_port, Some(64347));
+        assert_ne!(snapshot.state, "connected");
+    }
+
+    #[test]
+    fn one_tunnel_is_connected() {
+        // Upstream's own comment says "when count > 1, the core is connected",
+        // which is an off-by-one in their documentation. Following it literally
+        // would leave a perfectly good single-tunnel session reported as still
+        // connecting, forever.
+        let mut snapshot = PsiphonSnapshot::default();
+        apply(&mut snapshot, r#"{"noticeType":"ListeningSocksProxyPort","data":{"port":64347}}"#);
+        apply(&mut snapshot, r#"{"noticeType":"Tunnels","data":{"count":1}}"#);
+        assert_eq!(snapshot.state, "connected");
+    }
+
+    #[test]
+    fn losing_every_tunnel_is_a_reconnect_and_not_a_failure() {
+        // Psiphon reconnects on its own and keeps the listener bound while it
+        // does. Tearing the chain down here would turn a reconnection it
+        // handles into an outage we caused.
+        let mut snapshot = PsiphonSnapshot::default();
+        apply(&mut snapshot, r#"{"noticeType":"Tunnels","data":{"count":1}}"#);
+        apply(&mut snapshot, r#"{"noticeType":"Tunnels","data":{"count":0}}"#);
+        assert_eq!(snapshot.state, "connecting");
+        assert_eq!(snapshot.status_message.as_deref(), Some("Reconnecting"));
+        assert!(snapshot.last_error.is_none(), "a reconnect is not an error");
+    }
+
+    #[test]
+    fn the_regions_come_from_psiphon_rather_than_from_a_table_of_ours() {
+        // Measured: it reported 25. A hardcoded list goes stale silently and
+        // offers countries that are no longer there.
+        let mut snapshot = PsiphonSnapshot::default();
+        apply(
+            &mut snapshot,
+            r#"{"noticeType":"AvailableEgressRegions","data":{"regions":["US","JP","FR","XYZ",""]}}"#,
+        );
+        assert_eq!(snapshot.available_regions, vec!["FR", "JP", "US"]);
+    }
+
+    #[test]
+    fn the_exit_country_is_read_from_the_connected_server() {
+        let mut snapshot = PsiphonSnapshot::default();
+        apply(&mut snapshot, r#"{"noticeType":"ConnectedServerRegion","data":{"serverRegion":"FR"}}"#);
+        assert_eq!(snapshot.exit_region.as_deref(), Some("FR"));
+    }
+
+    #[test]
+    fn giving_up_names_the_exit_country_as_the_likely_reason() {
+        // Measured: a fresh data directory holds 430 bootstrap servers, and
+        // asking for Japan narrowed that to 13, none of which answered inside
+        // the two-minute establish timeout. The process then exits, and without
+        // reading this notice the only thing left to report is that it stopped
+        // -- which points at the network rather than at the one setting that
+        // actually caused it.
+        let mut snapshot = PsiphonSnapshot::default();
+        apply(&mut snapshot, r#"{"noticeType":"EstablishTunnelTimeout","data":{"timeout":"2m0s"}}"#);
+        assert_eq!(snapshot.state, "error");
+        let reason = snapshot.last_error.expect("a reason");
+        assert!(reason.contains("exit country"), "{reason}");
+        assert!(reason.contains("Best available"), "say what to do instead: {reason}");
+    }
+
+    #[test]
+    fn a_region_is_either_two_upper_case_letters_or_nothing_at_all() {
+        assert!(PsiphonSettings { egress_region: String::new() }.validate().is_ok());
+        assert!(PsiphonSettings { egress_region: "JP".into() }.validate().is_ok());
+        for bad in ["jp", "JPN", "J", "!!"] {
+            assert!(
+                PsiphonSettings { egress_region: bad.into() }.validate().is_err(),
+                "{bad} should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn the_config_asks_for_a_chosen_port_and_no_http_listener() {
+        let rendered = render_config(
+            &PsiphonSettings { egress_region: "JP".into() },
+            Path::new("/tmp/psiphon"),
+        );
+        let config: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        // Zero is "pick one and tell me". A fixed port is one more thing that
+        // can already be taken on a machine we do not control.
+        assert_eq!(config["LocalSocksProxyPort"], 0);
+        assert_eq!(config["DisableLocalHTTPProxy"], true);
+        assert_eq!(config["EgressRegion"], "JP");
+        // Bounded, because tunnel-core's own default is unlimited -- and an
+        // unlimited establish is a carrier that never reports failure.
+        assert_eq!(
+            config["EstablishTunnelTimeoutSeconds"],
+            ESTABLISH_TUNNEL_TIMEOUT_SECONDS
+        );
+        assert_eq!(config["EmitDiagnosticNotices"], true);
+    }
+
+    #[test]
+    fn no_exit_country_is_sent_as_empty_rather_than_omitted() {
+        // tunnel-core reads a missing EgressRegion and an empty one the same
+        // way, but writing it explicitly keeps the config self-describing for
+        // anyone reading it out of the data directory during a support call.
+        let rendered = render_config(&PsiphonSettings::default(), Path::new("/tmp/psiphon"));
+        let config: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(config["EgressRegion"], "");
+    }
+
+    #[test]
+    fn a_notice_that_is_not_json_never_stops_the_reader() {
+        // A Go panic trace or a runtime warning arrives on the same stream.
+        // Treating it as a parse failure that ends the loop would take out the
+        // only channel this carrier has for reporting anything.
+        assert!(serde_json::from_str::<Notice>("panic: runtime error").is_err());
+    }
+}
+
+/// Whether this build ships the Psiphon carrier and the list it bootstraps from.
+///
+/// Both are required: the binary without the server list spends two minutes
+/// dialling nothing and then reports that it could not connect.
+pub fn is_available(app: &AppHandle) -> bool {
+    locate(app).is_ok() && locate_server_list(app).is_ok()
+}
+
+impl Psiphon {
+    /// Whether the child is still running.
+    ///
+    /// Asked of the process rather than of the snapshot: the notice reader
+    /// simply ends when the pipe closes, so a process that died leaves the last
+    /// state it reported sitting there looking healthy. Nothing else would ever
+    /// notice, and the screen would say connected over a listener that is gone.
+    pub fn is_alive(&self) -> bool {
+        let mut guard = lock(&self.inner.child);
+        match guard.as_mut() {
+            Some(child) => !matches!(child.try_wait(), Ok(Some(_))),
+            None => false,
+        }
+    }
+}

--- a/src-tauri/src/tor.rs
+++ b/src-tauri/src/tor.rs
@@ -235,8 +235,12 @@ impl Tor {
         let inner = &self.inner;
         let generation = inner.generation.fetch_add(1, Ordering::SeqCst) + 1;
 
-        let binary = locate(app, TOR_FILENAME, &[])?;
         let support = support_dir(app)?;
+        // tor lives in the support directory beside the transports it launches
+        // and the geoip data it reads, rather than as a target-triple sidecar:
+        // it is not shipped for every target, and a declared sidecar that is
+        // missing fails the whole bundle.
+        let binary = locate(app, TOR_FILENAME, &[support.join(TOR_FILENAME)])?;
         let home = app
             .path()
             .app_data_dir()
@@ -866,7 +870,10 @@ mod tests {
 /// rather than offering a carrier that cannot start -- a control that saves and
 /// does nothing is worse than one that is absent.
 pub fn is_available(app: &AppHandle) -> bool {
-    locate(app, TOR_FILENAME, &[]).is_ok() && support_dir(app).is_ok()
+    let Ok(support) = support_dir(app) else {
+        return false;
+    };
+    locate(app, TOR_FILENAME, &[support.join(TOR_FILENAME)]).is_ok()
 }
 
 impl Tor {

--- a/src-tauri/src/tor.rs
+++ b/src-tauri/src/tor.rs
@@ -1,0 +1,882 @@
+//! Tor as a carrier: three relays, and a SOCKS5 listener at the end of them.
+//!
+//! The same shape as [`crate::psiphon`] — a supervised child that ends in a
+//! listener mihomo routes into — and a different protocol for finding out what
+//! it is doing. Tor speaks a line-based control protocol on a loopback port
+//! rather than emitting notices, so this authenticates to that port and asks.
+//!
+//! ## Connected means bootstrapped, not listening
+//!
+//! The one thing that must not be got wrong here. Tor binds its SOCKS port and
+//! opens its control port almost immediately, long before it has a circuit —
+//! and a SOCKS listener with no circuit behind it accepts connections and then
+//! sits on them. Reporting connected there ships a carrier that says it is
+//! working and carries nothing, which on the Android client is exactly how meek
+//! passed review and then failed for three minutes straight.
+//!
+//! So the gate is `GETINFO status/bootstrap-phase` reporting `PROGRESS=100`,
+//! and nothing else counts.
+//!
+//! ## No datagrams, and that is declared rather than discovered
+//!
+//! Tor carries TCP only. [`CarrierKind::Tor`] says so, which puts `udp: false`
+//! on the proxy mihomo dials and a `NETWORK,udp,REJECT` rule above the default
+//! route. Both halves matter: a proxy that claims UDP and swallows it is
+//! experienced as DNS and QUIC hanging while TCP works, which is the hardest
+//! shape of broken to recognise. Refused, a resolver retries over TCP and a
+//! browser drops off QUIC, both within a round trip. The chain's own resolvers
+//! are DNS-over-HTTPS, so names still resolve throughout.
+
+use std::{
+    collections::VecDeque,
+    io::{BufRead, BufReader, Read, Write},
+    net::{Ipv4Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+use crate::carrier::{Carrier, CarrierKind};
+use crate::core_supervisor::CoreSupervisor;
+
+/// How long to wait for a circuit before calling it a failure.
+///
+/// Generous compared with Psiphon's, and deliberately: a bridge that has to be
+/// reached through a pluggable transport routinely takes tens of seconds, and a
+/// measured webtunnel circuit on the Android client built in seventeen. Cutting
+/// this short would report failure on networks where Tor was going to succeed.
+const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// How often to ask how far along it is.
+const BOOTSTRAP_POLL: Duration = Duration::from_millis(500);
+
+/// Long enough for tor to write its control port and cookie files.
+const CONTROL_FILE_TIMEOUT: Duration = Duration::from_secs(20);
+
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[cfg(windows)]
+const TOR_FILENAME: &str = "tor.exe";
+#[cfg(not(windows))]
+const TOR_FILENAME: &str = "tor";
+
+#[cfg(windows)]
+const LYREBIRD_FILENAME: &str = "lyrebird.exe";
+#[cfg(not(windows))]
+const LYREBIRD_FILENAME: &str = "lyrebird";
+
+/// How much of tor's own output to keep for a diagnostics report.
+const MAX_LINES: usize = 400;
+
+/// Which bridges to use, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum BridgeMode {
+    /// Straight to the Tor network. Right where Tor is not blocked, and the
+    /// fastest path when it works.
+    #[default]
+    None,
+    /// The list Tor ships in `pt_config.json`, alongside the binary it belongs
+    /// to. Not a list of ours: one written by hand rots, and two of the three
+    /// the Android client first shipped were already unreachable.
+    BuiltIn,
+    /// Lines the user pasted, from bridges.torproject.org or a friend.
+    Custom,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct TorSettings {
+    pub bridges: BridgeMode,
+    /// Which transport to take from the built-in list: "obfs4", "snowflake" or
+    /// "meek".
+    pub transport: String,
+    /// Bridge lines pasted by hand, one per line. Used when `bridges` is
+    /// `Custom`.
+    pub custom_bridges: String,
+}
+
+impl TorSettings {
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        match self.bridges {
+            BridgeMode::None => Ok(()),
+            BridgeMode::BuiltIn => Ok(()),
+            BridgeMode::Custom => {
+                if self.bridge_lines().is_empty() {
+                    Err("paste at least one bridge line, or choose the built-in bridges".into())
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// The pasted lines, with blanks and comments dropped.
+    ///
+    /// `Bridge ` prefixes are stripped: the page people copy from writes them
+    /// with the keyword and the torrc line needs it exactly once, so pasting
+    /// verbatim would otherwise produce `Bridge Bridge obfs4 ...` and tor would
+    /// refuse the file with a parse error naming a line the user did not write.
+    fn bridge_lines(&self) -> Vec<String> {
+        self.custom_bridges
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .map(|line| {
+                line.strip_prefix("Bridge ")
+                    .or_else(|| line.strip_prefix("bridge "))
+                    .unwrap_or(line)
+                    .trim()
+                    .to_string()
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TorSnapshot {
+    /// "idle", "connecting", "connected", "error".
+    pub state: String,
+    pub pid: Option<u32>,
+    pub socks_port: Option<u16>,
+    /// How far bootstrapping has got, 0-100.
+    pub bootstrap: u8,
+    /// What tor says it is doing right now, in its own words.
+    pub bootstrap_summary: Option<String>,
+    pub last_error: Option<String>,
+}
+
+impl Default for TorSnapshot {
+    fn default() -> Self {
+        Self {
+            state: "idle".into(),
+            pid: None,
+            socks_port: None,
+            bootstrap: 0,
+            bootstrap_summary: None,
+            last_error: None,
+        }
+    }
+}
+
+struct Inner {
+    child: Mutex<Option<Child>>,
+    snapshot: Mutex<TorSnapshot>,
+    lines: Mutex<VecDeque<String>>,
+    generation: AtomicU64,
+}
+
+#[derive(Clone)]
+pub struct Tor {
+    inner: Arc<Inner>,
+}
+
+impl Default for Tor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Tor {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                child: Mutex::new(None),
+                snapshot: Mutex::new(TorSnapshot::default()),
+                lines: Mutex::new(VecDeque::with_capacity(MAX_LINES)),
+                generation: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub fn snapshot(&self) -> TorSnapshot {
+        lock(&self.inner.snapshot).clone()
+    }
+
+    /// This carrier, when it is actually carrying traffic.
+    ///
+    /// `None` until bootstrap reaches 100. See the note at the top of this
+    /// file: a listening SOCKS port is not a circuit.
+    pub fn carrier(&self) -> Option<Carrier> {
+        let snapshot = lock(&self.inner.snapshot);
+        if snapshot.state != "connected" {
+            return None;
+        }
+        Some(Carrier {
+            kind: CarrierKind::Tor,
+            socks: SocketAddr::from((Ipv4Addr::LOCALHOST, snapshot.socks_port?)),
+            // Tor reaches the network through a guard that changes on its own
+            // schedule, so there is no one address to exempt from the TUN
+            // device; the process rule in `chain` carries that alone.
+            endpoint: None,
+            // Tor carries no datagrams at all, so it certainly carries no QUIC.
+            carries_quic: false,
+        })
+    }
+
+    pub fn lines(&self) -> Vec<String> {
+        lock(&self.inner.lines).iter().cloned().collect()
+    }
+
+    /// Starts tor and waits for a circuit.
+    pub fn start(&self, app: &AppHandle, settings: &TorSettings) -> Result<SocketAddr, String> {
+        settings.validate()?;
+        self.stop();
+
+        let inner = &self.inner;
+        let generation = inner.generation.fetch_add(1, Ordering::SeqCst) + 1;
+
+        let binary = locate(app, TOR_FILENAME, &[])?;
+        let support = support_dir(app)?;
+        let home = app
+            .path()
+            .app_data_dir()
+            .map_err(|error| format!("no application data directory: {error}"))?
+            .join("tor");
+        // Tor refuses to start if its data directory is group or world
+        // readable, which is a check worth keeping rather than working around.
+        std::fs::create_dir_all(&home)
+            .map_err(|error| format!("cannot prepare the Tor directory: {error}"))?;
+
+        let control_port_file = home.join("control-port");
+        let cookie_file = home.join("control-auth-cookie");
+        // Stale files from a previous run would be read as this run's, and the
+        // port in them points at a tor that is no longer there.
+        let _ = std::fs::remove_file(&control_port_file);
+        let _ = std::fs::remove_file(&cookie_file);
+
+        let torrc = home.join("torrc");
+        std::fs::write(
+            &torrc,
+            render_torrc(settings, &home, &support, &control_port_file, &cookie_file)?,
+        )
+        .map_err(|error| format!("cannot write the Tor configuration: {error}"))?;
+
+        {
+            let mut snapshot = lock(&inner.snapshot);
+            *snapshot = TorSnapshot {
+                state: "connecting".into(),
+                bootstrap_summary: Some("Starting Tor".into()),
+                ..TorSnapshot::default()
+            };
+        }
+
+        let mut command = Command::new(&binary);
+        command
+            .arg("-f")
+            .arg(&torrc)
+            .current_dir(&home)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        crate::core_supervisor::hide_console(&mut command);
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("cannot start Tor: {error}"))?;
+        let pid = child.id();
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+
+        {
+            let mut guard = lock(&inner.child);
+            if inner.generation.load(Ordering::SeqCst) != generation {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err("Tor was stopped while it was starting".into());
+            }
+            *guard = Some(child);
+        }
+        lock(&inner.snapshot).pid = Some(pid);
+
+        // Both streams drained, or tor blocks on its own logging once a pipe
+        // fills -- and its log is the only account of a failure that happens
+        // before the control port is up.
+        for reader in [
+            stdout.map(|out| Box::new(out) as Box<dyn Read + Send>),
+            stderr.map(|err| Box::new(err) as Box<dyn Read + Send>),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            spawn_log_reader(app.clone(), inner.clone(), reader, generation);
+        }
+
+        match self.wait_for_circuit(&control_port_file, &cookie_file, generation) {
+            Ok(address) => {
+                app.state::<CoreSupervisor>().record(
+                    "tor",
+                    "info",
+                    format!("Tor has a circuit; SOCKS listener on {address}"),
+                );
+                Ok(address)
+            }
+            Err(error) => {
+                self.stop();
+                let mut snapshot = lock(&inner.snapshot);
+                snapshot.state = "error".into();
+                snapshot.last_error = Some(error.clone());
+                Err(error)
+            }
+        }
+    }
+
+    /// Waits for `PROGRESS=100`, reporting how far it has got along the way.
+    fn wait_for_circuit(
+        &self,
+        control_port_file: &Path,
+        cookie_file: &Path,
+        generation: u64,
+    ) -> Result<SocketAddr, String> {
+        let inner = &self.inner;
+        let control = read_control_port(control_port_file, CONTROL_FILE_TIMEOUT)?;
+        let cookie = read_cookie(cookie_file, CONTROL_FILE_TIMEOUT)?;
+        let mut session = ControlSession::open(control, &cookie)?;
+
+        let deadline = Instant::now() + BOOTSTRAP_TIMEOUT;
+        while Instant::now() < deadline {
+            if inner.generation.load(Ordering::SeqCst) != generation {
+                return Err("Tor was stopped while it was starting".into());
+            }
+            // A tor that died before bootstrapping leaves the control socket
+            // closed; noticing here turns a hang into a message.
+            if let Some(child) = lock(&inner.child).as_mut() {
+                if matches!(child.try_wait(), Ok(Some(_))) {
+                    return Err("Tor stopped before it built a circuit".into());
+                }
+            } else {
+                return Err("Tor was stopped while it was starting".into());
+            }
+
+            let phase = session.get_info("status/bootstrap-phase")?;
+            let progress = parse_progress(&phase).unwrap_or(0);
+            let summary = parse_summary(&phase);
+            {
+                let mut snapshot = lock(&inner.snapshot);
+                snapshot.bootstrap = progress;
+                snapshot.bootstrap_summary = summary.clone();
+            }
+
+            if progress >= 100 {
+                let port = session.socks_port()?;
+                let mut snapshot = lock(&inner.snapshot);
+                snapshot.socks_port = Some(port);
+                snapshot.state = "connected".into();
+                snapshot.bootstrap = 100;
+                return Ok(SocketAddr::from((Ipv4Addr::LOCALHOST, port)));
+            }
+            thread::sleep(BOOTSTRAP_POLL);
+        }
+
+        let reached = lock(&inner.snapshot).bootstrap;
+        Err(format!(
+            "Tor did not build a circuit in {}s; it reached {reached}%. \
+             If this network blocks Tor, turn bridges on.",
+            BOOTSTRAP_TIMEOUT.as_secs()
+        ))
+    }
+
+    pub fn stop(&self) {
+        let inner = &self.inner;
+        inner.generation.fetch_add(1, Ordering::SeqCst);
+        if let Some(mut child) = lock(&inner.child).take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        *lock(&inner.snapshot) = TorSnapshot::default();
+    }
+}
+
+impl Drop for Tor {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.inner) == 1 {
+            self.stop();
+        }
+    }
+}
+
+/// One authenticated conversation with tor's control port.
+struct ControlSession {
+    stream: TcpStream,
+    reader: BufReader<TcpStream>,
+}
+
+impl ControlSession {
+    fn open(control: SocketAddr, cookie: &[u8]) -> Result<Self, String> {
+        let stream = TcpStream::connect_timeout(&control, CONTROL_TIMEOUT)
+            .map_err(|error| format!("cannot reach the Tor control port: {error}"))?;
+        stream
+            .set_read_timeout(Some(CONTROL_TIMEOUT))
+            .map_err(|error| format!("cannot configure the Tor control port: {error}"))?;
+        let reader = BufReader::new(
+            stream
+                .try_clone()
+                .map_err(|error| format!("cannot read the Tor control port: {error}"))?,
+        );
+        let mut session = Self { stream, reader };
+
+        // Cookie authentication rather than a password: tor writes a file only
+        // this user can read, and we prove we read it. A password would have to
+        // be generated, written to the torrc in a hashed form and held here in
+        // plaintext, which is more moving parts for no more safety.
+        let hex: String = cookie.iter().map(|byte| format!("{byte:02x}")).collect();
+        let reply = session.command(&format!("AUTHENTICATE {hex}"))?;
+        if !reply.starts_with("250") {
+            return Err(format!("the Tor control port refused authentication: {reply}"));
+        }
+        Ok(session)
+    }
+
+    fn command(&mut self, line: &str) -> Result<String, String> {
+        self.stream
+            .write_all(format!("{line}\r\n").as_bytes())
+            .map_err(|error| format!("cannot write to the Tor control port: {error}"))?;
+        self.read_reply()
+    }
+
+    /// Reads one reply, which may be several lines.
+    ///
+    /// The protocol marks continuation with `-` or `+` after the code and the
+    /// final line with a space, so reading a single line would take the first
+    /// line of a multi-line answer and leave the rest to be misread as the
+    /// reply to the next command.
+    fn read_reply(&mut self) -> Result<String, String> {
+        let mut reply = String::new();
+        loop {
+            let mut line = String::new();
+            let read = self
+                .reader
+                .read_line(&mut line)
+                .map_err(|error| format!("cannot read the Tor control port: {error}"))?;
+            if read == 0 {
+                return Err("the Tor control port closed".into());
+            }
+            reply.push_str(&line);
+            let trimmed = line.trim_end();
+            // "250 OK" ends it; "250-..." and "250+..." do not.
+            if trimmed.len() >= 4 && trimmed.as_bytes()[3] == b' ' {
+                return Ok(reply.trim_end().to_string());
+            }
+            if trimmed.len() < 4 {
+                return Ok(reply.trim_end().to_string());
+            }
+        }
+    }
+
+    fn get_info(&mut self, key: &str) -> Result<String, String> {
+        let reply = self.command(&format!("GETINFO {key}"))?;
+        if !reply.starts_with("250") {
+            return Err(format!("Tor refused GETINFO {key}: {reply}"));
+        }
+        Ok(reply)
+    }
+
+    /// The port tor actually bound, asked for rather than assumed.
+    ///
+    /// `SocksPort auto` means tor picks one, which is what stops a fixed port
+    /// from colliding with whatever else is already on this machine -- so the
+    /// only way to know it is to ask.
+    fn socks_port(&mut self) -> Result<u16, String> {
+        let reply = self.get_info("net/listeners/socks")?;
+        // 250-net/listeners/socks="127.0.0.1:9150"
+        let quoted = reply
+            .split('"')
+            .nth(1)
+            .ok_or("Tor did not report a SOCKS listener")?;
+        quoted
+            .rsplit(':')
+            .next()
+            .and_then(|port| port.parse().ok())
+            .ok_or_else(|| format!("Tor reported a SOCKS listener we cannot read: {quoted}"))
+    }
+}
+
+/// The configuration tor is started with.
+fn render_torrc(
+    settings: &TorSettings,
+    home: &Path,
+    support: &Path,
+    control_port_file: &Path,
+    cookie_file: &Path,
+) -> Result<String, String> {
+    let mut config = String::new();
+    // Both auto: a fixed port is one more thing that can already be taken on a
+    // machine we do not control, and that failure looks like Tor not starting.
+    config.push_str("SocksPort auto\n");
+    config.push_str("ControlPort auto\n");
+    config.push_str(&format!(
+        "ControlPortWriteToFile {}\n",
+        quote(control_port_file)
+    ));
+    config.push_str("CookieAuthentication 1\n");
+    config.push_str(&format!("CookieAuthFile {}\n", quote(cookie_file)));
+    config.push_str(&format!("DataDirectory {}\n", quote(home)));
+    config.push_str(&format!("GeoIPFile {}\n", quote(&support.join("geoip"))));
+    config.push_str(&format!("GeoIPv6File {}\n", quote(&support.join("geoip6"))));
+    // Everything on loopback, like mihomo's controller.
+    config.push_str("SocksPolicy accept 127.0.0.0/8\n");
+    config.push_str("SocksPolicy reject *\n");
+    // Without this tor keeps running after the process that started it dies,
+    // which on a crash leaves a tunnel nothing is routed into.
+    config.push_str("__OwningControllerProcess ");
+    config.push_str(&std::process::id().to_string());
+    config.push('\n');
+
+    if settings.bridges != BridgeMode::None {
+        let lyrebird = support.join(LYREBIRD_FILENAME);
+        if !lyrebird.is_file() {
+            return Err("the pluggable transports are missing from this installation".into());
+        }
+        // A normal tor launches its own transports. The Android client had to
+        // do the managed-proxy handshake by hand because Guardian Project's JNI
+        // build aborts on `exec`; nothing here has that problem, and porting
+        // that machinery would be work for a bug we do not have.
+        config.push_str(&format!(
+            "ClientTransportPlugin meek_lite,obfs4,webtunnel,snowflake exec {}\n",
+            quote(&lyrebird)
+        ));
+        config.push_str("UseBridges 1\n");
+        for line in bridge_lines(settings, support)? {
+            config.push_str(&format!("Bridge {line}\n"));
+        }
+    }
+    Ok(config)
+}
+
+/// The bridges to write into the torrc.
+fn bridge_lines(settings: &TorSettings, support: &Path) -> Result<Vec<String>, String> {
+    match settings.bridges {
+        BridgeMode::None => Ok(Vec::new()),
+        BridgeMode::Custom => Ok(settings.bridge_lines()),
+        BridgeMode::BuiltIn => {
+            let transport = match settings.transport.trim() {
+                "" => "obfs4",
+                other => other,
+            };
+            let lines = built_in_bridges(&support.join("pt_config.json"), transport)?;
+            if lines.is_empty() {
+                return Err(format!(
+                    "this build ships no built-in {transport} bridges; paste one instead"
+                ));
+            }
+            Ok(lines)
+        }
+    }
+}
+
+/// Tor's own built-in bridges, read from the file that ships beside the binary.
+///
+/// Deliberately not a list of ours. One written by hand rots: the first list
+/// the Android client shipped was written from memory and two of its three
+/// bridges were already unreachable from an uncensored network. This one is
+/// maintained by Tor, travels with the binary it belongs to, and is covered by
+/// the same signed digest the staging script already checks.
+fn built_in_bridges(path: &Path, transport: &str) -> Result<Vec<String>, String> {
+    let body = std::fs::read_to_string(path)
+        .map_err(|error| format!("cannot read the built-in bridges: {error}"))?;
+    let config: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|error| format!("the built-in bridge list is unreadable: {error}"))?;
+    Ok(config
+        .get("bridges")
+        .and_then(|bridges| bridges.get(transport))
+        .and_then(|list| list.as_array())
+        .map(|list| {
+            list.iter()
+                .filter_map(|value| value.as_str())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// A path as torrc wants it.
+///
+/// Quoted, with backslashes doubled: a Windows path is full of them and tor
+/// reads a backslash in a quoted value as an escape, so `C:\Users\...` becomes
+/// a path with control characters in it and tor refuses the file.
+fn quote(path: &Path) -> String {
+    format!("\"{}\"", path.to_string_lossy().replace('\\', "\\\\"))
+}
+
+fn read_control_port(path: &Path, timeout: Duration) -> Result<SocketAddr, String> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(body) = std::fs::read_to_string(path) {
+            // PORT=127.0.0.1:51234
+            if let Some(address) = body.trim().strip_prefix("PORT=") {
+                if let Ok(parsed) = address.trim().parse() {
+                    return Ok(parsed);
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    Err("Tor never reported a control port".into())
+}
+
+fn read_cookie(path: &Path, timeout: Duration) -> Result<Vec<u8>, String> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if let Ok(bytes) = std::fs::read(path) {
+            if !bytes.is_empty() {
+                return Ok(bytes);
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    Err("Tor never wrote its control cookie".into())
+}
+
+/// `NOTICE BOOTSTRAP PROGRESS=25 TAG=... SUMMARY="Loading..."`
+fn parse_progress(phase: &str) -> Option<u8> {
+    phase
+        .split("PROGRESS=")
+        .nth(1)?
+        .split(|c: char| !c.is_ascii_digit())
+        .next()?
+        .parse()
+        .ok()
+}
+
+fn parse_summary(phase: &str) -> Option<String> {
+    phase.split("SUMMARY=\"").nth(1)?.split('"').next().map(str::to_string)
+}
+
+fn spawn_log_reader(
+    app: AppHandle,
+    inner: Arc<Inner>,
+    reader: Box<dyn Read + Send>,
+    generation: u64,
+) {
+    thread::spawn(move || {
+        for line in BufReader::new(reader).lines() {
+            if inner.generation.load(Ordering::SeqCst) != generation {
+                return;
+            }
+            let Ok(line) = line else { break };
+            let line = line.trim().to_string();
+            if line.is_empty() {
+                continue;
+            }
+            {
+                let mut lines = lock(&inner.lines);
+                if lines.len() == MAX_LINES {
+                    lines.pop_front();
+                }
+                lines.push_back(line.clone());
+            }
+            // Only the ones worth a person's attention reach the shared log.
+            // Tor is chatty while bootstrapping and would evict the engine's
+            // own entries from a bounded buffer.
+            if line.contains("[warn]") || line.contains("[err]") {
+                let level = if line.contains("[err]") { "error" } else { "warn" };
+                app.state::<CoreSupervisor>().record("tor", level, line);
+            }
+        }
+    });
+}
+
+fn support_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+    if let Ok(resources) = app.path().resource_dir() {
+        candidates.push(resources.join("tor"));
+        candidates.push(resources.join("binaries").join("tor"));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            candidates.push(parent.join("tor"));
+        }
+    }
+    for candidate in candidates {
+        if candidate.join("geoip").is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err("the Tor support files are missing from this installation".into())
+}
+
+fn locate(app: &AppHandle, filename: &str, extra: &[PathBuf]) -> Result<PathBuf, String> {
+    let mut candidates = extra.to_vec();
+    if let Ok(path) = std::env::var("WHITEAESTHER_TOR_PATH") {
+        if !path.trim().is_empty() {
+            candidates.push(PathBuf::from(path));
+        }
+    }
+    if let Ok(resources) = app.path().resource_dir() {
+        candidates.push(resources.join(filename));
+        candidates.push(resources.join("binaries").join(filename));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            candidates.push(parent.join(filename));
+        }
+    }
+    for candidate in candidates {
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err("the Tor carrier is missing from this installation".into())
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_progress_and_summary_are_read_from_the_control_reply() {
+        let phase = "250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=25 TAG=loading_status \
+                     SUMMARY=\"Loading networkstatus consensus\"";
+        assert_eq!(parse_progress(phase), Some(25));
+        assert_eq!(
+            parse_summary(phase).as_deref(),
+            Some("Loading networkstatus consensus")
+        );
+    }
+
+    #[test]
+    fn only_a_hundred_per_cent_counts_as_a_circuit() {
+        // The trap this carrier exists around: tor binds its SOCKS port almost
+        // at once and reports progress for a long time afterwards. Anything
+        // below 100 is a listener with nothing behind it, which accepts
+        // connections and then sits on them -- a carrier that says it works and
+        // carries nothing.
+        for progress in [0u8, 5, 25, 80, 99] {
+            let phase = format!("250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS={progress}");
+            assert!(parse_progress(&phase).unwrap() < 100, "{progress}");
+        }
+        let done = "250-status/bootstrap-phase=NOTICE BOOTSTRAP PROGRESS=100 TAG=done SUMMARY=\"Done\"";
+        assert_eq!(parse_progress(done), Some(100));
+    }
+
+    #[test]
+    fn a_pasted_bridge_keeps_its_keyword_from_being_doubled() {
+        // The page people copy from writes "Bridge obfs4 ...", and the torrc
+        // needs the keyword exactly once. Pasted verbatim without this, tor
+        // refuses the whole file with a parse error naming a line the user
+        // never wrote.
+        let settings = TorSettings {
+            bridges: BridgeMode::Custom,
+            transport: String::new(),
+            custom_bridges: "Bridge obfs4 1.2.3.4:443 ABC cert=x iat-mode=0\n\
+                             obfs4 5.6.7.8:443 DEF cert=y iat-mode=0\n\
+                             \n\
+                             # a comment\n"
+                .into(),
+        };
+        let lines = settings.bridge_lines();
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        assert!(lines[0].starts_with("obfs4 1.2.3.4"), "{lines:?}");
+        assert!(lines[1].starts_with("obfs4 5.6.7.8"), "{lines:?}");
+    }
+
+    #[test]
+    fn choosing_custom_bridges_without_pasting_any_is_refused() {
+        // Otherwise tor starts with UseBridges 1 and no bridge, which it treats
+        // as a configuration error and reports in a way nobody would connect
+        // back to an empty text box.
+        let settings = TorSettings {
+            bridges: BridgeMode::Custom,
+            transport: String::new(),
+            custom_bridges: "  \n # nothing but a comment\n".into(),
+        };
+        assert!(settings.validate().is_err());
+    }
+
+    #[test]
+    fn windows_paths_survive_the_torrc() {
+        // tor reads a backslash inside a quoted value as an escape, so an
+        // unescaped Windows path becomes one with control characters in it and
+        // the file is refused.
+        let quoted = quote(Path::new(r"C:\Users\someone\AppData\tor"));
+        assert_eq!(quoted, "\"C:\\\\Users\\\\someone\\\\AppData\\\\tor\"");
+    }
+
+    #[test]
+    fn the_built_in_bridges_come_from_tors_own_file() {
+        // Not a list of ours. The one the Android client wrote by hand had two
+        // of its three bridges already unreachable before it shipped.
+        let file = std::env::temp_dir().join("whiteaesther-pt-config-test.json");
+        std::fs::write(
+            &file,
+            r#"{"bridges":{"obfs4":["obfs4 1.2.3.4:443 A cert=x"],"snowflake":["snowflake 192.0.2.3:80 B"]}}"#,
+        )
+        .unwrap();
+        assert_eq!(built_in_bridges(&file, "obfs4").unwrap().len(), 1);
+        assert_eq!(built_in_bridges(&file, "snowflake").unwrap().len(), 1);
+        // A transport the file does not carry is empty rather than an error
+        // here; the caller turns that into a message naming the transport.
+        assert!(built_in_bridges(&file, "conjure").unwrap().is_empty());
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn a_socks_listener_is_read_from_what_tor_reports_rather_than_assumed() {
+        // SocksPort auto means tor picks one, which is what stops a fixed port
+        // colliding with whatever else is on the machine.
+        let reply = "250-net/listeners/socks=\"127.0.0.1:51234\"\r\n250 OK";
+        let quoted = reply.split('"').nth(1).unwrap();
+        let port: u16 = quoted.rsplit(':').next().unwrap().parse().unwrap();
+        assert_eq!(port, 51234);
+    }
+
+    #[test]
+    fn no_bridges_means_no_transport_plugin_line() {
+        // A ClientTransportPlugin naming a binary we did not ship would stop
+        // tor from starting at all, so it appears only when bridges do.
+        let home = Path::new("/tmp/tor");
+        let support = Path::new("/tmp/support");
+        let config = render_torrc(
+            &TorSettings::default(),
+            home,
+            support,
+            Path::new("/tmp/tor/control-port"),
+            Path::new("/tmp/tor/cookie"),
+        )
+        .unwrap();
+        assert!(!config.contains("ClientTransportPlugin"), "{config}");
+        assert!(!config.contains("UseBridges"), "{config}");
+        // The things that must always be there.
+        assert!(config.contains("SocksPort auto"), "{config}");
+        assert!(config.contains("CookieAuthentication 1"), "{config}");
+        assert!(config.contains("SocksPolicy reject *"), "{config}");
+        assert!(config.contains("__OwningControllerProcess"), "{config}");
+    }
+}
+
+/// Whether this build actually ships the Tor carrier.
+///
+/// Tor publishes no expert bundle for `windows-aarch64` or `linux-aarch64`, so
+/// a build for those targets has everything except this. The screen reads this
+/// rather than offering a carrier that cannot start -- a control that saves and
+/// does nothing is worse than one that is absent.
+pub fn is_available(app: &AppHandle) -> bool {
+    locate(app, TOR_FILENAME, &[]).is_ok() && support_dir(app).is_ok()
+}
+
+impl Tor {
+    /// Whether the child is still running. See the note on the Psiphon one:
+    /// a dead process leaves a healthy-looking snapshot behind it.
+    pub fn is_alive(&self) -> bool {
+        let mut guard = lock(&self.inner.child);
+        match guard.as_mut() {
+            Some(child) => !matches!(child.try_wait(), Ok(Some(_))),
+            None => false,
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,8 +30,7 @@
     "externalBin": [
       "binaries/aether",
       "binaries/mihomo",
-      "binaries/psiphon-tunnel-core",
-      "binaries/tor"
+      "binaries/psiphon-tunnel-core"
     ],
     "resources": {
       "../LICENSE": "licenses/whiteaesther-AGPL-3.0.txt",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,12 +29,19 @@
     "targets": "all",
     "externalBin": [
       "binaries/aether",
-      "binaries/mihomo"
+      "binaries/mihomo",
+      "binaries/psiphon-tunnel-core",
+      "binaries/tor"
     ],
     "resources": {
       "../LICENSE": "licenses/whiteaesther-AGPL-3.0.txt",
       "../licenses/mihomo-GPL-3.0.txt": "licenses/mihomo-GPL-3.0.txt",
-      "../THIRD_PARTY_NOTICES.md": "licenses/THIRD_PARTY_NOTICES.md"
+      "../THIRD_PARTY_NOTICES.md": "licenses/THIRD_PARTY_NOTICES.md",
+      "binaries/psiphon_server_entries.txt": "psiphon_server_entries.txt",
+      "../licenses/psiphon-tunnel-core-GPL-3.0.txt": "licenses/psiphon-tunnel-core-GPL-3.0.txt",
+      "binaries/tor/*": "tor/",
+      "../licenses/tor-BSD-3-Clause.txt": "licenses/tor-BSD-3-Clause.txt",
+      "../licenses/lyrebird-BSD-3-Clause.txt": "licenses/lyrebird-BSD-3-Clause.txt"
     },
     "icon": [
       "icons/32x32.png",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,6 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import type { ChainSettings, ConnectionProfile, LanSettings, CoreLogEvent, CoreProbe, CoreSnapshot } from "../types";
+import type {
+  CarrierKind,
+  ChainSettings,
+  ConnectionProfile,
+  LanSettings,
+  CoreLogEvent,
+  CoreProbe,
+  CoreSnapshot,
+  PsiphonSnapshot,
+  TorSnapshot,
+} from "../types";
 
 export function isDesktopRuntime(): boolean {
   return "__TAURI_INTERNALS__" in window;
@@ -194,6 +204,61 @@ export async function setChain(settings: ChainSettings): Promise<boolean> {
 export async function chainStatus(): Promise<ChainStatus> {
   requireDesktop();
   return invoke("chain_status");
+}
+
+/**
+ * What the Psiphon carrier is doing, including every exit country it has.
+ *
+ * The country list is Psiphon's own answer, so it is empty until the first
+ * successful connect. The screen offers "best available" until then rather than
+ * naming countries it cannot promise.
+ */
+export async function psiphonStatus(): Promise<PsiphonSnapshot> {
+  requireDesktop();
+  return invoke("psiphon_status");
+}
+
+/** What Tor is doing, including how far bootstrapping has got. */
+export async function torStatus(): Promise<TorSnapshot> {
+  requireDesktop();
+  return invoke("tor_status");
+}
+
+/**
+ * Which carriers this build can actually run.
+ *
+ * Not every build ships every one: Tor publishes no expert bundle for arm64
+ * Windows or Linux. The picker offers only what is here, rather than a control
+ * that saves and cannot start.
+ */
+export async function carriersAvailable(): Promise<CarrierKind[]> {
+  requireDesktop();
+  return invoke("carriers_available");
+}
+
+/**
+ * Asks Tor's circumvention service which bridges work in a given country.
+ *
+ * Goes out through whichever carrier is up, because the service is itself
+ * blocked in most of the places its answer is wanted. The country is the
+ * user's own and is asked for rather than guessed — inferring it from the
+ * current exit would ask about the one country the answer does not apply to.
+ */
+export async function fetchBridges(country: string): Promise<string[]> {
+  requireDesktop();
+  return invoke("fetch_bridges", { country });
+}
+
+/**
+ * Moves a live carrier to a different exit country.
+ *
+ * A restart rather than a setting change: Psiphon picks its egress during the
+ * handshake and cannot be told to move afterwards. The chain and the system
+ * proxy follow the new listener, so this takes as long as a connect does.
+ */
+export async function setPsiphonRegion(region: string): Promise<CoreSnapshot> {
+  requireDesktop();
+  return invoke("set_psiphon_region", { region });
 }
 
 /** Where another device points, and on what terms. */

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -292,6 +292,59 @@ const FA: Record<string, string> = {
   "Dial nodes through the tunnel": "شماره‌گیری نودها از داخل تونل",
   "Round-trip through the tunnel over the last eighty seconds": "زمان رفت و برگشت از تونل در هشتاد ثانیهٔ اخیر",
 
+  // -- the way out: which carrier runs, and where it comes out -----------
+  // "حامل" for carrier reads as freight rather than as a route, so the heading
+  // asks the question the screen actually answers instead of naming a concept
+  // the user has no reason to hold.
+  "Way out": "راه خروج",
+  "What carries your traffic off this network. Everything below applies to Aether only.":
+    "چه چیزی ترافیک شما را از این شبکه بیرون می‌برد. هر چه پایین‌تر است فقط به Aether مربوط می‌شود.",
+  "Cloudflare's network. Fast, and exits near you — it does not change your country.":
+    "شبکهٔ کلادفلر. سریع است و نزدیک خودتان خارج می‌شود — کشور شما را عوض نمی‌کند.",
+  "Psiphon": "سایفون",
+  "Finds its own way out and can exit from another country. Slower to connect.":
+    "خودش راه خروج را پیدا می‌کند و می‌تواند از کشوری دیگر خارج شود. کندتر وصل می‌شود.",
+  "Exit country": "کشور خروج",
+  "A preference, not a guarantee. Psiphon keeps trying rather than substituting, so a country with no capacity is a slow connect.":
+    "یک ترجیح است، نه تضمین. سایفون به‌جای جایگزینی، تلاش را ادامه می‌دهد؛ پس کشوری که ظرفیت ندارد یعنی اتصال کند.",
+  "Best available": "بهترین گزینهٔ موجود",
+  "Moving the exit. This reconnects, so it takes as long as connecting does.":
+    "در حال جابه‌جایی خروج. این کار دوباره وصل می‌شود، پس به اندازهٔ یک اتصال طول می‌کشد.",
+  "The country list is Psiphon's own and arrives once you have connected at least once.":
+    "فهرست کشورها را خود سایفون می‌دهد و پس از نخستین اتصال می‌رسد.",
+  "Under Psiphon the endpoint scanner, the pinned endpoint and the transport choice do nothing — Psiphon finds its own route.":
+    "زیر سایفون، پویشگر نقطهٔ پایانی، نقطهٔ پایانی ثابت‌شده و انتخاب ترابرد هیچ کاری نمی‌کنند — سایفون مسیر خودش را پیدا می‌کند.",
+
+  // -- Tor, and its bridges ----------------------------------------------
+  // "پل" is the settled Persian word for a Tor bridge and is what the Tor
+  // Project's own Persian pages use, so it is what someone who has read them
+  // will be looking for here.
+  "Tor": "تور",
+  "Three relays. The strongest against being identified, and the slowest. No UDP.":
+    "سه بازپخش. قوی‌ترین گزینه در برابر شناسایی، و کندترین. UDP ندارد.",
+  "Bridges": "پل‌ها",
+  "Only needed where Tor itself is blocked. Off is faster and works on an ordinary network.":
+    "فقط جایی لازم است که خود تور مسدود باشد. خاموش سریع‌تر است و روی شبکهٔ معمولی کار می‌کند.",
+  "Off": "خاموش",
+  "Built-in": "همراه برنامه",
+  "Pasted": "چسبانده‌شده",
+  "Bridge transport": "ترابرد پل",
+  "Tor ships these bridges itself, so they are as current as this build. They are also public, which is what a censor blocks first.":
+    "این پل‌ها را خود تور می‌دهد، پس به اندازهٔ همین نسخه به‌روزند. عمومی هم هستند، و سانسورچی اول همین‌ها را می‌بندد.",
+  "Bridge lines": "خط‌های پل",
+  "One per line, from bridges.torproject.org or someone who has one. A leading “Bridge” is fine — it is stripped.":
+    "هر خط یکی، از bridges.torproject.org یا از کسی که دارد. اگر اول خط «Bridge» باشد اشکالی ندارد — حذف می‌شود.",
+  "Tor carries no UDP, so QUIC and plain DNS are refused rather than left to hang. Pages still load and names still resolve.":
+    "تور UDP را حمل نمی‌کند، پس QUIC و DNS ساده رد می‌شوند تا معلق نمانند. صفحه‌ها باز می‌شوند و نام‌ها همچنان ترجمه می‌شوند.",
+  "Ask Tor for bridges": "از تور پل بگیر",
+  "The country you are connecting from, not the one you want to appear in. Sent through your current connection, because this service is itself blocked in most places it is needed.":
+    "کشوری که از آن وصل می‌شوید، نه کشوری که می‌خواهید از آن دیده شوید. از راه اتصال فعلی فرستاده می‌شود، چون خود این سرویس در بیشتر جاهایی که لازم است مسدود است.",
+  "Country you are connecting from": "کشوری که از آن وصل می‌شوید",
+  "Asking…": "در حال پرسیدن…",
+  "Fetch": "دریافت پل",
+  "Under Tor the endpoint scanner, the pinned endpoint and the transport choice do nothing — Tor picks its own relays.":
+    "زیر تور، پویشگر نقطهٔ پایانی، نقطهٔ پایانی ثابت‌شده و انتخاب ترابرد هیچ کاری نمی‌کنند — تور بازپخش‌های خودش را انتخاب می‌کند.",
+
   // -- section headings, buttons and the paragraphs between them ---------
   // Reached through the primitives in panels.tsx rather than by a call at each
   // use site, so a control added later is translated by construction.

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -5,13 +5,24 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { buildCoreCommand } from "@/core/command";
 import { endpointError, normalizeEndpoint } from "@/core/endpoint";
 import { REPORT_EVENT_LIMIT, buildReport, reportFilename } from "@/core/report";
-import { type LanStatus, lanShareStatus, saveReport, setLanShare } from "@/core/api";
+import {
+  type LanStatus,
+  carriersAvailable,
+  fetchBridges,
+  isDesktopRuntime,
+  lanShareStatus,
+  psiphonStatus,
+  saveReport,
+  setLanShare,
+  setPsiphonRegion,
+} from "@/core/api";
 import { NumberField, Row, RulesField, Seg, TextField } from "./panels";
 import { Chain } from "./Chain";
 import { Scanner } from "./Scanner";
@@ -318,6 +329,325 @@ const PROTOCOLS: Array<{ id: string; label: string; detail: string; protocol: Co
   { id: "gool", label: "WARP in WARP", detail: "Nested tunnel. Slower, harder to classify.", protocol: "gool" },
 ];
 
+/**
+ * The ways out of the network, and what each one costs.
+ *
+ * Tor is deliberately absent until it exists: an option that saves and does
+ * nothing is worse than one that is not offered.
+ */
+const CARRIERS: Array<{ id: ConnectionProfile["carrier"]; label: string; detail: string }> = [
+  {
+    id: "aether",
+    label: "Aether",
+    detail: "Cloudflare's network. Fast, and exits near you — it does not change your country.",
+  },
+  {
+    id: "psiphon",
+    label: "Psiphon",
+    detail: "Finds its own way out and can exit from another country. Slower to connect.",
+  },
+  {
+    id: "tor",
+    label: "Tor",
+    detail: "Three relays. The strongest against being identified, and the slowest. No UDP.",
+  },
+];
+
+/**
+ * Where Tor's bridges come from.
+ *
+ * The built-in list is Tor's own, shipped inside the expert bundle beside the
+ * binary it belongs to — so it can only go stale when the bundle does.
+ */
+const BRIDGE_MODES: Array<[ConnectionProfile["tor"]["bridges"], string]> = [
+  ["none", "Off"],
+  ["built-in", "Built-in"],
+  ["custom", "Pasted"],
+];
+
+const BRIDGE_TRANSPORTS: Array<[string, string]> = [
+  ["obfs4", "obfs4"],
+  ["snowflake", "snowflake"],
+  ["meek", "meek"],
+];
+
+/** Tor's bridges: off, Tor's own list, or lines the user was given. */
+function TorPanel({
+  profile,
+  onChange,
+}: Pick<AdvancedProps, "profile" | "onChange">) {
+  const set = (patch: Partial<ConnectionProfile["tor"]>) =>
+    onChange({ ...profile, tor: { ...profile.tor, ...patch } });
+
+  return (
+    <>
+      <Row
+        title="Bridges"
+        help="Only needed where Tor itself is blocked. Off is faster and works on an ordinary network."
+      >
+        <Seg value={profile.tor.bridges} options={BRIDGE_MODES} onChange={(bridges) => set({ bridges })} />
+      </Row>
+
+      {profile.tor.bridges === "built-in" ? (
+        <Row
+          title="Bridge transport"
+          help="Tor ships these bridges itself, so they are as current as this build. They are also public, which is what a censor blocks first."
+        >
+          <Seg
+            value={profile.tor.transport || "obfs4"}
+            options={BRIDGE_TRANSPORTS}
+            onChange={(transport) => set({ transport })}
+          />
+        </Row>
+      ) : null}
+
+      {profile.tor.bridges === "custom" ? (
+        <>
+          <RulesField
+            label="Bridge lines"
+            help="One per line, from bridges.torproject.org or someone who has one. A leading “Bridge” is fine — it is stripped."
+            value={profile.tor.customBridges}
+            onChange={(customBridges) => set({ customBridges })}
+            placeholder="obfs4 1.2.3.4:443 FINGERPRINT cert=… iat-mode=0"
+          />
+          <BridgeFetch
+            onFetched={(lines) =>
+              set({
+                // Appended rather than replacing: someone who was given a
+                // working line by a friend should not lose it to a button.
+                customBridges: [profile.tor.customBridges.trim(), lines.join("\n")]
+                  .filter(Boolean)
+                  .join("\n"),
+              })
+            }
+          />
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * The one-tap fetch: ask Tor which bridges work in a country.
+ *
+ * The request goes out through whichever carrier is already up, because
+ * `bridges.torproject.org` is blocked in most of the places its answer is
+ * wanted. And it asks about the country the person is *in*, which is why there
+ * is a field rather than a guess — a desktop has no SIM to read one from, and
+ * inferring it from the current exit would ask about the one country the answer
+ * does not apply to.
+ */
+function BridgeFetch({ onFetched }: { onFetched: (lines: string[]) => void }) {
+  const t = useT();
+  const [country, setCountry] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  const ask = async () => {
+    setFailure(null);
+    setNote(null);
+    setBusy(true);
+    try {
+      const lines = await fetchBridges(country);
+      onFetched(lines);
+      setNote(`${lines.length} ${lines.length === 1 ? "bridge added" : "bridges added"}`);
+    } catch (error) {
+      setFailure(String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Row
+        title="Ask Tor for bridges"
+        help="The country you are connecting from, not the one you want to appear in. Sent through your current connection, because this service is itself blocked in most places it is needed."
+      >
+        <div className="flex items-center gap-2">
+          <Input
+            value={country}
+            onChange={(event) => setCountry(event.target.value.toUpperCase().slice(0, 2))}
+            placeholder="IR"
+            className="h-9 w-16 text-center font-mono text-[13px]"
+            aria-label={t("Country you are connecting from")}
+          />
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy || country.trim().length !== 2}
+            onClick={() => void ask()}
+          >
+            {busy ? t("Asking…") : t("Fetch")}
+          </Button>
+        </div>
+      </Row>
+      {note ? <p className="pb-1 text-[12.5px] text-muted-foreground">{note}</p> : null}
+      {failure ? <p className="pb-1 text-[12.5px] text-destructive">{failure}</p> : null}
+    </>
+  );
+}
+
+/**
+ * Choosing the way out, and where it comes out.
+ *
+ * The country list is Psiphon's own answer rather than a table of ours, so it
+ * is empty until the first successful connect — the field says "best available"
+ * until then instead of offering countries it cannot promise.
+ */
+function CarrierPanel({
+  profile,
+  onChange,
+}: Pick<AdvancedProps, "profile" | "onChange">) {
+  const t = useT();
+  const set = (patch: Partial<ConnectionProfile>) => onChange({ ...profile, ...patch });
+  const [regions, setRegions] = useState<string[]>([]);
+  const [moving, setMoving] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  // Everything until the backend answers. A picker that starts empty and fills
+  // in would flicker; one that starts full and removes a carrier is worse,
+  // because someone may have clicked it already.
+  const [available, setAvailable] = useState<ConnectionProfile["carrier"][] | null>(null);
+
+  useEffect(() => {
+    if (!isDesktopRuntime()) return;
+    let cancelled = false;
+    carriersAvailable()
+      .then((list) => {
+        if (!cancelled) setAvailable(list);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (profile.carrier !== "psiphon" || !isDesktopRuntime()) return;
+    let cancelled = false;
+    const read = () =>
+      psiphonStatus()
+        .then((status) => {
+          if (!cancelled) setRegions(status.availableRegions);
+        })
+        .catch(() => {});
+    read();
+    // Psiphon reports its countries after a handshake, so the list arrives some
+    // time after the screen does. Polling rather than waiting for an event
+    // because it changes at most once per session.
+    const timer = window.setInterval(read, 5_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [profile.carrier]);
+
+  const chooseRegion = async (region: string) => {
+    set({ psiphon: { ...profile.psiphon, egressRegion: region } });
+    if (!isDesktopRuntime()) return;
+    setFailure(null);
+    setMoving(true);
+    try {
+      // Applies to a live session; a no-op when nothing is connected, in which
+      // case the choice above still stands for the next connect.
+      await setPsiphonRegion(region);
+    } catch (error) {
+      setFailure(String(error));
+    } finally {
+      setMoving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-[15px]">{t("Way out")}</CardTitle>
+        <CardDescription>
+          {t("What carries your traffic off this network. Everything below applies to Aether only.")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="grid grid-cols-2 gap-2.5">
+          {CARRIERS.filter((option) => !available || available.includes(option.id)).map((option) => {
+            const on = profile.carrier === option.id;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                aria-pressed={on}
+                onClick={() => set({ carrier: option.id })}
+                className={`rounded-lg border p-3 text-left transition ${
+                  on ? "border-primary bg-primary/5" : "border-border hover:border-primary/40"
+                }`}
+              >
+                <div className="text-[13.5px] font-medium">{t(option.label)}</div>
+                <div className="mt-1 text-[12.5px] leading-snug text-muted-foreground">
+                  {t(option.detail)}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {profile.carrier === "psiphon" ? (
+          <>
+            <Row title="Exit country" help="A preference, not a guarantee. Psiphon keeps trying rather than substituting, so a country with no capacity is a slow connect.">
+              <select
+                value={profile.psiphon.egressRegion}
+                disabled={moving}
+                onChange={(event) => void chooseRegion(event.target.value)}
+                className="h-9 rounded-md border border-input bg-background px-2 text-[13px]"
+              >
+                <option value="">{t("Best available")}</option>
+                {regions.map((region) => (
+                  <option key={region} value={region}>
+                    {region}
+                  </option>
+                ))}
+              </select>
+            </Row>
+            {moving ? (
+              <p className="pb-1 text-[12.5px] text-muted-foreground">
+                {t("Moving the exit. This reconnects, so it takes as long as connecting does.")}
+              </p>
+            ) : null}
+            {failure ? <p className="pb-1 text-[12.5px] text-destructive">{failure}</p> : null}
+            {regions.length === 0 ? (
+              <p className="pb-1 text-[12.5px] text-muted-foreground">
+                {t("The country list is Psiphon's own and arrives once you have connected at least once.")}
+              </p>
+            ) : null}
+            {/* The brief's rule, made visible rather than left to be discovered:
+                the scanner, the pinned endpoint and the discovery depth all
+                describe a hunt for a Cloudflare gateway, and none of them do
+                anything here. */}
+            <p className="pt-2 text-[12.5px] leading-snug text-muted-foreground">
+              {t("Under Psiphon the endpoint scanner, the pinned endpoint and the transport choice do nothing — Psiphon finds its own route.")}
+            </p>
+          </>
+        ) : null}
+
+        {profile.carrier === "tor" ? (
+          <>
+            <TorPanel profile={profile} onChange={onChange} />
+            {/* Said plainly rather than left to be met as a fault. Tor carries
+                no datagrams, so the chain refuses them rather than swallowing
+                them — which is what makes a resolver fall back to TCP within a
+                round trip instead of hanging. */}
+            <p className="pt-2 text-[12.5px] leading-snug text-muted-foreground">
+              {t("Tor carries no UDP, so QUIC and plain DNS are refused rather than left to hang. Pages still load and names still resolve.")}
+            </p>
+            <p className="pt-1 text-[12.5px] leading-snug text-muted-foreground">
+              {t("Under Tor the endpoint scanner, the pinned endpoint and the transport choice do nothing — Tor picks its own relays.")}
+            </p>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
 function Routes({ profile, onChange }: AdvancedProps) {
   const t = useT();
   const set = (patch: Partial<ConnectionProfile>) => onChange({ ...profile, ...patch });
@@ -328,6 +658,7 @@ function Routes({ profile, onChange }: AdvancedProps) {
 
   return (
     <>
+      <CarrierPanel profile={profile} onChange={onChange} />
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-[15px]">{t("Protocol")}</CardTitle>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,81 @@ export const ENDPOINT_MODES: Array<{ id: EndpointMode; label: string; detail: st
   { id: "custom-only", label: "Custom only", detail: "Use the pinned address or fail." },
 ];
 
+/**
+ * What gets us out of the network.
+ *
+ * Each one ends in a SOCKS5 listener on loopback that mihomo routes the
+ * interface into. The strings are a stored format — they are what the backend
+ * serialises into the saved profile.
+ */
+export type CarrierKind = "aether" | "psiphon" | "tor";
+
+export interface PsiphonSettings {
+  /**
+   * A two-letter country to exit from, or empty for whichever Psiphon
+   * considers best.
+   *
+   * A preference and not a guarantee: Psiphon treats an unreachable region as
+   * a reason to keep trying rather than to substitute, so a country with no
+   * capacity is a slow connect rather than a different exit than the one asked
+   * for.
+   */
+  egressRegion: string;
+}
+
+/**
+ * Which bridges Tor should use, if any.
+ *
+ * "built-in" is Tor's own list, shipped inside the expert bundle beside the
+ * binary — not a list of ours, which would rot between releases.
+ */
+export type BridgeMode = "none" | "built-in" | "custom";
+
+export interface TorSettings {
+  bridges: BridgeMode;
+  /** Which transport to take from the built-in list. */
+  transport: string;
+  /** Bridge lines pasted by hand, one per line. */
+  customBridges: string;
+}
+
+/** What Tor is doing, as the backend reports it. */
+export interface TorSnapshot {
+  state: "idle" | "connecting" | "connected" | "error";
+  pid: number | null;
+  socksPort: number | null;
+  /**
+   * How far bootstrapping has got, 0–100.
+   *
+   * Only 100 counts as connected: Tor binds its SOCKS port long before it has
+   * a circuit, and a listener with nothing behind it accepts connections and
+   * then sits on them.
+   */
+  bootstrap: number;
+  /** What Tor says it is doing, in its own words. */
+  bootstrapSummary: string | null;
+  lastError: string | null;
+}
+
+/** What the Psiphon carrier is doing, as the backend reports it. */
+export interface PsiphonSnapshot {
+  state: "idle" | "connecting" | "connected" | "error";
+  pid: number | null;
+  socksPort: number | null;
+  /** The country the connected server is in, as Psiphon reports it. */
+  exitRegion: string | null;
+  /**
+   * Every country Psiphon last said it had.
+   *
+   * Empty until the first successful connect, because this is Psiphon's own
+   * answer rather than a table of ours — which is honest: we do not know what
+   * it has until it tells us.
+   */
+  availableRegions: string[];
+  lastError: string | null;
+  statusMessage: string | null;
+}
+
 /** A subscription or pasted-config source feeding the chain. */
 export interface ChainSource {
   name: string;
@@ -110,6 +185,18 @@ export interface ConnectionProfile {
   systemProxy: boolean;
   /** Keep retrying after a route drops, rather than leaving it dead. */
   autoReconnect: boolean;
+  /**
+   * Which way out of the network to use.
+   *
+   * Everything else in this profile describes the Aether engine and applies
+   * only when this is "aether". A profile saved before carriers existed names
+   * none, which the backend reads as "aether".
+   */
+  carrier: CarrierKind;
+  /** How the Psiphon carrier runs. Ignored unless `carrier` selects it. */
+  psiphon: PsiphonSettings;
+  /** How the Tor carrier runs. Ignored unless `carrier` selects it. */
+  tor: TorSettings;
   /** The second hop that changes the exit address. Off unless configured. */
   chain: ChainSettings;
   /** Whether other devices on this network may use the tunnel. */
@@ -196,6 +283,9 @@ export const DEFAULT_PROFILE: ConnectionProfile = {
   gateway: false,
   systemProxy: false,
   autoReconnect: true,
+  carrier: "aether",
+  psiphon: { egressRegion: "" },
+  tor: { bridges: "none", transport: "obfs4", customBridges: "" },
   chain: { enabled: false, throughTunnel: true, sources: [], manual: "", node: null },
   lanShare: { enabled: false, port: 1080, username: "", password: "" },
   killSwitch: false,


### PR DESCRIPTION
Ports the Android client's carrier work to the desktop, following the six phases in `PORT-CARRIERS.md`. Every gate was checked by measurement — the brief's own rule is that building is not evidence.

## What a carrier is

Whatever gets us out of the network, ending in a SOCKS5 listener that mihomo routes the interface into. The app already worked this way and did not know it: `chain.rs` named Aether in three constants, so nothing else could ever be on the other end.

Those three became one `Carrier`: the proxy name every node dials through, the process exempted from the TUN device, and whether datagrams survive. The second one matters more than it reads — getting it wrong under full tunnel is not a degraded connection but total silent loss, as the carrier's own packets get handed back to the carrier that produced them.

## The gates

| Phase | Gate | Evidence |
|---|---|---|
| 1 | Aether path unchanged | config renders byte-identical; run on a live machine |
| 2 | Psiphon carries traffic | request from a separate process left through France |
| 3 | Country moves the exit | pinned US → a US address |
| 4 | Tor reaches an exit relay | `{"IsTor":true,"IP":"152.53.170.213"}` from Tor's own check |
| 5 | Bridges | Tor's built-in list ships; the moat service returned 6 real lines for Iran |
| 6 | Carrier failure is caught | watcher added; kill switch honoured on the carrier path |

152 Rust tests, 45 frontend tests, clean typecheck, clean build.

## Three places this disagrees with the brief

**Psiphon's console client cannot be downloaded.** Upstream publishes only library archives — no executable, and the c-shared libraries would mean FFI and a Go runtime inside the Tauri process. It is built from source at a pinned revision instead. **CI will need a Go toolchain it does not have today.**

**Tor's bundle ships better bridge lists than porting `refresh-bridges.ps1` would produce.** `pt_config.json` carries Tor's own obfs4/snowflake/meek lists, covered by the same signed digest the staging script already verifies. Maintaining our own would reproduce something that arrives fresher and free.

**The moat endpoint takes plain `{"country":"xx"}`,** not the JSON-API envelope. The envelope gets a `200` with the country silently replaced by the request's source address — an empty answer that reads as "no bridges needed here". Caught by testing against the live service rather than the shape.

## Notes

- Verification is stronger than usual in two places: mihomo's digests are now *verified* rather than merely printed, and Tor's are taken from Tor's own signed manifest rather than computed from bytes we happened to receive.
- Tor publishes no arm64 expert bundle. Those builds ship without it, and the app offers only the carriers it actually has rather than a control that cannot start.
- **No version bump**, so this merges without publishing a release.

## Known gaps

- Tor bridges have never reached a circuit from an uncensored network — `bridges: none` is what was tested.
- The carrier watcher is unit-tested but no live carrier has been killed to watch it fire.
- Psiphon reports `carries_quic: false` because it was never measured; that labels hysteria2 nodes unusable behind it, which costs a label and risks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
