### PR TITLE
Do not quote the transport binary in the torrc, and never have

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -155,3 +155,11 @@ The Rust and JavaScript dependencies are recorded in `src-tauri/Cargo.lock` and 
 each under its own licence — predominantly MIT and Apache-2.0. Notable components include Tauri
 (MIT/Apache-2.0), React (MIT), Radix UI (MIT), Tailwind CSS (MIT), shadcn/ui (MIT) and Lucide
 (ISC).
+
+Two are named separately because they are not MIT or Apache-2.0 and are compiled into the shipped
+binary. `rustls` (Apache-2.0 OR ISC OR MIT) with its `ring` provider (Apache-2.0 AND ISC) is the TLS
+client, present for exactly one request: asking Tor's circumvention service which bridges work in a
+given country, which has to travel through whichever carrier is up. `webpki-roots`
+(CDLA-Permissive-2.0) supplies the trust anchors for that request — Mozilla's CA set, pinned in the
+build rather than read from the machine, so a root added to this computer cannot read a request made
+through a carrier.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -101,13 +101,16 @@ over documented interfaces, and none of their code is linked into WhiteAesther.
 
 - Upstream: <https://gitlab.torproject.org/tpo/core/tor> and
   <https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/lyrebird>
-- The build shipped here: the **Tor Expert Bundle** `15.0.21`, downloaded unmodified by
+- The build shipped here: the **Tor Expert Bundle** `15.0.22`, downloaded unmodified by
   `scripts/stage-tor.mjs` and verified against the SHA-256 Tor publishes for it in
   `sha256sums-signed-build.txt` — so the check is against Tor's own number, not one we computed from
   bytes we happened to receive. The Windows x86-64 bundle we ship is
-  `f22b8b17cb18c9fa775dfcf68acf6a2fe788336535fe94645204ca85158aa490`; the digests for the other
+  `231dad6b9cb401a54c260db7046965ef04e4f72ff071b140d423fb5da281ab1e`; the digests for the other
   targets are in `BUNDLES` in that script.
-- Corresponding source: <https://dist.torproject.org/torbrowser/15.0.21/>
+- Corresponding source: <https://dist.torproject.org/torbrowser/15.0.22/> — note that Tor keeps only
+  the current release there, so an older version named in a past build of this file will 404. The
+  revision is still the record of what we shipped; `gitlab.torproject.org/tpo/core/tor` has the
+  source for every version.
 - Licence: BSD 3-Clause. The full texts are in `licenses/tor-BSD-3-Clause.txt` and
   `licenses/lyrebird-BSD-3-Clause.txt`, copied out of that same archive rather than fetched
   separately — a licence file that can drift from the build it describes is worse than none.

--- a/scripts/stage-tor.mjs
+++ b/scripts/stage-tor.mjs
@@ -34,8 +34,17 @@ const option = (name) => {
   return index === -1 ? undefined : process.argv[index + 1];
 };
 
