### PR TITLE
1.8.1 — Psiphon carries no datagrams, and the Aether-only controls go away

### DIFF
--- a/CARRIER-CHAINING.md
+++ b/CARRIER-CHAINING.md
@@ -1,0 +1,272 @@
+# Chaining two carriers
+
+A carrier is whatever gets us out of the network, and `PORT-CARRIERS.md` left the
+app with three of them, one at a time. This is the design for running two in
+sequence: the first leaves the local network, the second decides the exit
+address, and the subscription node — if there is one — sits after both.
+
+Everything below rests on measurement rather than reading. Every claim marked
+**measured** was produced on 2026-09-10 against the shipped 1.8.0 binaries, and
+the method is recorded so it can be repeated when a version moves.
+
+## The shape
+
+```
+applications → mihomo → hop 1 → hop 2 → [exit node] → internet
+                          ↑        ↑
+              leaves this network  decides the exit address
+```
+
+mihomo already owns the interface and dials whatever carrier is running. It does
+not need to know there are two: it dials **hop 2's** listener, and hop 2 has been
+configured to make its own outbound connections through hop 1. Nothing in
+`chain.rs` learns a new concept; it learns that some of its inputs are now
+plural.
+
+## How each carrier is told to use the one before it
+
+Three mechanisms, one per carrier. Each covers two of the six orderings, which
+is why three tests were enough.
+
+| Carrier | Setting | Measured |
+|---|---|---|
+| Psiphon | `UpstreamProxyURL: "socks5://127.0.0.1:PORT"` | ✅ 15 connections arrived at a proxy under our control; tunnel established through it |
+| Tor | `Socks5Proxy 127.0.0.1:PORT` in the torrc | ✅ 5 connections arrived; bootstrapped to 50% through it |
+| Aether | `AETHER_UPSTREAM=socks5://127.0.0.1:PORT` (already a profile field) | ✅ with a precondition — see below |
+
+**Method.** A SOCKS5 proxy under our own control, logging every request, placed
+where the previous hop would be. This distinguishes *the option is accepted* from
+*the option is used*: a carrier that ignores the setting connects anyway, and
+from the outside the two look identical. That is the failure worth catching —
+the user believes they have two hops and has one.
+
+## The nine findings
+
+### 1. Aether cannot register a new identity through a chain — measured
+
+Confirmed three separate ways: through our own proxy, through a real Psiphon
+tunnel, and through the proxy again with full SOCKS logging. Same failure each
+time.
+
+The cause is Aether's own anti-censorship design. In the proxy log, **the only
+hostname connection was the test's own** — Aether never asks for
+`api.cloudflareclient.com` by name. It dials raw Cloudflare edge addresses with
+a spoofed SNI so that DNS cannot be poisoned or blocked, and through a SOCKS
+proxy that fails: the direct route with a transport error, then the camouflaged
+route with `cert verification failed — unable to get local issuer certificate`.
+
+**With an existing identity it works completely.** The identity loads, the
+upstream is used, the cached gateway is reused, and traffic exits at a Cloudflare
+address while the proxy logs the connection to the MASQUE gateway.
+
+So: `Psiphon → Aether` and `Tor → Aether` require Aether to have registered at
+least once **directly**. The app must guarantee that before offering Aether as a
+second hop, and say so plainly when it cannot — a fresh install whose first
+action is `Psiphon → Aether` will otherwise fail with a message about
+registration that names nothing the user can act on.
+
+### 2. Any chain containing Psiphon or Tor is TCP-only — measured
+
+Psiphon's SOCKS5 refuses `UDP ASSOCIATE` with `0x07 COMMAND NOT SUPPORTED`. Tor
+carries no datagrams by design.
+
+`carries_udp` and `carries_quic` stop being properties of *a* carrier and become
+properties of *the chain*, computed as the AND across hops. Two consequences,
+and both must reach the screen rather than being discovered:
+
+- Aether in such a chain can only use **MASQUE H2**. H3 rides QUIC and WireGuard
+  is UDP; both die at the TCP-only hop. Those options must be disabled, not
+  merely annotated.
+- The `udp: false` declaration and the `NETWORK,udp,REJECT` rule already written
+  for Tor now apply to any chain with a TCP-only hop.
+
+### 3. Psiphon does not leak when its upstream fails — measured
+
+Pointed at a proxy that refused every connection, Psiphon made **1340 attempts
+and never once connected directly**. `tunnels: (none)`.
+
+This is what makes a chain trustworthy. Someone who picks `Aether → Psiphon` so
+that the local network sees only Cloudflare gets that guarantee even when Aether
+drops: Psiphon fails closed rather than revealing the thing it was hiding.
+
+### 4. But it hammers while it fails — measured
+
+Those 1340 attempts are the same finding read the other way. If hop 1 dies, hop 2
+will pound the network indefinitely.
+
+The watcher must therefore treat the chain as one unit: when **any** hop dies,
+stop them all. Watching hops independently and restarting the dead one is wrong
+here — hop 2 has no route while hop 1 is down, and letting it keep trying is both
+noisy and, on a hostile network, the kind of traffic that gets an address
+blocked.
+
+### 5. Both hop processes must be exempted from the TUN device
+
+Under full tunnel, `auto-route` sends the default route into the device, and a
+carrier's own packets would be captured and handed back to the carrier that
+produced them. The loop is silent and total — including the traffic that would
+have explained why.
+
+Strictly, only hop 1 reaches the physical network; hop 2 talks to hop 1 on
+loopback, which `auto-route` does not capture. **Exempt both anyway.** The cost
+is one rule; the risk otherwise is a hop that makes one unexpected direct
+connection — a DNS query, an IPv6 attempt, a fallback — and takes the whole
+connection down in a way that produces no diagnosis at all.
+
+The address-based `IP-CIDR` exemption stays as a second line of defence and
+applies to **hop 1 only**, since it is the only hop with a gateway on the real
+internet, and only Aether has a single address worth naming.
+
+### 6. Hop 1 must pass every port — measured
+
+Psiphon dialled ports **22, 53, 443 and 554**; Tor dialled **993, 9100, 443 and
+1080**. Both vary ports deliberately to avoid classification.
+
+Aether and Psiphon pass arbitrary ports, so every ordering is fine today. But
+this is a real property of a first hop and belongs in `CarrierKind` rather than
+in someone's memory: a future carrier that only forwards 443 would silently
+break every chain built on it.
+
+### 7. Tor accepts bridges and an upstream proxy together — partly measured
+
+`tor --verify-config` reports `Configuration was valid` with `Socks5Proxy`,
+`ClientTransportPlugin` and `UseBridges` all present, and the pluggable-transport
+specification carries `TOR_PT_PROXY` for exactly this case.
+
+**Not verified at runtime.** Whether lyrebird honours the upstream when tor hands
+it one has not been observed carrying traffic. Treat `X → Tor with bridges` as
+unproven until it is, and gate it behind a real test rather than shipping it on
+the strength of a config check.
+
+### 8. `upstreamProxy` collides with the chain
+
+The profile already exposes `upstreamProxy` for a proxy the user runs
+themselves. A chain sets the same field programmatically.
+
+**The user's own value wins.** A chain requested alongside a manual upstream
+proxy is refused with a message naming the conflict, rather than one silently
+overwriting the other. Quietly replacing a proxy someone configured deliberately
+is the worse failure: their traffic goes somewhere they did not choose.
+
+### 9. Two of the six orderings do not do what they look like
+
+`Psiphon → Aether` and `Tor → Aether` end at Cloudflare, which egresses near the
+user and does not change their country — the very thing carriers exist to
+provide. They are being shipped because they were asked for, and because there
+are networks where only Psiphon or Tor gets out at all and Aether's speed is
+still wanted afterwards.
+
+They must not be presented as ways to get a foreign exit. The screen states the
+exit each ordering produces; `PORT-CARRIERS.md` already records what happens when
+it does not — an Android screen that said traffic left from Cloudflare while
+Psiphon carried it out of Singapore.
+
+## The types
+
+```rust
+/// An ordered pair. `first` leaves the local network; `second` decides the exit.
+///
+/// `second: None` is the single-carrier case, which is every session that exists
+/// today — so a profile written before chaining reads as itself.
+pub struct CarrierChain {
+    pub first: CarrierKind,
+    pub second: Option<CarrierKind>,
+}
+
+/// A chain that is up. Ordered as traffic travels: hop 1 first.
+pub struct RunningChain {
+    hops: Vec<Carrier>,        // one or two
+}
+
+impl RunningChain {
+    /// What mihomo dials: the last hop.
+    fn listener(&self) -> SocketAddr;
+    /// Every process to keep out of the TUN device. All of them, see finding 5.
+    fn process_names(&self) -> Vec<&'static str>;
+    /// AND across hops, not the last hop's answer. See finding 2.
+    fn carries_udp(&self) -> bool;
+    fn carries_quic(&self) -> bool;
+    /// Hop 1's gateway, when it has one. Only hop 1 touches the real network.
+    fn endpoint(&self) -> Option<IpAddr>;
+}
+```
+
+`ChainRequest.carrier: Option<Carrier>` becomes
+`ChainRequest.carriers: Option<RunningChain>`. `render()` changes in four
+places: the proxy declaration takes the last hop, the `PROCESS-NAME` rules
+become one per hop, the `udp:` flag and the `NETWORK,udp,REJECT` rule read the
+AND, and the `IP-CIDR` exemption reads hop 1.
+
+## Startup and teardown
+
+Sequential, and the order is not negotiable.
+
+1. Hop 1 starts and must reach **carrying traffic** — not merely listening. Both
+   existing gates apply: Psiphon's `Tunnels ≥ 1`, Tor's `PROGRESS=100`. Hop 2
+   will use hop 1 immediately, and a listener with no tunnel behind it swallows
+   its connections.
+2. Hop 1's listener address is written into hop 2's upstream setting.
+3. Hop 2 starts and must reach carrying traffic by its own gate.
+4. mihomo starts, pointed at hop 2, with both process names exempted.
+5. The system proxy and the shared door follow mihomo, exactly as now.
+
+Teardown is the reverse, and **any** hop dying tears down the whole chain
+(finding 4). Establish time is the sum of both hops: measured, Psiphon takes
+30–60s and Tor 30–120s, so a chain can legitimately need three minutes. The
+screen must show which hop is being worked on, or the wait is indistinguishable
+from a hang.
+
+## The "find one that works" button
+
+Six orderings plus three single carriers is nine attempts, and at three minutes
+each that is half an hour. That is not a button, it is abandoning the app.
+
+- **Singles first, in order of measured speed:** Aether (~25s), Psiphon (~40s),
+  Tor (~60s). On most networks the first one answers and the search ends.
+- **Chains only after every single has failed**, which is the situation the
+  search exists for.
+- **A hard cap per attempt**, around 90 seconds — long enough for a legitimately
+  slow Psiphon, short enough that nine of them stay bounded.
+- **Skip what cannot work:** with no Aether identity, every `X → Aether` is
+  skipped rather than attempted (finding 1). With a manual `upstreamProxy` set,
+  chains are skipped (finding 8).
+- **Report each attempt as it happens, and allow cancelling.** A silent
+  multi-minute search is the same fault as a carrier that says connected and
+  carries nothing.
+
+The search must also say what it settled on. Ending on `Psiphon → Tor` without
+saying so leaves someone believing they are on Aether.
+
+## Order of work, each ending at a gate checked from outside the app
+
+1. `CarrierChain` and `RunningChain`, with `render()` taking plural inputs.
+   **Gate:** the single-carrier config renders byte-identically to 1.8.0 — the
+   same assertion that guarded phase 1 of the carrier port.
+2. Sequential startup and teardown for one hard-coded pair.
+   **Gate:** `Aether → Psiphon` carries traffic, and the exit address is
+   Psiphon's rather than Cloudflare's, measured from another process.
+3. All six orderings selectable, with the impossible ones refused rather than
+   attempted. **Gate:** each of the six either carries traffic or refuses with a
+   message naming the actual reason.
+4. Weakest-link UDP, and the transport controls disabled where they cannot work.
+   **Gate:** with a TCP-only hop, the rendered config declares `udp: false`,
+   carries `NETWORK,udp,REJECT`, and the screen offers no H3 or WireGuard.
+5. The chain-wide watcher and kill switch.
+   **Gate:** killing hop 1 stops hop 2 within seconds; with the kill switch on,
+   traffic is held rather than sent in the clear.
+6. The search button, and the honest exit labelling.
+   **Gate:** on a network where only one ordering works, the search finds it and
+   names it.
+
+## Rules
+
+- Never present an ordering as giving a foreign exit when it ends at Aether.
+- A hop that dies takes the chain with it. No independent restarts.
+- Both hop processes stay out of the TUN device, whatever the reasoning says
+  about which one strictly needs it.
+- Do not claim any ordering works until traffic from another process has been
+  observed leaving through it, and the exit address checked. Building is not
+  evidence — three of the nine findings above contradict what the code looked
+  like it would do.
+- Finding 7 is unproven at runtime. Do not ship `X → Tor with bridges` on the
+  strength of a config check.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "getrandom 0.3.4",
  "rustls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.8.0"
