### PR TITLE
1.8.0 — three ways out of the network instead of one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.8.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "getrandom 0.3.4",
  "rustls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.7.1"
+version = "1.8.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Merging this publishes the release: the gate sets `publish=true` when the merged version has no release yet, and v1.8.0 has none.

## What changed for people using it

Until now traffic left through Cloudflare, which is explicit that it does not change your country — it egresses near you, so someone in Iran connects and still looks like they are in Iran. The only way around that was the exit chain.

This release makes the way out itself a choice, under **Advanced → Routes & transports → Way out**:

- **Aether** — what you have now. Fastest, does not change your country.
- **Psiphon** — finds its own path, and can exit from another country. 25 of them, read from Psiphon's own available-regions notice rather than a table of ours, so it cannot go stale silently.
- **Tor** — three relays. Bridges for networks that block Tor itself, including a one-tap fetch from Tor's own circumvention service that travels through whichever carrier is already up, because that service is blocked in most of the places its answer is wanted.

Everything already here composes with all three: mihomo still owns the interface and routes it into whichever carrier is running, so the exit chain, whole-machine and full tunnel are unaffected.

## Verified rather than assumed

Each measured from a separate process, through the carrier's own listener:

| | |
|---|---|
| Psiphon, unpinned | exited in France |
| Psiphon, pinned US | exited at a US address |
| Tor, direct | `{"IsTor":true}` from Tor's own check |
| Tor, built-in obfs4 bridge | `Bootstrapped 100%`, exit relay answered |
| Aether | config renders byte-identical to before the carrier work |

## One gap, stated plainly

The carrier watcher — the code that decides what happens to traffic when a carrier process dies — is unit-tested but has never fired against a live process. Everything else above was observed working end to end.

Checking it takes two minutes after install: connect with Psiphon, kill `psiphon-tunnel-core.exe`, and the app should go to error within about two seconds, closing the chain and honouring the kill switch.

## Notes for the next release

`scripts/stage-tor.mjs` pins Tor Browser `15.0.22`. That pin **expires** — `dist.torproject.org` keeps only the current release, and 15.0.21 started 404ing mid-review. Expect to bump it on Tor's cadence; a green build says nothing about next month's.

CI now needs a Go toolchain, because Psiphon publishes no console client and is compiled from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