-/** Pinned so a build is reproducible. Bump deliberately, digests and all. */
-const VERSION = "15.0.21";
+/**
+ * Pinned so a build is reproducible. Bump deliberately, digests and all.
+ *
+ * This one expires, unlike the others. `dist.torproject.org/torbrowser/` keeps
+ * only the current release -- 15.0.21 was pinned here and staging began failing
+ * with a plain 404 the day 15.0.22 replaced it. A pin protects against the
+ * asset changing under us; it cannot keep the asset alive. Expect to bump this
+ * on roughly Tor Browser's release cadence, and note that a green build says
+ * nothing about tomorrow.
+ */
+const VERSION = "15.0.22";
 
 /**
  * Rust target triple to the bundle that serves it, with the SHA-256 Tor
@@ -58,19 +67,19 @@ const VERSION = "15.0.21";
 const BUNDLES = {
   "x86_64-pc-windows-msvc": {
     asset: `tor-expert-bundle-windows-x86_64-${VERSION}.tar.gz`,
-    sha256: "f22b8b17cb18c9fa775dfcf68acf6a2fe788336535fe94645204ca85158aa490",
+    sha256: "231dad6b9cb401a54c260db7046965ef04e4f72ff071b140d423fb5da281ab1e",
   },
   "x86_64-apple-darwin": {
     asset: `tor-expert-bundle-macos-x86_64-${VERSION}.tar.gz`,
-    sha256: "7e21f5dab4c627e2ff8e894b2039fa49bdd78d12b025f96893d4d6238c6577e4",
+    sha256: "be1be1cb13cd093713f02a0beade0d2471b61119011bfeb0efc08353eadf2e4e",
   },
   "aarch64-apple-darwin": {
     asset: `tor-expert-bundle-macos-aarch64-${VERSION}.tar.gz`,
-    sha256: "83dec16412c1d97b91af603229481dd29f578e1485620ecffd9ac4aabcf6fb46",
+    sha256: "e8ea3f667c83309abad34280f0f9e1cfae52843da6b8db111ca15d6221051db5",
   },
   "x86_64-unknown-linux-gnu": {
     asset: `tor-expert-bundle-linux-x86_64-${VERSION}.tar.gz`,
-    sha256: "40ef58c536d7077543a25707be5ba467f4b6bcdbafdc015daa25bcf9cb1edc11",
+    sha256: "08d49de27f542b8f73e2014e064d8320562b5d20019c03d4725c5a5249d97985",
   },
 };
 

--- a/src-tauri/src/psiphon.rs
+++ b/src-tauri/src/psiphon.rs
@@ -240,6 +240,20 @@ impl Psiphon {
         lock(&self.inner.notices).iter().cloned().collect()
     }
 
+    /// Whether the child is still running.
+    ///
+    /// Asked of the process rather than of the snapshot: the notice reader
+    /// simply ends when the pipe closes, so a process that died leaves the last
+    /// state it reported sitting there looking healthy. Nothing else would ever
+    /// notice, and the screen would say connected over a listener that is gone.
+    pub fn is_alive(&self) -> bool {
+        let mut guard = lock(&self.inner.child);
+        match guard.as_mut() {
+            Some(child) => !matches!(child.try_wait(), Ok(Some(_))),
+            None => false,
+        }
+    }
+
     /// Starts Psiphon and waits for a tunnel.
     ///
     /// Blocking, and returns only once there is something to route into or a
@@ -640,6 +654,14 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Whether this build ships the Psiphon carrier and the list it bootstraps from.
+///
+/// Both are required: the binary without the server list spends two minutes
+/// dialling nothing and then reports that it could not connect.
+pub fn is_available(app: &AppHandle) -> bool {
+    locate(app).is_ok() && locate_server_list(app).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -777,26 +799,3 @@ mod tests {
     }
 }
 
-/// Whether this build ships the Psiphon carrier and the list it bootstraps from.
-///
-/// Both are required: the binary without the server list spends two minutes
-/// dialling nothing and then reports that it could not connect.
-pub fn is_available(app: &AppHandle) -> bool {
-    locate(app).is_ok() && locate_server_list(app).is_ok()
-}
-
-impl Psiphon {
-    /// Whether the child is still running.
-    ///
-    /// Asked of the process rather than of the snapshot: the notice reader
-    /// simply ends when the pipe closes, so a process that died leaves the last
-    /// state it reported sitting there looking healthy. Nothing else would ever
-    /// notice, and the screen would say connected over a listener that is gone.
-    pub fn is_alive(&self) -> bool {
-        let mut guard = lock(&self.inner.child);
-        match guard.as_mut() {
-            Some(child) => !matches!(child.try_wait(), Ok(Some(_))),
-            None => false,
-        }
-    }
-}

--- a/src-tauri/src/tor.rs
+++ b/src-tauri/src/tor.rs
@@ -227,6 +227,16 @@ impl Tor {
         lock(&self.inner.lines).iter().cloned().collect()
     }
 
+    /// Whether the child is still running. See the note on the Psiphon one:
+    /// a dead process leaves a healthy-looking snapshot behind it.
+    pub fn is_alive(&self) -> bool {
+        let mut guard = lock(&self.inner.child);
+        match guard.as_mut() {
+            Some(child) => !matches!(child.try_wait(), Ok(Some(_))),
+            None => false,
+        }
+    }
+
     /// Starts tor and waits for a circuit.
     pub fn start(&self, app: &AppHandle, settings: &TorSettings) -> Result<SocketAddr, String> {
         settings.validate()?;
@@ -544,9 +554,22 @@ fn render_torrc(
         // do the managed-proxy handshake by hand because Guardian Project's JNI
         // build aborts on `exec`; nothing here has that problem, and porting
         // that machinery would be work for a bug we do not have.
+        //
+        // The path is NOT quoted here, unlike every other path in this file.
+        // tor strips quotes from its own options but passes the `exec` argument
+        // through to CreateProcess as written, so a quoted path becomes a file
+        // name with quotation marks in it:
+        //
+        //     Managed proxy ""…/lyrebird.exe"" having PID 0 terminated
+        //     CreateProcessA() failed: The system cannot find the file specified
+        //
+        // and then every bridge fails with "there is no configured transport
+        // called obfs4". Measured, both ways: unquoted works, and it works even
+        // when the path contains a space -- which the installed path does,
+        // under `C:\Program Files`.
         config.push_str(&format!(
             "ClientTransportPlugin meek_lite,obfs4,webtunnel,snowflake exec {}\n",
-            quote(&lyrebird)
+            lyrebird.to_string_lossy()
         ));
         config.push_str("UseBridges 1\n");
         for line in bridge_lines(settings, support)? {
@@ -738,6 +761,19 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Whether this build actually ships the Tor carrier.
+///
+/// Tor publishes no expert bundle for `windows-aarch64` or `linux-aarch64`, so
+/// a build for those targets has everything except this. The screen reads this
+/// rather than offering a carrier that cannot start -- a control that saves and
+/// does nothing is worse than one that is absent.
+pub fn is_available(app: &AppHandle) -> bool {
+    let Ok(support) = support_dir(app) else {
+        return false;
+    };
+    locate(app, TOR_FILENAME, &[support.join(TOR_FILENAME)]).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -840,6 +876,55 @@ mod tests {
     }
 
     #[test]
+    fn the_transport_binary_is_the_one_path_that_must_not_be_quoted() {
+        // tor strips quotes from its own options but hands the `exec` argument
+        // to CreateProcess as written, so a quoted path becomes a file name
+        // with quotation marks in it. It fails with "CreateProcessA() failed:
+        // The system cannot find the file specified", and then every bridge
+        // reports "there is no configured transport called obfs4" -- which
+        // points at the bridge list rather than at the one line that is wrong.
+        //
+        // Measured both ways. Unquoted also survives a space in the path, which
+        // matters because the installed path is under `C:\Program Files`.
+        let support = std::env::temp_dir().join("whiteaesther-pt-quote-test");
+        std::fs::create_dir_all(&support).unwrap();
+        let lyrebird = support.join(LYREBIRD_FILENAME);
+        std::fs::write(&lyrebird, b"not a real binary").unwrap();
+        std::fs::write(
+            support.join("pt_config.json"),
+            r#"{"bridges":{"obfs4":["obfs4 1.2.3.4:443 A cert=x"]}}"#,
+        )
+        .unwrap();
+
+        let config = render_torrc(
+            &TorSettings {
+                bridges: BridgeMode::BuiltIn,
+                transport: "obfs4".into(),
+                custom_bridges: String::new(),
+            },
+            Path::new("/tmp/tor"),
+            &support,
+            Path::new("/tmp/tor/control-port"),
+            Path::new("/tmp/tor/cookie"),
+        )
+        .unwrap();
+
+        let plugin = config
+            .lines()
+            .find(|line| line.starts_with("ClientTransportPlugin"))
+            .expect("a transport plugin line");
+        assert!(!plugin.contains('"'), "the exec path must not be quoted: {plugin}");
+        assert!(plugin.contains(&lyrebird.to_string_lossy().to_string()), "{plugin}");
+
+        // And the paths that are tor's own options still are quoted, or a
+        // Windows path breaks them instead.
+        assert!(config.contains("DataDirectory \""), "{config}");
+        assert!(config.contains("CookieAuthFile \""), "{config}");
+
+        let _ = std::fs::remove_dir_all(&support);
+    }
+
+    #[test]
     fn no_bridges_means_no_transport_plugin_line() {
         // A ClientTransportPlugin naming a binary we did not ship would stop
         // tor from starting at all, so it appears only when bridges do.
@@ -863,27 +948,3 @@ mod tests {
     }
 }
 
-/// Whether this build actually ships the Tor carrier.
-///
-/// Tor publishes no expert bundle for `windows-aarch64` or `linux-aarch64`, so
-/// a build for those targets has everything except this. The screen reads this
-/// rather than offering a carrier that cannot start -- a control that saves and
-/// does nothing is worse than one that is absent.
-pub fn is_available(app: &AppHandle) -> bool {
-    let Ok(support) = support_dir(app) else {
-        return false;
-    };
-    locate(app, TOR_FILENAME, &[support.join(TOR_FILENAME)]).is_ok()
-}
-
-impl Tor {
-    /// Whether the child is still running. See the note on the Psiphon one:
-    /// a dead process leaves a healthy-looking snapshot behind it.
-    pub fn is_alive(&self) -> bool {
-        let mut guard = lock(&self.inner.child);
-        match guard.as_mut() {
-            Some(child) => !matches!(child.try_wait(), Ok(Some(_))),
-            None => false,
-        }
-    }
-}


### PR DESCRIPTION
Found by a pre-release audit, before the release rather than after it.

## The blocker

**Every Tor bridge failed, on every platform.** tor strips quotes from its own options but hands the `exec` argument of `ClientTransportPlugin` straight to CreateProcess, so a quoted path becomes a file name with quotation marks in it:

```
Managed proxy ""…/lyrebird.exe"" having PID 0 terminated
CreateProcessA() failed: The system cannot find the file specified
[warn] Can't use bridge: there is no configured transport called "obfs4"
```

All seven built-in bridges were refused. The error pointed at the bridge list rather than at the one line that was wrong, so someone who actually needed a bridge would have concluded the bridges were dead.

Measured both ways: unquoted works, and it works with a space in the path — which matters, because the installed path is under `C:\Program Files`.

**Gate, now genuinely closed:** a circuit through a built-in obfs4 bridge reaches `Bootstrapped 100%`, and `check.torproject.org` answers `{"IsTor":true,"IP":"45.84.107.172"}` through it.

The golden config test missed this because it only covers the no-bridge shape. The new test asserts the exec path carries no quotes while tor's own options still do.

## Two smaller things the audit turned up

- `is_alive` and `is_available` sat *after* their test modules — appended rather than inserted, and clippy said so. Moved into place; zero clippy warnings in the four new files now.
- `webpki-roots` is **CDLA-Permissive-2.0**, which "predominantly MIT and Apache-2.0" does not cover. Named in the notices along with `rustls`/`ring`, with why the TLS client exists and why the trust anchors are pinned in the build rather than read from the machine.

## Not fixed here

The carrier watcher still has never fired against a live process — unit-tested only.

No version bump, so this merges without publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