+version = "1.8.1"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/src/carrier.rs
+++ b/src-tauri/src/carrier.rs
@@ -90,15 +90,28 @@ impl CarrierKind {
 
     /// Whether this carrier can carry datagrams at all.
     ///
-    /// Tor cannot: it is a TCP-only transport, and nothing configures that
-    /// away. Declaring the proxy `udp: true` anyway produces a carrier that
+    /// Declaring a proxy `udp: true` when it cannot produces a carrier that
     /// swallows every datagram -- DNS and QUIC hang rather than failing, and
     /// neither falls back because nothing told them to. Refused, a resolver
     /// retries over TCP and a browser drops off QUIC, both within a round trip.
+    ///
+    /// Tor cannot, by design: it is a TCP-only transport and nothing configures
+    /// that away.
+    ///
+    /// **Psiphon cannot either, which was measured rather than assumed.** Its
+    /// SOCKS5 listener answers `UDP ASSOCIATE` with `0x07 COMMAND NOT
+    /// SUPPORTED`, so mihomo has no way to relay a datagram through it. This
+    /// shipped as `true` in 1.8.0 on the strength of a guess, and the cost was
+    /// exactly the failure described above: under Psiphon, QUIC hung instead of
+    /// falling back, which reads as "the internet is slow" rather than as
+    /// anything to report.
+    ///
+    /// Only Aether carries datagrams, and even then not a QUIC handshake --
+    /// see `Carrier::carries_quic`, which is a narrower question.
     pub fn carries_udp(self) -> bool {
         match self {
-            Self::Aether | Self::Psiphon => true,
-            Self::Tor => false,
+            Self::Aether => true,
+            Self::Psiphon | Self::Tor => false,
         }
     }
 
@@ -167,13 +180,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn tor_is_the_one_carrier_that_carries_no_datagrams() {
+    fn only_aether_carries_datagrams() {
         // Declared rather than discovered. A proxy that claims UDP and swallows
         // it is experienced as DNS and QUIC hanging while TCP works, which is
         // the hardest shape of broken to recognise.
-        assert!(!CarrierKind::Tor.carries_udp());
+        //
+        // Tor is TCP-only by design. Psiphon was measured: its SOCKS5 answers
+        // `UDP ASSOCIATE` with 0x07 COMMAND NOT SUPPORTED. 1.8.0 claimed it
+        // carried datagrams because nobody had asked it.
         assert!(CarrierKind::Aether.carries_udp());
-        assert!(CarrierKind::Psiphon.carries_udp());
+        assert!(!CarrierKind::Psiphon.carries_udp());
+        assert!(!CarrierKind::Tor.carries_udp());
     }
 
     #[test]

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -1899,18 +1899,42 @@ mod tests {
 
     #[test]
     fn a_carrier_that_carries_datagrams_refuses_none_of_them() {
-        for kind in [CarrierKind::Aether, CarrierKind::Psiphon] {
-            let config = render(&RenderPlan {
-                carrier: carrier_of(kind),
-                manual: "vless://x",
-                ..Default::default()
-            });
-            assert!(config.contains("udp: true"), "{kind:?}: {config}");
-            assert!(
-                !config.contains("NETWORK,udp,REJECT"),
-                "{kind:?} carries datagrams and must not refuse them: {config}"
-            );
-        }
+        // Aether is the only one. This test used to include Psiphon, on the
+        // strength of a guess that its SOCKS5 relayed datagrams; asking it
+        // directly returned 0x07 COMMAND NOT SUPPORTED. The guess shipped in
+        // 1.8.0 and made QUIC hang under Psiphon instead of falling back.
+        let config = render(&RenderPlan {
+            carrier: carrier_of(CarrierKind::Aether),
+            manual: "vless://x",
+            ..Default::default()
+        });
+        assert!(config.contains("udp: true"), "{config}");
+        assert!(
+            !config.contains("NETWORK,udp,REJECT"),
+            "Aether carries datagrams and must not refuse them: {config}"
+        );
+    }
+
+    #[test]
+    fn psiphon_refuses_datagrams_exactly_as_tor_does() {
+        // Measured, not inferred: Psiphon's SOCKS5 answers UDP ASSOCIATE with
+        // 0x07. Both halves have to follow from that -- the declaration and the
+        // rule -- or the failure is a hang rather than a refusal.
+        let config = render(&RenderPlan {
+            carrier: carrier_of(CarrierKind::Psiphon),
+            manual: "vless://x",
+            ..Default::default()
+        });
+        assert!(config.contains("udp: false"), "{config}");
+        assert!(config.contains("  - NETWORK,udp,REJECT\n"), "{config}");
+
+        // And in the right place: after everything sent DIRECT, before the
+        // catch-all, so the local network keeps its datagrams.
+        let rules = config.split("rules:\n").nth(1).expect("a rules section");
+        let private = rules.find("192.168.0.0/16").expect("the private rule");
+        let reject = rules.find("NETWORK,udp,REJECT").expect("the refusal");
+        let catch_all = rules.find("MATCH,").expect("the catch-all");
+        assert!(private < reject && reject < catch_all, "{config}");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -312,6 +312,8 @@ const FA: Record<string, string> = {
     "در حال جابه‌جایی خروج. این کار دوباره وصل می‌شود، پس به اندازهٔ یک اتصال طول می‌کشد.",
   "The country list is Psiphon's own and arrives once you have connected at least once.":
     "فهرست کشورها را خود سایفون می‌دهد و پس از نخستین اتصال می‌رسد.",
+  "The transport, search and anti-blocking settings belong to the Aether engine. Choose Aether above to see them.":
+    "تنظیمات ترابرد، جستجو و ضدمسدودسازی به موتور Aether مربوط‌اند. برای دیدنشان بالا Aether را انتخاب کنید.",
   "Under Psiphon the endpoint scanner, the pinned endpoint and the transport choice do nothing — Psiphon finds its own route.":
     "زیر سایفون، پویشگر نقطهٔ پایانی، نقطهٔ پایانی ثابت‌شده و انتخاب ترابرد هیچ کاری نمی‌کنند — سایفون مسیر خودش را پیدا می‌کند.",
 

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -91,9 +91,25 @@ export interface AdvancedProps {
   jumpTo?: { section: SectionId; at: number } | null;
 }
 
+/**
+ * The sections that only describe the Aether engine.
+ *
+ * "Endpoint" is pinning a Cloudflare gateway, which Psiphon and Tor neither
+ * read nor have. Hidden rather than shown-and-inert, for the same reason the
+ * transport cards are.
+ */
+const AETHER_ONLY_SECTIONS: SectionId[] = ["endpoint"];
+
 export function Advanced(props: AdvancedProps) {
   const t = useT();
   const [section, setSection] = useState<SectionId>("status");
+  const aetherOnly = props.profile.carrier === "aether";
+
+  // Someone who was reading Endpoint and then switched carrier would otherwise
+  // be left looking at a section that is no longer in the list.
+  useEffect(() => {
+    if (!aetherOnly && AETHER_ONLY_SECTIONS.includes(section)) setSection("routes");
+  }, [aetherOnly, section]);
 
   const { jumpTo } = props;
   useEffect(() => {
@@ -109,7 +125,9 @@ export function Advanced(props: AdvancedProps) {
             <span className="px-2.5 pb-1 pt-3.5 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
               {t(group.group)}
             </span>
-            {group.items.map(({ id, label, icon: Icon }) => (
+            {group.items
+              .filter(({ id }) => aetherOnly || !AETHER_ONLY_SECTIONS.includes(id))
+              .map(({ id, label, icon: Icon }) => (
               <button
                 key={id}
                 type="button"
@@ -656,10 +674,31 @@ function Routes({ profile, onChange }: AdvancedProps) {
   const isMasque = profile.protocol === "masque";
   const isH2 = isMasque && profile.masqueTransport === "h2";
 
+  // Everything below the carrier picker describes the Aether engine: which
+  // transport it rides, how hard it searches for a Cloudflare gateway, how it
+  // obfuscates. Under Psiphon or Tor none of it is read.
+  //
+  // 1.8.0 left these live and merely added a sentence saying they did nothing,
+  // and the first question asked of that screen was "which of these protocols
+  // work with Psiphon?" — with MASQUE H2 still highlighted as though it were
+  // the answer. A control that saves and does nothing is worse than one that is
+  // absent, so they are absent.
+  const aetherOnly = profile.carrier === "aether";
+
   return (
     <>
       <CarrierPanel profile={profile} onChange={onChange} />
-      <Card>
+      {!aetherOnly ? (
+        <Card>
+          <CardContent className="py-4">
+            <p className="text-[13px] leading-snug text-muted-foreground">
+              {t("The transport, search and anti-blocking settings belong to the Aether engine. Choose Aether above to see them.")}
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
+      {aetherOnly ? (
+      <><Card>
         <CardHeader className="pb-3">
           <CardTitle className="text-[15px]">{t("Protocol")}</CardTitle>
           <CardDescription>{t("Retries alternate the two MASQUE transports automatically.")}</CardDescription>
@@ -832,7 +871,8 @@ function Routes({ profile, onChange }: AdvancedProps) {
             />
           </div>
         </CardContent>
-      </Card>
+      </Card></>
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
Merging this publishes 1.8.1.

## Two faults in 1.8.0

**Psiphon was declared `udp: true` on a guess.** Asking its SOCKS5 directly returns `0x07 COMMAND NOT SUPPORTED` for `UDP ASSOCIATE`, so mihomo had no way to relay a datagram through it. A proxy that claims UDP and swallows it is experienced as QUIC and DNS *hanging* while TCP works — which reads as "the internet is slow" rather than as anything to report.

It now declares `udp: false` and the rendered chain carries `NETWORK,udp,REJECT`, so a resolver retries over TCP and a browser drops off QUIC within a round trip. The measurement is recorded on `carries_udp`, and a test that encoded the guess now encodes the answer.

**The Aether-only controls are hidden under a carrier.** 1.8.0 left Protocol, Search, Anti-blocking and Endpoint fully interactive and merely added a sentence saying they did nothing. The first question asked of that screen was *which of these protocols work with Psiphon* — with MASQUE H2 still highlighted as though it were the answer. A control that saves and does nothing is worse than one that is absent, so now they are absent, with one line saying where they went.

## Plus the chaining design

`CARRIER-CHAINING.md` — running two carriers in sequence, in any of the six orderings, with the subscription node after both.

It rests on nine findings measured against the shipped 1.8.0 binaries rather than on reading. **Three of them contradicted what the code looked like it would do:**

- **Aether cannot register a new identity through a chain.** It never resolves `api.cloudflareclient.com` by name — it dials raw Cloudflare edge IPs with a spoofed SNI so DNS cannot be blocked, and that fails through SOCKS. With an existing identity it works completely. So `X → Aether` has a precondition the app must guarantee.
- **Psiphon refuses datagrams** (the bug above).
- **Both carriers vary their outbound ports deliberately** — Psiphon used 22/53/443/554, Tor used 993/9100/443/1080 — so a first hop must pass everything.

Also measured: Psiphon does **not** leak when its upstream fails (1340 refused attempts, zero direct connections), but it does hammer, so the watcher must treat a chain as one unit.

The UI for chaining is a rewrite rather than an extension, and is scoped in the document's step 6 — not attempted here.

## Verification

154 Rust tests, 45 frontend, clean typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
