### PR TITLE
Chain two carriers in any order, and find the one that works

### DIFF
--- a/CARRIER-CHAINING.md
+++ b/CARRIER-CHAINING.md
@@ -161,6 +161,44 @@ exit each ordering produces; `PORT-CARRIERS.md` already records what happens whe
 it does not — an Android screen that said traffic left from Cloudflare while
 Psiphon carried it out of Singapore.
 
+### 10. The last hop was standing in for the whole chain — measured
+
+Written after the first end-to-end run of a real pair, which found seven faults
+with one cause. Every question that is properly about *the chain* was being
+asked of its **last hop**, because before chaining there was only ever one hop
+and the two were the same thing.
+
+| Asked of the last hop | What it broke |
+| --- | --- |
+| `current_carrier`, polled by the Aether hop | `Aether → X` never got past hop 1: the poll waited the full 30s hop timeout for the *second* hop's listener, which does not exist yet because it is started through the first. Two of six orderings, dead. |
+| `has_something_to_do` | mihomo refused to start for `X → Aether` — "the chain has nothing to carry". Two more orderings, dead. |
+| `engine_is_wanted` | Toggling the exit chain on a live `X → Aether` stopped the routing engine, and with it the only thing enforcing that the chain carries no datagrams. |
+| `spawn_carrier_watch` | Returned outright when the last hop was Aether, so `X → Aether` had no watcher at all; in the others, hop 1 dying went unnoticed while the screen read connected. |
+| `Running.carrier`, for the QUIC advice | `Psiphon → Aether` was told to "switch the protocol to WireGuard" — Aether's remedy for Aether's shortfall, useless against Psiphon refusing datagrams in front of it. |
+| `carries_quic()` | Read the snapshot's `transport`, which holds a proxy name under a carrier and so matched neither MASQUE transport: **every** chain reported itself as carrying QUIC, including ones whose first hop refuses datagrams outright. |
+
+Two further faults were teardown rather than capability:
+
+- `stop_carriers` knows only the two carriers that are separate programs, so the
+  error paths left a chained Aether running. Measured: after one failed
+  `Psiphon → Aether`, the engine lost its upstream, began hunting for a
+  Cloudflare gateway **directly**, and was still sweeping two minutes later with
+  the screen reading Stopped. On a network that filters, that is the one thing
+  this must never do.
+- `carrier_died` stopped mihomo and the door but left the surviving hops up.
+
+And one that was honest before chaining and is not now: the snapshot's
+`socks_address` kept the last hop's own port while mihomo owned the route, so
+"This app only" named a listener that bypasses mihomo — and with it the datagram
+rejection and the Iranian-sites bypass that only mihomo applies.
+
+The remedy is structural, not seven patches: the rules live on `RunningChain`,
+which is the only type that can see every hop, and the call sites ask it rather
+than re-deriving. `needs_routing_engine`, `carries_udp`, `carries_quic`,
+`datagram_blocker` and `process_names` are that surface. Where a caller
+genuinely means the engine and not the exit — the Aether hop's own readiness
+poll — it says so by name: `aether_carrier`, never `current_carrier`.
+
 ## The types
 
 ```rust

--- a/CARRIER-CHAINING.md
+++ b/CARRIER-CHAINING.md
@@ -296,6 +296,37 @@ saying so leaves someone believing they are on Aether.
    **Gate:** on a network where only one ordering works, the search finds it and
    names it.
 
+## What the gates actually returned
+
+Steps 1-5 are closed, measured from outside the app on 2026-09-10.
+
+- **Step 2 and 3.** Five of the six orderings were run and every one carried
+  real traffic through mihomo: `Aether → Psiphon`, `Psiphon → Aether`,
+  `Tor → Aether`, `Tor → Psiphon`, `Aether → Tor`. `Psiphon → Tor` has not
+  been run. The exit belongs to the last hop, not the first: on
+  `Aether → Tor`, `curl` through mihomo's port reached
+  `check.torproject.org/api/ip`, which answered
+  `{"IsTor":true,"IP":"203.55.81.2"}`.
+- **Step 4.** `Aether → Tor` rendered
+  `{name: tor, type: socks5, port: 45990, udp: false}` with
+  `NETWORK,udp,REJECT` — Aether carries datagrams and Tor does not, and the
+  chain declared the weaker of the two. The transport cards are absent from the
+  screen for any chain.
+- **Step 5.** Hop 1 killed at 13:22:52.186; `Aether, carrying Aether → Tor,
+  stopped unexpectedly` logged at 13:22:52.809 — **623ms** — and five seconds
+  later `tor`, `mihomo` and the engine were all gone. The kill-switch half is
+  untested.
+
+One thing measured and not yet explained: both orderings **ending** at Aether
+come up, carry traffic, and then reset within seconds —
+`h2 body: connection reset; reconnecting`, three times out of three, at 4s, 10s
+and immediately. A lone Aether stays up for minutes, so this correlates with
+the SOCKS upstream rather than with the chain wiring, which puts it in the
+engine's upstream path. The engine recovers on its own and the app reports
+`reconnecting` honestly, so it degrades rather than breaks — but it is why the
+snapshot's advertised address had to stop following the engine's listener line
+(finding 10): an internal reconnect is routine here, not rare.
+
 ## Rules
 
 - Never present an ordering as giving a foreign exit when it ends at Aether.

--- a/src-tauri/src/carrier.rs
+++ b/src-tauri/src/carrier.rs
@@ -306,6 +306,22 @@ impl RunningChain {
         self.hops.iter().all(|hop| hop.carries_quic)
     }
 
+    /// The hop whose datagram limit a person has to be told about.
+    ///
+    /// The first hop that cannot carry a QUIC handshake, because that is the
+    /// one the remedy has to address -- and the last hop's kind when every hop
+    /// can, so there is always something to name. Keyed on the last hop, the
+    /// advice for `Psiphon -> Aether` read "switch the protocol to WireGuard",
+    /// which is Aether's remedy for Aether's 28-byte shortfall and does
+    /// nothing whatever about Psiphon refusing datagrams in front of it.
+    pub fn datagram_blocker(&self) -> CarrierKind {
+        self.hops
+            .iter()
+            .find(|hop| !hop.carries_quic)
+            .unwrap_or_else(|| self.last())
+            .kind
+    }
+
     /// The gateway to exempt from the TUN device by address.
     ///
     /// The **first** hop's, because it is the only one with a gateway on the
@@ -318,6 +334,28 @@ impl RunningChain {
     /// Whether this is more than one hop, for the lines a person reads.
     pub fn is_chained(&self) -> bool {
         self.hops.len() > 1
+    }
+
+    /// Whether mihomo has to run for this chain to behave correctly.
+    ///
+    /// The single answer to a question that used to be asked in two places and
+    /// answered differently in each -- once in the renderer's
+    /// `has_something_to_do` and once in the supervisor's `engine_is_wanted`.
+    /// Both keyed it on the last hop, and both were wrong for the same reason.
+    ///
+    /// A carrier that is not Aether needs mihomo because mihomo owns the
+    /// interface and routes it into whichever listener is up. *Any* chain of
+    /// two hops needs it as well, whatever it ends at, because a chain carries
+    /// only what its weakest hop carries and mihomo is the only thing that can
+    /// enforce that. `Psiphon -> Aether` ends at a listener that accepts
+    /// `UDP ASSOCIATE` quite happily and the datagrams then have to cross
+    /// Psiphon, which refuses them -- so without mihomo they are accepted and
+    /// die in the middle of the chain instead of being refused at the edge.
+    ///
+    /// Only a lone Aether can do without it: one hop, datagrams and all, whose
+    /// own listener is directly usable.
+    pub fn needs_routing_engine(&self) -> bool {
+        self.is_chained() || self.last().kind != CarrierKind::Aether
     }
 }
 
@@ -432,6 +470,61 @@ mod tests {
         assert_eq!(names.len(), 2, "{names:?}");
         assert!(names.contains(&CarrierKind::Aether.process_name()), "{names:?}");
         assert!(names.contains(&CarrierKind::Tor.process_name()), "{names:?}");
+    }
+
+    #[test]
+    fn the_hop_that_blocks_datagrams_is_the_one_named_in_the_advice() {
+        // `Psiphon -> Aether` was told to "switch the protocol to WireGuard",
+        // which is Aether's remedy for Aether's 28-byte shortfall and does
+        // nothing about Psiphon refusing datagrams in front of it. The hop to
+        // name is the first that cannot carry a handshake, not the last.
+        let psiphon_then_aether = RunningChain::pair(
+            hop(CarrierKind::Psiphon, 1080, None, false),
+            hop(CarrierKind::Aether, 1819, None, true),
+        );
+        assert_eq!(psiphon_then_aether.datagram_blocker(), CarrierKind::Psiphon);
+
+        // And when the engine itself is the obstacle -- MASQUE fits datagrams
+        // but not a QUIC handshake -- it is named, because it is the hop whose
+        // transport can actually be changed.
+        let masque_alone = RunningChain::single(hop(CarrierKind::Aether, 1819, None, false));
+        assert_eq!(masque_alone.datagram_blocker(), CarrierKind::Aether);
+
+        // Nothing blocking: the exit is named, so there is always a subject.
+        let wireguard_alone = RunningChain::single(hop(CarrierKind::Aether, 1819, None, true));
+        assert_eq!(wireguard_alone.datagram_blocker(), CarrierKind::Aether);
+    }
+
+    #[test]
+    fn only_a_lone_aether_can_do_without_the_routing_engine() {
+        // The whole of the rule, in the units the callers ask in.
+        let kinds = [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor];
+        for first in kinds {
+            for second in kinds {
+                if first == second {
+                    continue;
+                }
+                assert!(
+                    RunningChain::pair(
+                        hop(first, 1080, None, true),
+                        hop(second, 1819, None, true),
+                    )
+                    .needs_routing_engine(),
+                    "{first:?} -> {second:?}: only mihomo can enforce the weakest hop"
+                );
+            }
+        }
+        for kind in [CarrierKind::Psiphon, CarrierKind::Tor] {
+            assert!(
+                RunningChain::single(hop(kind, 1080, None, false)).needs_routing_engine(),
+                "{kind:?} alone is routed into by mihomo, so it needs it"
+            );
+        }
+        assert!(
+            !RunningChain::single(hop(CarrierKind::Aether, 1819, None, true))
+                .needs_routing_engine(),
+            "a lone Aether hands out a directly usable listener"
+        );
     }
 
     #[test]

--- a/src-tauri/src/carrier.rs
+++ b/src-tauri/src/carrier.rs
@@ -155,6 +155,172 @@ pub struct Carrier {
     pub carries_quic: bool,
 }
 
+/// An ordered pair of carriers, as the user chose them.
+///
+/// `first` is what leaves the local network; `second` decides the exit address.
+/// `second: None` is the single-carrier case, which is every session that
+/// existed before chaining -- so a profile written then reads as itself.
+///
+/// See `CARRIER-CHAINING.md` for what was measured about each ordering, and in
+/// particular why `second: Some(Aether)` needs an identity that already exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct CarrierChain {
+    pub first: CarrierKind,
+    pub second: Option<CarrierKind>,
+}
+
+// Part of this is read only by later steps of CARRIER-CHAINING.md: the
+// sequential startup in step 2, and the two-selector screen in step 6. It lives
+// with the type rather than being invented twice when those land.
+#[allow(dead_code)]
+impl CarrierChain {
+    /// The carrier whose listener traffic is finally routed into.
+    pub fn last(&self) -> CarrierKind {
+        self.second.unwrap_or(self.first)
+    }
+
+
+    /// Every kind in the chain, in the order traffic travels.
+    pub fn kinds(&self) -> Vec<CarrierKind> {
+        match self.second {
+            Some(second) => vec![self.first, second],
+            None => vec![self.first],
+        }
+    }
+
+    pub fn is_chained(&self) -> bool {
+        self.second.is_some()
+    }
+
+    /// Whether this is the Aether engine on its own.
+    ///
+    /// The one case that takes the engine's own supervisor rather than the
+    /// carrier path: it has a scan to run, transports to alternate and a
+    /// gateway to re-pick, none of which the others have.
+    pub fn is_lone_aether(&self) -> bool {
+        self.first == CarrierKind::Aether && self.second.is_none()
+    }
+
+    /// What to call this chain on screen and in a log line.
+    ///
+    /// The arrow is the order traffic travels, which is the thing people get
+    /// backwards. Naming only the exit would hide the hop that decides what the
+    /// local network sees; naming only the first would hide where traffic comes
+    /// out. Both, in order.
+    pub fn label(&self) -> String {
+        match self.second {
+            Some(second) => format!("{} → {}", self.first.label(), second.label()),
+            None => self.first.label().to_string(),
+        }
+    }
+
+    /// Whether this chain contains a given carrier at any position.
+    ///
+    /// Settings belong to a carrier rather than to a position: an exit country
+    /// is Psiphon's whether Psiphon is the first hop or the second.
+    pub fn contains(&self, kind: CarrierKind) -> bool {
+        self.kinds().contains(&kind)
+    }
+
+    /// Why this ordering cannot be run, when it cannot.
+    ///
+    /// Only the shapes that are wrong regardless of the network. Whether a
+    /// given carrier can reach anything from here is a question for the
+    /// attempt, not for validation.
+    pub fn refusal(&self) -> Option<String> {
+        let second = self.second?;
+        if second == self.first {
+            // Two hops of the same carrier buy nothing: the second would dial
+            // its own servers through the first, doubling the latency to reach
+            // the same network.
+            return Some(format!(
+                "{} cannot be chained to itself -- the second hop would reach the same network \
+                 through the first, for twice the delay.",
+                self.first.label()
+            ));
+        }
+        None
+    }
+}
+
+/// A chain that is up, ordered as traffic travels.
+///
+/// Built by the supervisor once every hop is carrying traffic, and handed to
+/// [`crate::chain`] in place of a single `Carrier`. The accessors exist because
+/// three of the four answers the routing engine needs are **not** the last
+/// hop's answer, and reading them off one carrier is how a chain silently
+/// becomes a single hop in the rendered config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunningChain {
+    hops: Vec<Carrier>,
+}
+
+#[allow(dead_code)]
+impl RunningChain {
+    /// One hop: the case that exists today.
+    pub fn single(carrier: Carrier) -> Self {
+        Self { hops: vec![carrier] }
+    }
+
+    /// Two hops, in the order traffic travels.
+    pub fn pair(first: Carrier, second: Carrier) -> Self {
+        Self { hops: vec![first, second] }
+    }
+
+    /// What mihomo dials: the last hop, because every earlier one is reached
+    /// through it rather than by us.
+    pub fn listener(&self) -> SocketAddr {
+        self.hops.last().expect("a chain has at least one hop").socks
+    }
+
+    /// The carrier the exit address belongs to.
+    pub fn last(&self) -> &Carrier {
+        self.hops.last().expect("a chain has at least one hop")
+    }
+
+    /// Every process to keep out of the TUN device.
+    ///
+    /// All of them, not just the one that reaches the physical network.
+    /// Strictly, only the first hop does -- later hops talk to it on loopback,
+    /// which `auto-route` does not capture. Exempting all of them costs one
+    /// rule each and covers the case that would otherwise be silent: a hop that
+    /// makes one unexpected direct connection, and takes the whole connection
+    /// down with no diagnosis at all.
+    pub fn process_names(&self) -> Vec<&'static str> {
+        self.hops.iter().map(Carrier::process_name).collect()
+    }
+
+    /// Whether datagrams survive the whole chain.
+    ///
+    /// The AND across hops, not the last hop's answer. Measured: Psiphon's
+    /// SOCKS5 refuses `UDP ASSOCIATE` and Tor carries no datagrams at all, so
+    /// one TCP-only hop makes the entire chain TCP-only however capable the
+    /// others are.
+    pub fn carries_udp(&self) -> bool {
+        self.hops.iter().all(Carrier::carries_udp)
+    }
+
+    /// Whether a QUIC handshake fits through the whole chain. Same reasoning.
+    pub fn carries_quic(&self) -> bool {
+        self.hops.iter().all(|hop| hop.carries_quic)
+    }
+
+    /// The gateway to exempt from the TUN device by address.
+    ///
+    /// The **first** hop's, because it is the only one with a gateway on the
+    /// real internet. Later hops reach the network through it, so their traffic
+    /// never touches the physical interface and there is no address to name.
+    pub fn endpoint(&self) -> Option<IpAddr> {
+        self.hops.first().and_then(|hop| hop.endpoint)
+    }
+
+    /// Whether this is more than one hop, for the lines a person reads.
+    pub fn is_chained(&self) -> bool {
+        self.hops.len() > 1
+    }
+}
+
 impl Carrier {
     /// The name this carrier's proxy takes in the config.
     pub fn proxy_name(&self) -> &'static str {
@@ -226,6 +392,146 @@ mod tests {
         // Every saved profile predates carriers. Defaulting to anything else
         // would move existing users onto a way out they never chose.
         assert_eq!(CarrierKind::default(), CarrierKind::Aether);
+    }
+
+    fn hop(kind: CarrierKind, port: u16, endpoint: Option<&str>, quic: bool) -> Carrier {
+        Carrier {
+            kind,
+            socks: SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, port)),
+            endpoint: endpoint.map(|value| value.parse().unwrap()),
+            carries_quic: quic,
+        }
+    }
+
+    #[test]
+    fn a_chain_is_dialled_at_its_last_hop() {
+        // Every earlier hop is reached through the last one rather than by us,
+        // so the last listener is the only address mihomo has any business
+        // dialling.
+        let chain = RunningChain::pair(
+            hop(CarrierKind::Aether, 1819, Some("162.159.198.2"), false),
+            hop(CarrierKind::Psiphon, 64347, None, false),
+        );
+        assert_eq!(chain.listener().port(), 64347);
+        assert_eq!(chain.last().kind, CarrierKind::Psiphon);
+        assert!(chain.is_chained());
+    }
+
+    #[test]
+    fn every_hop_stays_out_of_the_tun_device() {
+        // Strictly only the first hop reaches the physical network. Exempting
+        // all of them is deliberate: the failure this guards against is a hop
+        // that makes one unexpected direct connection, and it is total and
+        // silent -- the packets that would have explained it are the ones being
+        // fed back.
+        let chain = RunningChain::pair(
+            hop(CarrierKind::Aether, 1819, None, false),
+            hop(CarrierKind::Tor, 9150, None, false),
+        );
+        let names = chain.process_names();
+        assert_eq!(names.len(), 2, "{names:?}");
+        assert!(names.contains(&CarrierKind::Aether.process_name()), "{names:?}");
+        assert!(names.contains(&CarrierKind::Tor.process_name()), "{names:?}");
+    }
+
+    #[test]
+    fn one_tcp_only_hop_makes_the_whole_chain_tcp_only() {
+        // The AND, not the last hop's answer. Reading it off the last hop is
+        // how a chain ending at Aether would claim to carry datagrams that a
+        // Psiphon or Tor hop in front of it cannot pass -- and a proxy that
+        // claims UDP and swallows it is experienced as hanging, not failing.
+        let aether_then_tor = RunningChain::pair(
+            hop(CarrierKind::Aether, 1819, None, true),
+            hop(CarrierKind::Tor, 9150, None, false),
+        );
+        assert!(!aether_then_tor.carries_udp());
+        assert!(!aether_then_tor.carries_quic());
+
+        // And the reverse ordering, where the capable hop is last.
+        let tor_then_aether = RunningChain::pair(
+            hop(CarrierKind::Tor, 9150, None, false),
+            hop(CarrierKind::Aether, 1819, None, true),
+        );
+        assert!(
+            !tor_then_aether.carries_udp(),
+            "a Tor hop in front cannot pass what Aether would carry"
+        );
+        assert!(!tor_then_aether.carries_quic());
+
+        // Aether alone still carries datagrams.
+        assert!(RunningChain::single(hop(CarrierKind::Aether, 1819, None, true)).carries_udp());
+    }
+
+    #[test]
+    fn the_address_exemption_names_the_first_hops_gateway() {
+        // The first hop is the only one with a gateway on the real internet.
+        // Naming the last hop's would exempt an address nothing connects to,
+        // and leave the one that matters captured.
+        let chain = RunningChain::pair(
+            hop(CarrierKind::Aether, 1819, Some("162.159.198.2"), false),
+            hop(CarrierKind::Psiphon, 64347, None, false),
+        );
+        assert_eq!(chain.endpoint().map(|ip| ip.to_string()).as_deref(), Some("162.159.198.2"));
+
+        // Psiphon and Tor have no single gateway, so a chain starting with one
+        // has no address to name and relies on the process rule alone.
+        let starts_with_psiphon = RunningChain::pair(
+            hop(CarrierKind::Psiphon, 64347, None, false),
+            hop(CarrierKind::Aether, 1819, Some("162.159.198.2"), false),
+        );
+        assert!(starts_with_psiphon.endpoint().is_none());
+    }
+
+    #[test]
+    fn a_carrier_cannot_be_chained_to_itself() {
+        // The second hop would dial the same network through the first, for
+        // twice the delay and no change of exit.
+        for kind in [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor] {
+            let refusal = CarrierChain { first: kind, second: Some(kind) }
+                .refusal()
+                .expect("chaining a carrier to itself should be refused");
+            assert!(refusal.contains(kind.label()), "{refusal}");
+        }
+    }
+
+    #[test]
+    fn every_ordering_of_two_different_carriers_is_allowed() {
+        // All six, because all six were measured to work -- two of them only
+        // with an Aether identity that already exists, which is a precondition
+        // the supervisor checks rather than a shape this refuses.
+        let kinds = [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor];
+        let mut allowed = 0;
+        for first in kinds {
+            for second in kinds {
+                if first == second {
+                    continue;
+                }
+                let chain = CarrierChain { first, second: Some(second) };
+                assert!(chain.refusal().is_none(), "{first:?} -> {second:?}");
+                assert_eq!(chain.last(), second);
+                assert_eq!(chain.kinds(), vec![first, second]);
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, 6, "there are six orderings of three carriers taken two at a time");
+    }
+
+    #[test]
+    fn a_profile_with_no_second_hop_is_the_single_carrier_case() {
+        // Every session that exists today. A profile written before chaining
+        // carries no `second`, and must read as exactly what it was.
+        let stored = serde_json::json!({ "first": "psiphon" });
+        let chain: CarrierChain = serde_json::from_value(stored).unwrap();
+        assert_eq!(chain.first, CarrierKind::Psiphon);
+        assert_eq!(chain.second, None);
+        assert_eq!(chain.last(), CarrierKind::Psiphon);
+        assert!(!chain.is_chained());
+        assert!(chain.refusal().is_none());
+
+        // And an entirely absent chain is Aether, as it always was.
+        let empty: CarrierChain = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(empty.first, CarrierKind::Aether);
+        assert_eq!(empty.second, None);
     }
 
     #[test]

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
-use crate::carrier::{Carrier, CarrierKind};
+use crate::carrier::{CarrierKind, RunningChain};
 use crate::core_supervisor::CoreSupervisor;
 
 /// The group every rule points at. Selecting a node means selecting into this.
@@ -112,11 +112,16 @@ impl Default for ChainSettings {
 pub struct ChainRequest<'a> {
     /// Whatever is getting us out of the network right now, when something is.
     ///
-    /// Was the Aether listener as a bare address. It carries the listener still,
-    /// and with it the three things about the carrier that change what gets
-    /// rendered -- the proxy name, the process to exempt from the TUN device,
-    /// and whether datagrams survive the trip. See [`crate::carrier`].
-    pub carrier: Option<Carrier>,
+    /// Was the Aether listener as a bare address, then one `Carrier`, and now a
+    /// chain of one or two hops.
+    ///
+    /// Deliberately the whole chain rather than the hop mihomo dials, because
+    /// three of the four answers needed here are **not** the last hop's: every
+    /// process is exempted from the TUN device, datagram support is the AND
+    /// across hops, and the address exemption belongs to the first. Reading
+    /// them off one carrier is how a chain silently becomes a single hop in the
+    /// rendered config. See [`crate::carrier::RunningChain`].
+    pub carriers: Option<RunningChain>,
     pub settings: &'a ChainSettings,
     /// Let Iranian sites go straight out. See [`crate::iran_routes`].
     pub bypass_iran_sites: bool,
@@ -141,12 +146,17 @@ impl ChainRequest<'_> {
     /// the whole arrangement is that mihomo owns the interface and routes it
     /// into whichever carrier is up, so refusing to start without an exit chain
     /// would leave Psiphon or Tor connected and carrying nothing.
+    /// The last hop decides this, not the chain's length. A chain ending at
+    /// Aether hands out a listener applications can use directly, exactly as a
+    /// lone Aether does -- so it needs no more help from mihomo than that case
+    /// does, whatever is carrying it underneath.
     fn has_something_to_do(&self) -> bool {
         self.wants_exit_chain()
             || self.tun
             || self
-                .carrier
-                .is_some_and(|carrier| carrier.kind != CarrierKind::Aether)
+                .carriers
+                .as_ref()
+                .is_some_and(|chain| chain.last().kind != CarrierKind::Aether)
     }
 }
 
@@ -221,7 +231,7 @@ impl Chain {
         self.stop();
 
         let settings = request.settings;
-        let carrier = request.carrier;
+        let carriers = request.carriers.as_ref();
         let usable: Vec<&ChainSource> = settings
             .sources
             .iter()
@@ -231,7 +241,7 @@ impl Chain {
             if usable.is_empty() && settings.manual.trim().is_empty() {
                 return Err("add a subscription or a config before turning the chain on".into());
             }
-            if settings.through_tunnel && carrier.is_none() {
+            if settings.through_tunnel && carriers.is_none() {
                 return Err("connect first, or turn off \"dial nodes through the tunnel\"".into());
             }
         } else if !request.has_something_to_do() {
@@ -242,7 +252,7 @@ impl Chain {
         // Full tunnel forwards everything to the carrier's listener, so without
         // one it would capture the machine's traffic and have nowhere to send
         // it -- which is worse than not capturing it.
-        if request.tun && carrier.is_none() {
+        if request.tun && carriers.is_none() {
             return Err("connect first: full tunnel has nothing to forward to".into());
         }
 
@@ -267,7 +277,7 @@ impl Chain {
         // moved it, and anything configured against the last run quietly went
         // out past the hop with the old exit address.
         let mixed = preferred_port(
-            carrier.map_or(DEFAULT_MIXED_PORT, |carrier| next_port(carrier.socks)),
+            carriers.map_or(DEFAULT_MIXED_PORT, |chain| next_port(chain.listener())),
         )?;
         // The API stays ephemeral: only this process ever speaks to it.
         let api = free_port()?;
@@ -291,7 +301,7 @@ impl Chain {
         }
 
         let config = render(&RenderPlan {
-            carrier,
+            carriers: carriers.cloned(),
             mixed,
             api,
             secret: &secret,
@@ -381,7 +391,7 @@ impl Chain {
             api: api_address,
             secret,
             through_tunnel: settings.through_tunnel,
-            carrier: carrier.map(|carrier| carrier.kind),
+            carrier: carriers.map(|chain| chain.last().kind),
             home: home.clone(),
         });
         Ok(mixed_address)
@@ -713,7 +723,7 @@ impl Drop for Chain {
 /// these are bools and Options of the same shape, and transposing two of them
 /// would produce a config that is valid, silently wrong, and routes traffic.
 struct RenderPlan<'a> {
-    carrier: Option<Carrier>,
+    carriers: Option<RunningChain>,
     mixed: u16,
     api: u16,
     secret: &'a str,
@@ -729,7 +739,7 @@ struct RenderPlan<'a> {
 impl Default for RenderPlan<'_> {
     fn default() -> Self {
         Self {
-            carrier: None,
+            carriers: None,
             mixed: DEFAULT_MIXED_PORT,
             api: 1821,
             secret: "",
@@ -743,8 +753,11 @@ impl Default for RenderPlan<'_> {
 }
 
 fn render(plan: &RenderPlan) -> String {
+    // Borrowed rather than destructured with the rest: a chain is a Vec and so
+    // is not Copy, and moving it out of a shared reference is not allowed.
+    // Everything else here is a scalar or a slice.
+    let carriers = plan.carriers.as_ref();
     let RenderPlan {
-        carrier,
         mixed,
         api,
         secret,
@@ -753,6 +766,7 @@ fn render(plan: &RenderPlan) -> String {
         bypass_iran_sites,
         exit_chain,
         tun,
+        ..
     } = *plan;
     let mut config = String::new();
     config.push_str(&format!("mixed-port: {mixed}\n"));
@@ -830,19 +844,22 @@ fn render(plan: &RenderPlan) -> String {
 
     // Declared only when there is a carrier to declare. A socks5 proxy pointing
     // at a port nothing is listening on would fail every node it fronted.
-    let (through, fetch_through) = match carrier {
-        Some(carrier) => {
-            let name = carrier.proxy_name();
-            // `udp` is the carrier's answer, not a constant. A carrier that
-            // cannot carry datagrams and is declared as though it can swallows
-            // every one of them: DNS and QUIC hang rather than failing, and
-            // neither falls back because nothing told them to. The REJECT rule
-            // below is the other half of the same statement.
+    let (through, fetch_through) = match carriers {
+        Some(chain) => {
+            // The last hop: every earlier one is reached through it rather than
+            // by mihomo, so it is the only listener there is anything to dial.
+            let name = chain.last().proxy_name();
+            // `udp` is the *chain's* answer, not the last hop's. One TCP-only
+            // hop anywhere in it makes the whole thing TCP-only, and a proxy
+            // declared as carrying datagrams that cannot swallows every one:
+            // DNS and QUIC hang rather than failing, and neither falls back
+            // because nothing told them to. The REJECT rule below is the other
+            // half of the same statement.
             config.push_str(&format!(
                 "proxies:\n  - {{name: {name}, type: socks5, server: {}, port: {}, udp: {}}}\n",
-                carrier.socks.ip(),
-                carrier.socks.port(),
-                carrier.carries_udp(),
+                chain.listener().ip(),
+                chain.listener().port(),
+                chain.carries_udp(),
             ));
             (
                 format!("\n    dialer-proxy: {name}"),
@@ -891,9 +908,9 @@ fn render(plan: &RenderPlan) -> String {
     // With neither -- no exit chain and no carrier -- there is nothing to name,
     // and DIRECT is the only honest answer. `start` refuses that combination
     // before it can be rendered, so this is a floor rather than a path.
-    let catch_all = match (exit_chain, carrier) {
+    let catch_all = match (exit_chain, carriers) {
         (true, _) => EXIT_GROUP,
-        (false, Some(carrier)) => carrier.proxy_name(),
+        (false, Some(chain)) => chain.last().proxy_name(),
         (false, None) => "DIRECT",
     };
 
@@ -933,13 +950,18 @@ fn render(plan: &RenderPlan) -> String {
     // address to name at all: Psiphon and Tor reach many relays, so there the
     // process rule is the whole of it.
     if tun {
-        if let Some(carrier) = carrier {
-            config.push_str(&format!(
-                "  - PROCESS-NAME,{},DIRECT\n",
-                carrier.process_name()
-            ));
+        // One rule per hop, not one for the hop mihomo dials. Strictly only the
+        // first hop reaches the physical network -- later hops talk to it on
+        // loopback, which `auto-route` does not capture -- but exempting all of
+        // them costs a rule each and covers the case that would otherwise be
+        // silent: a hop that makes one unexpected direct connection and takes
+        // the whole connection down with nothing to read afterwards.
+        for process in carriers.map(RunningChain::process_names).unwrap_or_default() {
+            config.push_str(&format!("  - PROCESS-NAME,{process},DIRECT\n"));
         }
-        if let Some(address) = carrier.and_then(|carrier| carrier.endpoint) {
+        // The *first* hop's gateway. Later hops reach the network through it,
+        // so they have no address on the real internet to name.
+        if let Some(address) = carriers.and_then(RunningChain::endpoint) {
             let prefix = if address.is_ipv4() { 32 } else { 128 };
             // `no-resolve` because the address is already an address, and
             // resolving it would be one more DNS query going through the
@@ -1010,7 +1032,7 @@ fn render(plan: &RenderPlan) -> String {
     //
     // DNS still resolves throughout: the resolvers configured above are
     // DNS-over-HTTPS, which is TCP.
-    if carrier.is_some_and(|carrier| !carrier.carries_udp()) {
+    if carriers.is_some_and(|chain| !chain.carries_udp()) {
         config.push_str("  - NETWORK,udp,REJECT\n");
     }
 
@@ -1327,35 +1349,42 @@ const MAX_BODY: usize = 8 * 1024 * 1024;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::carrier::Carrier;
 
     fn source(name: &str, url: &str) -> ChainSource {
         ChainSource { name: name.into(), url: url.into(), enabled: true }
     }
 
-    /// The Aether engine, up and carrying, with no gateway picked yet.
-    fn tunnel() -> Option<Carrier> {
-        Some(Carrier {
-            kind: CarrierKind::Aether,
-            socks: "127.0.0.1:1819".parse().unwrap(),
-            endpoint: None,
+    fn hop(kind: CarrierKind, port: u16, endpoint: Option<&str>) -> Carrier {
+        Carrier {
+            kind,
+            socks: format!("127.0.0.1:{port}").parse().unwrap(),
+            endpoint: endpoint.map(|value| value.parse().unwrap()),
             carries_quic: false,
-        })
+        }
+    }
+
+    /// The Aether engine alone, up and carrying, with no gateway picked yet.
+    fn tunnel() -> Option<RunningChain> {
+        Some(RunningChain::single(hop(CarrierKind::Aether, 1819, None)))
     }
 
     /// The same, once a gateway is known.
-    fn tunnel_via(endpoint: &str) -> Option<Carrier> {
-        Some(Carrier {
-            endpoint: Some(endpoint.parse().unwrap()),
-            ..tunnel().unwrap()
-        })
+    fn tunnel_via(endpoint: &str) -> Option<RunningChain> {
+        Some(RunningChain::single(hop(CarrierKind::Aether, 1819, Some(endpoint))))
     }
 
-    /// A carrier that is not Aether, for the properties that differ by kind.
-    fn carrier_of(kind: CarrierKind) -> Option<Carrier> {
-        Some(Carrier {
-            kind,
-            ..tunnel().unwrap()
-        })
+    /// One carrier alone, for the properties that differ by kind.
+    fn carrier_of(kind: CarrierKind) -> Option<RunningChain> {
+        Some(RunningChain::single(hop(kind, 1819, None)))
+    }
+
+    /// Two hops, in the order traffic travels.
+    fn chain_of(first: CarrierKind, second: CarrierKind) -> Option<RunningChain> {
+        Some(RunningChain::pair(
+            hop(first, 1819, Some("162.159.198.2")),
+            hop(second, 64347, None),
+        ))
     }
 
     #[test]
@@ -1365,7 +1394,7 @@ mod tests {
         // local network and leaving the exit address unchanged.
         let sources = [source("ours", "https://example.com/a"), source("theirs", "https://example.com/b")];
         let refs: Vec<&ChainSource> = sources.iter().collect();
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, manual: "vless://pasted", ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, manual: "vless://pasted", ..Default::default() });
 
         let providers = config.matches("dialer-proxy: aether").count();
         assert_eq!(providers, 3, "two subscriptions and the pasted block, all behind the tunnel");
@@ -1379,7 +1408,7 @@ mod tests {
         // cache, and the screen showed one stale node out of seven.
         let sources = [source("ours", "https://example.com/a")];
         let refs: Vec<&ChainSource> = sources.iter().collect();
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
         assert!(config.contains("\n    proxy: aether"), "the fetch must name the tunnel");
         // And the nodes it carries still dial through the tunnel: these are two
         // different routes and setting one must not have replaced the other.
@@ -1401,8 +1430,8 @@ mod tests {
         // could not refresh.
         let old = [source("ours", "https://example.com/old")];
         let new = [source("ours", "https://example.com/new")];
-        let old_config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &old.iter().collect::<Vec<_>>(), ..Default::default() });
-        let new_config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &new.iter().collect::<Vec<_>>(), ..Default::default() });
+        let old_config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &old.iter().collect::<Vec<_>>(), ..Default::default() });
+        let new_config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &new.iter().collect::<Vec<_>>(), ..Default::default() });
         let path_of = |config: &str| {
             config
                 .lines()
@@ -1421,7 +1450,7 @@ mod tests {
         // nothing which could actually leave this network is: the catch-all
         // must be the exit, and every direct rule must name a range that is
         // unroutable from outside.
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://pasted", ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://pasted", ..Default::default() });
         assert!(config.contains("MATCH,exit"));
         assert!(!config.contains("MATCH,DIRECT"), "the catch-all must never be direct");
 
@@ -1441,7 +1470,7 @@ mod tests {
     fn dns_resolves_inside_the_chain() {
         // A query that escapes names the destination even when the traffic does
         // not, which is the most common way a chain like this leaks.
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
         assert!(config.contains("enhanced-mode: fake-ip"));
         assert!(config.contains("https://1.1.1.1/dns-query"));
         assert!(!config.contains("\n    - 8.8.8.8"), "a plain resolver would leave the chain");
@@ -1449,7 +1478,7 @@ mod tests {
 
     #[test]
     fn the_control_api_is_never_exposed() {
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s3cret", manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s3cret", manual: "vless://x", ..Default::default() });
         assert!(config.contains("external-controller: 127.0.0.1:1821"));
         assert!(config.contains("secret: \"s3cret\""));
     }
@@ -1460,7 +1489,7 @@ mod tests {
         off.enabled = false;
         let on = source("on", "https://example.com/on");
         let refs: Vec<&ChainSource> = vec![&on];
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", sources: &refs, ..Default::default() });
         assert!(config.contains("example.com/on"));
         assert!(!config.contains("example.com/off"));
         let _ = off;
@@ -1469,7 +1498,7 @@ mod tests {
     #[test]
     fn full_tunnel_declares_a_device_and_hijacks_dns() {
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1489,7 +1518,7 @@ mod tests {
         // hijacking is what stops the query leaving in the clear beside a
         // tunnelled connection.
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1505,7 +1534,7 @@ mod tests {
         // Without this, those queries take a direct route whatever the traffic
         // does -- so the resolver and the exit end up in different countries,
         // which is both a leak and a mismatch anyone can see on a leak test.
-        let config = render(&RenderPlan { carrier: tunnel(), manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), manual: "vless://x", ..Default::default() });
         assert!(config.contains("respect-rules: true"), "{config}");
         // Resolving the proxies' own names cannot go through the proxies.
         assert!(config.contains("proxy-server-nameserver:"), "{config}");
@@ -1518,7 +1547,7 @@ mod tests {
     #[test]
     fn without_full_tunnel_no_device_is_declared() {
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             manual: "vless://x",
             ..Default::default()
         });
@@ -1534,7 +1563,7 @@ mod tests {
         // handed back to the tunnel that produced them -- taking everything
         // down including whatever would have explained why.
         let config = render(&RenderPlan {
-            carrier: tunnel_via("162.159.198.2"),
+            carriers: tunnel_via("162.159.198.2"),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1565,7 +1594,7 @@ mod tests {
         // there and is retried by Windows on some other adapter -- which is
         // how a query escapes a tunnel that looked complete.
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1599,7 +1628,7 @@ mod tests {
         // matches nothing, and every packet the tunnel sends is handed back to
         // the tunnel -- so the exemption cannot depend on knowing it.
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1629,7 +1658,7 @@ mod tests {
         // reach a gateway on the open internet. With it on, the connection
         // went away entirely once the exit chain was in the path.
         let config = render(&RenderPlan {
-            carrier: tunnel_via("162.159.198.2"),
+            carriers: tunnel_via("162.159.198.2"),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1642,7 +1671,7 @@ mod tests {
         // /32 on an IPv6 address would silently exempt a sixteenth of the
         // internet rather than one host.
         let config = render(&RenderPlan {
-            carrier: tunnel_via("2606:4700:d0::a29f:c602"),
+            carriers: tunnel_via("2606:4700:d0::a29f:c602"),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -1657,7 +1686,7 @@ mod tests {
         // the tunnel itself -- pointing at a group that was never declared
         // would be a config mihomo rejects.
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             exit_chain: false,
             tun: true,
             ..Default::default()
@@ -1672,7 +1701,7 @@ mod tests {
         let source = source("ours", "https://example.com/a");
         let refs: Vec<&ChainSource> = vec![&source];
         let config = render(&RenderPlan {
-            carrier: tunnel(),
+            carriers: tunnel(),
             sources: &refs,
             tun: true,
             ..Default::default()
@@ -1696,7 +1725,7 @@ mod tests {
 
     #[test]
     fn iran_bypass_adds_rule_providers_ahead_of_the_exit_group() {
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", bypass_iran_sites: true, ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", bypass_iran_sites: true, ..Default::default() });
         assert!(config.contains("DOMAIN-SUFFIX,ir,DIRECT"));
         assert!(config.contains("RULE-SET,iran-domain,DIRECT"));
         assert!(config.contains("RULE-SET,iran-ip,DIRECT"));
@@ -1713,7 +1742,7 @@ mod tests {
     fn without_the_iran_bypass_no_rule_provider_is_declared() {
         // The default: nothing here should change for someone who never
         // touched the setting.
-        let config = render(&RenderPlan { carrier: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
+        let config = render(&RenderPlan { carriers: tunnel(), mixed: 1820, api: 1821, secret: "s", manual: "vless://x", ..Default::default() });
         assert!(!config.contains("rule-providers"));
         assert!(!config.contains("DOMAIN-SUFFIX,ir"));
         assert_eq!(config.matches("MATCH,exit").count(), 1);
@@ -1787,7 +1816,7 @@ mod tests {
         };
         let refs: Vec<&ChainSource> = vec![&source];
         let config = render(&RenderPlan {
-            carrier: tunnel_via("162.159.198.2"),
+            carriers: tunnel_via("162.159.198.2"),
             mixed: 1820,
             api: 1821,
             secret: "s3cret",
@@ -1855,6 +1884,92 @@ mod tests {
     }
 
     #[test]
+    fn a_chain_is_dialled_at_its_last_hop_and_exempts_every_process() {
+        // The whole point of handing `render` the chain rather than the hop it
+        // dials. Three of these four answers are not the last hop's, and
+        // reading them off one carrier is how a chain silently becomes a single
+        // hop in the rendered config.
+        let config = render(&RenderPlan {
+            carriers: chain_of(CarrierKind::Aether, CarrierKind::Psiphon),
+            manual: "vless://x",
+            tun: true,
+            ..Default::default()
+        });
+
+        // Dialled at the last hop: Psiphon's name and Psiphon's port.
+        assert!(
+            config.contains("name: psiphon, type: socks5, server: 127.0.0.1, port: 64347"),
+            "{config}"
+        );
+        assert!(config.contains("dialer-proxy: psiphon"), "{config}");
+        assert!(!config.contains("dialer-proxy: aether"), "{config}");
+
+        // Both processes out of the device, not just the one mihomo dials.
+        assert!(
+            config.contains(&format!("- PROCESS-NAME,{},DIRECT", CarrierKind::Aether.process_name())),
+            "the first hop must be exempted: {config}"
+        );
+        assert!(
+            config.contains(&format!("- PROCESS-NAME,{},DIRECT", CarrierKind::Psiphon.process_name())),
+            "the second hop must be exempted too: {config}"
+        );
+
+        // The address exemption is the first hop's gateway. The second hop
+        // reaches the network through the first and has no address to name.
+        assert!(config.contains("- IP-CIDR,162.159.198.2/32,DIRECT,no-resolve"), "{config}");
+    }
+
+    #[test]
+    fn one_tcp_only_hop_makes_the_whole_rendered_chain_tcp_only() {
+        // Measured: Psiphon's SOCKS5 refuses UDP ASSOCIATE and Tor carries no
+        // datagrams. A chain is only as good as its weakest hop, and both
+        // halves of saying so have to reach the config -- the declaration and
+        // the rule -- or the failure is a hang rather than a refusal.
+        //
+        // Aether is last here and does carry datagrams. Reading the last hop
+        // would declare `udp: true` over a Psiphon hop that cannot pass one.
+        let config = render(&RenderPlan {
+            carriers: chain_of(CarrierKind::Psiphon, CarrierKind::Aether),
+            manual: "vless://x",
+            ..Default::default()
+        });
+        assert!(config.contains("udp: false"), "the weakest hop decides: {config}");
+        assert!(config.contains("  - NETWORK,udp,REJECT\n"), "{config}");
+    }
+
+    #[test]
+    fn a_chain_of_two_capable_hops_still_carries_datagrams() {
+        // The AND must not be a blanket "chains are TCP-only". Aether twice is
+        // refused elsewhere as pointless, so this uses the only pair that is
+        // both allowed and capable -- and asserts the rule stays absent.
+        let config = render(&RenderPlan {
+            carriers: Some(RunningChain::pair(
+                Carrier { carries_quic: true, ..hop(CarrierKind::Aether, 1819, None) },
+                Carrier { carries_quic: true, ..hop(CarrierKind::Aether, 1820, None) },
+            )),
+            manual: "vless://x",
+            ..Default::default()
+        });
+        assert!(config.contains("udp: true"), "{config}");
+        assert!(!config.contains("NETWORK,udp,REJECT"), "{config}");
+    }
+
+    #[test]
+    fn a_chain_with_no_exit_group_sends_everything_to_its_last_hop() {
+        // Without a second-hop subscription the catch-all names the carrier,
+        // and for a chain that is the last hop. Naming the first would send
+        // traffic to a listener that is not carrying the exit.
+        let config = render(&RenderPlan {
+            carriers: chain_of(CarrierKind::Aether, CarrierKind::Tor),
+            exit_chain: false,
+            tun: true,
+            ..Default::default()
+        });
+        assert!(config.contains("  - MATCH,tor\n"), "{config}");
+        assert!(!config.contains("MATCH,aether"), "{config}");
+    }
+
+    #[test]
     fn the_remedy_offered_matches_the_carrier_that_cannot_carry_it() {
         // Aether over MASQUE is 28 bytes short and WireGuard closes the gap, so
         // there is something to switch. Tor carries no datagrams at all and no
@@ -1879,7 +1994,7 @@ mod tests {
         // QUIC hang while TCP works. Refused, a resolver retries over TCP and a
         // browser drops off QUIC, both within a round trip.
         let config = render(&RenderPlan {
-            carrier: carrier_of(CarrierKind::Tor),
+            carriers: carrier_of(CarrierKind::Tor),
             manual: "vless://x",
             ..Default::default()
         });
@@ -1904,7 +2019,7 @@ mod tests {
         // directly returned 0x07 COMMAND NOT SUPPORTED. The guess shipped in
         // 1.8.0 and made QUIC hang under Psiphon instead of falling back.
         let config = render(&RenderPlan {
-            carrier: carrier_of(CarrierKind::Aether),
+            carriers: carrier_of(CarrierKind::Aether),
             manual: "vless://x",
             ..Default::default()
         });
@@ -1921,7 +2036,7 @@ mod tests {
         // 0x07. Both halves have to follow from that -- the declaration and the
         // rule -- or the failure is a hang rather than a refusal.
         let config = render(&RenderPlan {
-            carrier: carrier_of(CarrierKind::Psiphon),
+            carriers: carrier_of(CarrierKind::Psiphon),
             manual: "vless://x",
             ..Default::default()
         });
@@ -1945,7 +2060,7 @@ mod tests {
         // not exist, and feed that carrier's own packets back into itself.
         for kind in [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor] {
             let config = render(&RenderPlan {
-                carrier: carrier_of(kind),
+                carriers: carrier_of(kind),
                 manual: "vless://x",
                 tun: true,
                 ..Default::default()
@@ -1973,7 +2088,7 @@ mod tests {
         // would put the whole machine on the local network in the clear.
         for kind in [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor] {
             let config = render(&RenderPlan {
-                carrier: carrier_of(kind),
+                carriers: carrier_of(kind),
                 exit_chain: false,
                 tun: true,
                 ..Default::default()
@@ -1992,7 +2107,7 @@ mod tests {
         // address to write, so there the process rule is the whole of it --
         // and an exemption invented for them would name the wrong host.
         let aether = render(&RenderPlan {
-            carrier: tunnel_via("162.159.198.2"),
+            carriers: tunnel_via("162.159.198.2"),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -2000,7 +2115,7 @@ mod tests {
         assert!(aether.contains("- IP-CIDR,162.159.198.2/32,DIRECT,no-resolve"), "{aether}");
 
         let tor = render(&RenderPlan {
-            carrier: carrier_of(CarrierKind::Tor),
+            carriers: carrier_of(CarrierKind::Tor),
             manual: "vless://x",
             tun: true,
             ..Default::default()
@@ -2132,6 +2247,18 @@ mod tests {
 #[cfg(test)]
 mod config_dump {
     use super::*;
+    use crate::carrier::Carrier;
+
+    /// Its own copy rather than a shared helper: this module exists to be run
+    /// by hand and should not break when the suite's fixtures move.
+    fn hop(kind: CarrierKind, port: u16, endpoint: Option<&str>) -> Carrier {
+        Carrier {
+            kind,
+            socks: format!("127.0.0.1:{port}").parse().unwrap(),
+            endpoint: endpoint.and_then(|value| value.parse().ok()),
+            carries_quic: false,
+        }
+    }
 
     /// Writes the config the app would generate with the Iran bypass on, so it
     /// can be handed to the real mihomo for validation. Not part of the suite:
@@ -2151,17 +2278,24 @@ mod config_dump {
             // All three set from the environment so one dump can cover any
             // shape: which carrier, whether a device is held up, and whether a
             // gateway has been picked.
-            carrier: Some(Carrier {
-                kind: match std::env::var("WHITEAESTHER_CONFIG_DUMP_CARRIER").as_deref() {
-                    Ok("psiphon") => CarrierKind::Psiphon,
-                    Ok("tor") => CarrierKind::Tor,
+            carriers: Some({
+                let kind = |name: &str| match name {
+                    "psiphon" => CarrierKind::Psiphon,
+                    "tor" => CarrierKind::Tor,
                     _ => CarrierKind::Aether,
-                },
-                socks: "127.0.0.1:1819".parse().unwrap(),
-                endpoint: std::env::var("WHITEAESTHER_CONFIG_DUMP_ENDPOINT")
-                    .ok()
-                    .and_then(|value| value.parse().ok()),
-                carries_quic: false,
+                };
+                let first = hop(
+                    kind(std::env::var("WHITEAESTHER_CONFIG_DUMP_CARRIER").unwrap_or_default().as_str()),
+                    1819,
+                    std::env::var("WHITEAESTHER_CONFIG_DUMP_ENDPOINT").ok().as_deref(),
+                );
+                // A second hop when one is named, so a dump can cover a chain.
+                match std::env::var("WHITEAESTHER_CONFIG_DUMP_SECOND") {
+                    Ok(name) if !name.is_empty() => {
+                        RunningChain::pair(first, hop(kind(&name), 64347, None))
+                    }
+                    _ => RunningChain::single(first),
+                }
             }),
             mixed: 1820,
             api: 1821,

--- a/src-tauri/src/chain.rs
+++ b/src-tauri/src/chain.rs
@@ -141,22 +141,17 @@ impl ChainRequest<'_> {
 
     /// Whether mihomo has any reason to run at all.
     ///
-    /// Three of them, and it used to know only two. A carrier that is not
-    /// Aether needs the engine running even with no second hop and no device:
-    /// the whole arrangement is that mihomo owns the interface and routes it
-    /// into whichever carrier is up, so refusing to start without an exit chain
-    /// would leave Psiphon or Tor connected and carrying nothing.
-    /// The last hop decides this, not the chain's length. A chain ending at
-    /// Aether hands out a listener applications can use directly, exactly as a
-    /// lone Aether does -- so it needs no more help from mihomo than that case
-    /// does, whatever is carrying it underneath.
+    /// The carrier half of this is [`RunningChain::needs_routing_engine`], and
+    /// deliberately not restated here: this rule and the supervisor's used to
+    /// be two copies keyed on the last hop, and they disagreed the moment a
+    /// chain ended at Aether.
     fn has_something_to_do(&self) -> bool {
         self.wants_exit_chain()
             || self.tun
             || self
                 .carriers
                 .as_ref()
-                .is_some_and(|chain| chain.last().kind != CarrierKind::Aether)
+                .is_some_and(RunningChain::needs_routing_engine)
     }
 }
 
@@ -177,7 +172,11 @@ pub struct Running {
     /// up on can change under a chain that keeps running -- which is why
     /// `carries_quic` is still asked of the supervisor on every call rather
     /// than snapshotted alongside this.
-    carrier: Option<CarrierKind>,
+    /// The hop whose datagram limit the "this protocol cannot work" advice
+    /// has to describe -- see [`RunningChain::datagram_blocker`]. Not simply
+    /// "which carrier this is": under a chain those are different hops, and
+    /// naming the wrong one hands out a remedy that cannot work.
+    datagram_blocker: Option<CarrierKind>,
     /// The chain directory, so the node list can read back what the
     /// subscriptions actually contained. mihomo's API reports a protocol and a
     /// name and nothing about REALITY, and REALITY is the one thing this
@@ -245,8 +244,9 @@ impl Chain {
                 return Err("connect first, or turn off \"dial nodes through the tunnel\"".into());
             }
         } else if !request.has_something_to_do() {
-            // No second hop wanted, no device to hold up, and Aether needs no
-            // help routing its own listener.
+            // No second hop wanted, no device to hold up, and a lone Aether
+            // needs no help routing its own listener. A *chained* Aether does
+            // -- see `has_something_to_do`.
             return Err("the chain has nothing to carry".into());
         }
         // Full tunnel forwards everything to the carrier's listener, so without
@@ -391,7 +391,7 @@ impl Chain {
             api: api_address,
             secret,
             through_tunnel: settings.through_tunnel,
-            carrier: carriers.map(|chain| chain.last().kind),
+            datagram_blocker: carriers.map(RunningChain::datagram_blocker),
             home: home.clone(),
         });
         Ok(mixed_address)
@@ -414,7 +414,7 @@ impl Chain {
             let guard = self.running.lock().map_err(|_| "the chain lock is poisoned")?;
             match guard.as_ref() {
                 Some(running) => {
-                    (running.through_tunnel, running.carrier, Some(running.home.clone()))
+                    (running.through_tunnel, running.datagram_blocker, Some(running.home.clone()))
                 }
                 None => (false, None, None),
             }

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -495,6 +495,14 @@ struct SupervisorInner {
     snapshot: Mutex<CoreSnapshot>,
     logs: Mutex<VecDeque<CoreLogEvent>>,
     session: Mutex<Option<Session>>,
+    /// The chain that is up, built hop by hop as each starts carrying.
+    ///
+    /// Held here rather than derived from the snapshot, because the snapshot
+    /// can only ever describe one carrier: it has one `socks_address` and one
+    /// `endpoint`. With two hops, whichever was written last would be the only
+    /// one anything could see -- and the routing engine needs the first hop's
+    /// gateway and every hop's process name, not just the last one's listener.
+    chain: Mutex<Option<RunningChain>>,
     /// Bumped by every start and every stop. A retry thread that wakes up on a
     /// stale generation has been superseded and does nothing.
     generation: AtomicU64,
@@ -540,6 +548,7 @@ impl CoreSupervisor {
                 snapshot: Mutex::new(CoreSnapshot::default()),
                 logs: Mutex::new(VecDeque::with_capacity(MAX_LOGS)),
                 session: Mutex::new(None),
+                chain: Mutex::new(None),
                 generation: AtomicU64::new(0),
                 proxy_route: Mutex::new(None),
                 scan_child: Mutex::new(None),
@@ -580,6 +589,17 @@ impl CoreSupervisor {
     /// after the first had been dropped. Here they come from one snapshot.
     pub fn carrier(&self, app: &AppHandle) -> Option<Carrier> {
         current_carrier(app, &self.inner)
+    }
+
+    /// The whole chain that is carrying traffic, hops and all.
+    ///
+    /// What the routing engine needs, and not the same as `carrier()`: mihomo
+    /// has to exempt every hop's process from the TUN device and read datagram
+    /// support across all of them. Restarting mihomo with only the last hop is
+    /// how a live chain would silently become a single hop in the config it
+    /// renders.
+    pub fn chain(&self, app: &AppHandle) -> Option<RunningChain> {
+        current_chain(app, &self.inner)
     }
 
     /// Records a line from something the app runs alongside the core.
@@ -755,7 +775,7 @@ fn start_core_blocking(
         };
     }
 
-    match launch(app, inner, &profile, 0, generation) {
+    match launch(app, inner, &profile, 0, generation, true) {
         Ok(()) => Ok(lock(&inner.snapshot).clone()),
         Err(error) => {
             *lock(&inner.session) = None;
@@ -796,41 +816,57 @@ fn start_carrier_blocking(
         format!("carrier {} is starting", profile.carriers.label()),
     );
 
-    // Each carrier brings itself up its own way and they share nothing but the
-    // shape of the answer: a listener, and something to say about where traffic
-    // is leaving from.
-    let (listener, leaving_from) = match profile.carriers.last() {
-        CarrierKind::Psiphon => {
-            let psiphon = app.state::<crate::psiphon::Psiphon>();
-            let listener = psiphon.start(app, &profile.psiphon)?;
-            // The exit country, when Psiphon has said one.
-            (listener, psiphon.snapshot().exit_region)
-        }
-        CarrierKind::Tor => {
-            let tor = app.state::<crate::tor::Tor>();
-            let listener = tor.start(app, &profile.tor)?;
-            // Tor has no one exit to name -- the relay changes per circuit and
-            // per destination -- so nothing is claimed here rather than a
-            // guess being put in front of someone who would act on it.
-            (listener, None)
-        }
-        // Guarded by the caller, which only reaches this for a non-Aether
-        // carrier. Named rather than left to a wildcard so adding a fourth
-        // carrier fails to compile here instead of silently doing nothing.
-        CarrierKind::Aether => {
-            return Err("the Aether engine does not start through the carrier path".into())
-        }
-    };
+    // Hop by hop, in the order traffic travels. Each one must be *carrying
+    // traffic* before the next starts -- not merely listening -- because the
+    // next will use it immediately, and a listener with no tunnel behind it
+    // swallows connections rather than refusing them.
+    //
+    // Every hop after the first is told to make its own outbound connections
+    // through the one before it. That is the whole of the chaining: no hop
+    // knows it is in a chain, only that it has an upstream.
+    let kinds = profile.carriers.kinds();
+    let mut hops: Vec<Carrier> = Vec::with_capacity(kinds.len());
+    let mut leaving_from: Option<String> = None;
 
-    if !inner.is_current(generation) {
-        stop_carriers(app);
-        return Err("the connection was stopped while it was starting".into());
+    for (position, kind) in kinds.iter().copied().enumerate() {
+        let upstream = hops.last().map(|previous: &Carrier| previous.socks);
+        if position > 0 {
+            let mut snapshot = lock(&inner.snapshot);
+            snapshot.status_message = Some(format!(
+                "{} is up; starting {} through it",
+                kinds[position - 1].label(),
+                kind.label()
+            ));
+            mark_snapshot_dirty(inner);
+        }
+
+        let hop = start_hop(app, inner, profile, kind, upstream, generation)?;
+        if !inner.is_current(generation) {
+            stop_carriers(app);
+            return Err("the connection was stopped while it was starting".into());
+        }
+        // The last hop that says where it leaves from wins, because that is
+        // the one the exit address belongs to.
+        if let Some(region) = hop_exit_region(app, kind) {
+            leaving_from = Some(region);
+        }
+        hops.push(hop);
     }
+
+    let chain = match hops.as_slice() {
+        [only] => RunningChain::single(*only),
+        [first, second] => RunningChain::pair(*first, *second),
+        // `CarrierChain` holds at most two, so this is unreachable rather than
+        // a case to handle. Named so a third hop fails here loudly instead of
+        // being silently truncated to the first two.
+        other => return Err(format!("a chain of {} hops is not supported", other.len())),
+    };
+    *lock(&inner.chain) = Some(chain.clone());
 
     {
         let mut snapshot = lock(&inner.snapshot);
         snapshot.state = "connected".into();
-        snapshot.socks_address = listener.to_string();
+        snapshot.socks_address = chain.listener().to_string();
         snapshot.status_message = None;
         snapshot.started_at = Some(now_millis());
         // Reported in the field the engine uses for its gateway, because it
@@ -839,17 +875,23 @@ fn start_carrier_blocking(
         snapshot.endpoint = leaving_from;
         mark_snapshot_dirty(inner);
     }
-
-    // mihomo always runs for a carrier, whether or not a second hop was asked
-    // for: it is what owns the interface and routes it into the carrier.
-    let carrier = current_carrier(app, inner)
-        .ok_or("the carrier reported a listener and then stopped carrying traffic")?;
+    supervisor_log(
+        inner,
+        "info",
+        format!(
+            "{} is carrying traffic; listener on {}",
+            profile.carriers.label(),
+            chain.listener()
+        ),
+    );
     let tun = tun_is_possible(inner, profile.full_tunnel);
-    let chain = app.state::<Chain>();
-    let chain_listener = match chain.start(
+    // `engine`, not `chain`: the mihomo instance, as distinct from the carrier
+    // chain it is being pointed at.
+    let engine = app.state::<Chain>();
+    let chain_listener = match engine.start(
         app,
         &ChainRequest {
-            carriers: Some(RunningChain::single(carrier)),
+            carriers: Some(chain),
             settings: &profile.chain,
             bypass_iran_sites: profile.bypass_iran_sites,
             tun,
@@ -901,12 +943,21 @@ fn start_carrier_blocking(
 ///
 /// `profile` is the profile for this attempt, which is not necessarily the one
 /// the user configured -- see [`profile_for_attempt`].
+///
+/// `supervised` decides whether the engine retries on its own. True on the
+/// engine path, where the exit monitor and the route watch are the whole of how
+/// a dropped tunnel recovers. False when the engine is one hop of a chain: a
+/// hop that retries by itself leaves the hop in front of it hammering a dead
+/// upstream -- measured at 1340 attempts from Psiphon against a refusing proxy
+/// -- so the chain owns recovery instead, as one unit. See finding 4 in
+/// `CARRIER-CHAINING.md`.
 fn launch(
     app: &AppHandle,
     inner: &Arc<SupervisorInner>,
     profile: &CoreProfile,
     attempt: u32,
     generation: u64,
+    supervised: bool,
 ) -> Result<(), String> {
     let core_path = resolve_core_path(app, profile.core_path.as_deref())?;
     let version = core_version(&core_path)?;
@@ -1039,8 +1090,10 @@ fn launch(
     if let Some(stderr) = stderr {
         spawn_log_reader(app.clone(), inner.clone(), stderr, "stderr");
     }
-    spawn_exit_monitor(app.clone(), inner.clone(), generation);
-    spawn_route_watch(app.clone(), inner.clone(), generation);
+    if supervised {
+        spawn_exit_monitor(app.clone(), inner.clone(), generation);
+        spawn_route_watch(app.clone(), inner.clone(), generation);
+    }
 
     Ok(())
 }
@@ -1291,7 +1344,7 @@ pub async fn set_full_tunnel(
         return Err(NEEDS_ADMINISTRATOR.into());
     }
 
-    let Some(carrier) = supervisor.carrier(&app) else {
+    let Some(carriers) = supervisor.chain(&app) else {
         return Ok(false);
     };
 
@@ -1305,7 +1358,7 @@ pub async fn set_full_tunnel(
     let address = chain.start(
         &app,
         &ChainRequest {
-            carriers: Some(RunningChain::single(carrier)),
+            carriers: Some(carriers),
             settings: &chain_settings,
             bypass_iran_sites,
             tun: enabled,
@@ -1361,12 +1414,12 @@ pub async fn set_chain(
     };
 
     let socks = supervisor.connected_socks();
-    let carrier = supervisor.carrier(&app);
+    let carriers = supervisor.chain(&app);
     // Without a carrier the chain can still carry traffic straight to the
     // nodes. Refusing outright is what left this unusable on a network that
     // resets MASQUE: the tunnel never came up, so the chain never ran, so
     // nothing the user configured did anything at all.
-    if carrier.is_none() && (!settings.enabled || settings.through_tunnel) {
+    if carriers.is_none() && (!settings.enabled || settings.through_tunnel) {
         chain.stop();
         return Ok(false);
     }
@@ -1374,11 +1427,11 @@ pub async fn set_chain(
     // The engine also runs to hold up a full-tunnel device, so "is a second hop
     // wanted" is no longer the same question as "should it be running".
     let tun = tun_is_possible(inner, full_tunnel);
-    let started = if engine_is_wanted(settings.enabled, tun, carrier) {
+    let started = if engine_is_wanted(settings.enabled, tun, carriers.as_ref().map(|chain| *chain.last())) {
         let address = chain.start(
             &app,
             &ChainRequest {
-                carriers: carrier.map(RunningChain::single),
+                carriers: carriers.clone(),
                 settings: &settings,
                 bypass_iran_sites,
                 tun,
@@ -1398,7 +1451,7 @@ pub async fn set_chain(
     // Anything pointed at the old listener would go around the change the user
     // just made -- devices on the network included, which is why the shared
     // door is retargeted rather than left to be reconfigured by hand.
-    if let Some(listener) = started.or_else(|| carrier.map(|carrier| carrier.socks)) {
+    if let Some(listener) = started.or_else(|| carriers.as_ref().map(RunningChain::listener)) {
         app.state::<LanDoor>().retarget(listener);
     }
 
@@ -1862,7 +1915,7 @@ fn rescan_bad_route(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u
         snapshot.status_message = Some("Finding a faster gateway".into());
         mark_snapshot_dirty(inner);
     }
-    if let Err(error) = launch(app, inner, &profile, 0, next) {
+    if let Err(error) = launch(app, inner, &profile, 0, next, true) {
         handle_exit(app, inner, next, error);
     }
 }
@@ -2108,7 +2161,7 @@ fn handle_exit(app: &AppHandle, inner: &Arc<SupervisorInner>, generation: u64, r
         if !inner.is_current(generation) {
             return;
         }
-        if let Err(error) = launch(&app, &inner, &profile, attempt, generation) {
+        if let Err(error) = launch(&app, &inner, &profile, attempt, generation, true) {
             handle_exit(&app, &inner, generation, error);
         }
     });
@@ -2174,7 +2227,7 @@ fn hold(
         // gets a blocked transport past a filter, and a hold that only ever tried
         // the configured one would sit there forever.
         let next = profile_for_attempt(&profile, 1);
-        if let Err(error) = launch(&app, &inner, &next, 1, generation) {
+        if let Err(error) = launch(&app, &inner, &next, 1, generation, true) {
             handle_exit(&app, &inner, generation, error);
         }
     });
@@ -2294,7 +2347,17 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     // A tunnel that came up has spent its failures. Anything after this is a
     // fresh problem and gets the full retry budget again. Kept out of the
     // snapshot lock above so the two are never held at once.
-    if connected {
+    // Only the engine on its own orchestrates from here. When Aether is a hop
+    // of a chain its log still arrives, and everything below would fire on it:
+    // mihomo started early, pointed at Aether alone, before the hop in front
+    // even exists -- and then the chain path would start a second one. The
+    // chain path owns all of this for a chain, in order, once every hop is
+    // carrying.
+    let orchestrates_here = lock(&inner.session)
+        .as_ref()
+        .is_none_or(|session| session.profile.carriers.is_lone_aether());
+
+    if connected && orchestrates_here {
         let (wanted, chain_settings, lan, bypass_iran_sites, full_tunnel) = {
             let mut guard = lock(&inner.session);
             match guard.as_mut() {
@@ -2559,6 +2622,161 @@ fn stop_carriers(app: &AppHandle) {
 /// which holds `inner` and not the supervisor. Everything it reports comes from
 /// a single lock: taken separately, the listener and the gateway could be read
 /// from two different moments, and under a reconnect they were.
+/// Brings one hop up and waits until it is carrying traffic.
+///
+/// `upstream` is the previous hop's listener, or `None` for the first. Each
+/// carrier is told about it in its own way -- Psiphon's `UpstreamProxyURL`,
+/// Tor's `Socks5Proxy`, Aether's `AETHER_UPSTREAM` -- and all three were
+/// measured honouring it. See `CARRIER-CHAINING.md`.
+fn start_hop(
+    app: &AppHandle,
+    inner: &Arc<SupervisorInner>,
+    profile: &CoreProfile,
+    kind: CarrierKind,
+    upstream: Option<SocketAddr>,
+    generation: u64,
+) -> Result<Carrier, String> {
+    match kind {
+        CarrierKind::Psiphon => {
+            let psiphon = app.state::<crate::psiphon::Psiphon>();
+            psiphon.start(app, &profile.psiphon, upstream)?;
+            psiphon
+                .carrier()
+                .ok_or_else(|| "Psiphon reported a listener and then stopped carrying".into())
+        }
+        CarrierKind::Tor => {
+            let tor = app.state::<crate::tor::Tor>();
+            tor.start(app, &profile.tor, upstream)?;
+            tor.carrier()
+                .ok_or_else(|| "Tor reported a listener and then stopped carrying".into())
+        }
+        CarrierKind::Aether => start_aether_hop(app, inner, profile, upstream, generation),
+    }
+}
+
+/// How long to wait for the engine to come up as one hop of a chain.
+///
+/// Its own `startup_secs` governs the scan; this bounds the whole thing so a
+/// chain reports failure rather than sitting on "connecting" forever.
+const AETHER_HOP_TIMEOUT: Duration = Duration::from_secs(150);
+
+/// The engine as one hop, brought up and waited for.
+///
+/// Not the engine path: that one owns the session, retries on a widening
+/// backoff and alternates transports. Here it is a hop, and the chain owns
+/// recovery -- so `launch` runs unsupervised and this blocks until the log says
+/// the listener is up.
+fn start_aether_hop(
+    app: &AppHandle,
+    inner: &Arc<SupervisorInner>,
+    profile: &CoreProfile,
+    upstream: Option<SocketAddr>,
+    generation: u64,
+) -> Result<Carrier, String> {
+    let mut hop = profile.clone();
+    if let Some(address) = upstream {
+        // The user's own upstream proxy wins, and a chain alongside one is
+        // refused rather than silently overwriting it. Quietly replacing a
+        // proxy someone configured deliberately sends their traffic somewhere
+        // they did not choose. See finding 8 in `CARRIER-CHAINING.md`.
+        if non_empty(Some(profile.upstream_proxy.as_str())).is_some() {
+            return Err(
+                "this profile already dials through a proxy of your own, so Aether cannot also \
+                 be chained behind another carrier. Clear \"Dial through a local proxy\" under \
+                 Routes and transports, or put Aether first in the chain."
+                    .into(),
+            );
+        }
+        hop.upstream_proxy = format!("socks5://{address}");
+        // Measured: the engine never resolves Cloudflare's API by name, it
+        // dials raw edge addresses with a spoofed SNI so DNS cannot be
+        // blocked -- and that fails through a SOCKS proxy. Registration
+        // therefore cannot happen from inside a chain, though an identity that
+        // already exists works completely. Said before the attempt, because
+        // the engine's own error names a registration failure and nothing the
+        // person can act on. See finding 1 in `CARRIER-CHAINING.md`.
+        if !aether_identity_exists(app) {
+            return Err(
+                "Aether has not registered a device yet, and it cannot register from inside \
+                 another carrier. Connect with Aether on its own once, then chain it."
+                    .into(),
+            );
+        }
+    }
+
+    launch(app, inner, &hop, 0, generation, false)?;
+
+    let deadline = Instant::now() + AETHER_HOP_TIMEOUT;
+    while Instant::now() < deadline {
+        if !inner.is_current(generation) {
+            return Err("the connection was stopped while it was starting".into());
+        }
+        if let Some(carrier) = current_carrier(app, inner) {
+            return Ok(carrier);
+        }
+        // A core that died before connecting leaves no child; noticing turns a
+        // wait into a message.
+        if lock(&inner.child).is_none() {
+            let reported = lock(&inner.snapshot).last_error.clone();
+            return Err(reported.unwrap_or_else(|| "Aether stopped before it connected".into()));
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    Err(format!(
+        "Aether did not connect in {}s",
+        AETHER_HOP_TIMEOUT.as_secs()
+    ))
+}
+
+/// Whether the engine already has a device identity on disk.
+///
+/// Registration cannot happen from inside a chain, so an Aether hop behind
+/// another carrier needs one that already exists.
+fn aether_identity_exists(app: &AppHandle) -> bool {
+    let Ok(config_dir) = app.path().app_config_dir() else {
+        return false;
+    };
+    let identity = config_dir.join("identity");
+    // The engine derives its own file names from the `--config` path it is
+    // given, so this looks for any of them rather than one exact name.
+    std::fs::read_dir(identity).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("aether") && name.ends_with(".toml"))
+        })
+    })
+}
+
+/// Where a hop says its traffic leaves from, when it knows.
+///
+/// Only Psiphon does: it reports the connected server's country. Tor's relay
+/// changes per circuit and Aether's gateway is an address rather than a place,
+/// so neither claims one here -- a guess in front of someone who would act on
+/// it is worse than saying nothing.
+fn hop_exit_region(app: &AppHandle, kind: CarrierKind) -> Option<String> {
+    match kind {
+        CarrierKind::Psiphon => app.state::<crate::psiphon::Psiphon>().snapshot().exit_region,
+        CarrierKind::Tor | CarrierKind::Aether => None,
+    }
+}
+
+/// The chain that is carrying traffic, or `None` when nothing is.
+///
+/// Reads what the start path recorded rather than re-deriving it. A chain built
+/// hop by hop cannot be reconstructed from the snapshot afterwards -- the
+/// snapshot has one listener and one gateway, so the second hop's arrival
+/// erases the first's.
+fn current_chain(app: &AppHandle, inner: &SupervisorInner) -> Option<RunningChain> {
+    if let Some(chain) = lock(&inner.chain).clone() {
+        return Some(chain);
+    }
+    // No recorded chain: the engine on its own, whose state lives in the
+    // snapshot because its supervisor writes it there as the log arrives.
+    current_carrier(app, inner).map(RunningChain::single)
+}
+
 fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> {
     // Whose listener this is depends on what the session chose. Reading the
     // engine's snapshot regardless is what would put `aether` in a config that

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -575,9 +575,21 @@ impl CoreSupervisor {
     /// [`crate::chain::unusable_behind_the_carrier`]. Reported rather than
     /// worked out in the chain, because only the supervisor knows which
     /// transport actually came up -- a profile set to MASQUE can fall back.
-    pub fn carries_quic(&self) -> bool {
-        let snapshot = lock(&self.inner.snapshot);
-        !matches!(snapshot.transport.as_deref(), Some("masque-h2") | Some("masque-h3"))
+    pub fn carries_quic(&self, app: &AppHandle) -> bool {
+        // Asked of the chain, because the chain is what a node's handshake has
+        // to cross. This read the snapshot's `transport` field, which holds a
+        // MASQUE transport for a lone engine but a *proxy name* for anything
+        // carrier-driven -- so "aether" matched neither `masque-h2` nor
+        // `masque-h3` and every chain was reported as carrying QUIC, including
+        // `Psiphon -> Aether`, whose first hop refuses datagrams outright.
+        // hysteria2 and tuic nodes were then offered as usable behind a chain
+        // that cannot carry a single datagram.
+        match current_chain(app, &self.inner) {
+            Some(chain) => chain.carries_quic(),
+            // Nothing carrying yet: the nodes are dialled directly, so the
+            // only limit is the node's own.
+            None => true,
+        }
     }
 
     /// This engine as a carrier, or `None` when it is not carrying anything.
@@ -700,6 +712,25 @@ pub async fn probe_core(app: AppHandle, profile: Option<CoreProfile>) -> CorePro
 }
 
 fn probe_core_blocking(app: &AppHandle, profile: Option<CoreProfile>) -> CoreProbe {
+    // A connection that never runs the engine must not be gated on the
+    // engine's binary. The screen refuses to connect at all when this reports
+    // unavailable, so a bad `corePath` under Diagnostics -- or any other reason
+    // the engine cannot be resolved -- was enough to block `Psiphon -> Tor`,
+    // which does not use it, with a message naming a component it does not
+    // need. Absent a profile the engine is the safe assumption: that is the
+    // default, and the check has nothing else to go on.
+    let carriers = profile.as_ref().map(|value| value.carriers);
+    if let Some(carriers) = carriers {
+        if !carriers.contains(CarrierKind::Aether) {
+            return CoreProbe {
+                available: true,
+                path: None,
+                version: None,
+                message: format!("{} does not use the Aether engine", carriers.label()),
+            };
+        }
+    }
+
     let requested = profile.and_then(|value| value.core_path);
     match resolve_core_path(app, requested.as_deref()) {
         Ok(path) => match core_version(&path) {
@@ -754,6 +785,17 @@ fn start_core_blocking(
         attempt: 0,
     });
 
+    // Named on every path, the engine's included, and before the branch that
+    // acts on it. A chain that arrives already collapsed to one hop is
+    // otherwise invisible: it takes the engine path, which says nothing about
+    // carriers at all, and the log reads exactly like a session nobody chained.
+    // That cost a whole test cycle to work out from generated config files.
+    supervisor_log(
+        inner,
+        "info",
+        format!("the way out is {}", profile.carriers.label()),
+    );
+
     // A carrier that is not the engine takes an entirely different path: there
     // is no gateway to hunt, no transport to alternate, and nothing to read out
     // of log prose. The session above is still claimed first, so a stop and a
@@ -763,7 +805,11 @@ fn start_core_blocking(
             Ok(snapshot) => Ok(snapshot),
             Err(error) => {
                 *lock(&inner.session) = None;
-                stop_carriers(app);
+                // Every hop, not just the two that are separate programs: a
+                // chain that got as far as bringing Aether up has a child to
+                // kill, and leaving it means an engine dialling out with the
+                // hop in front of it gone.
+                stop_all_hops(app, inner);
                 let mut snapshot = lock(&inner.snapshot);
                 snapshot.state = "error".into();
                 snapshot.pid = None;
@@ -831,18 +877,25 @@ fn start_carrier_blocking(
     for (position, kind) in kinds.iter().copied().enumerate() {
         let upstream = hops.last().map(|previous: &Carrier| previous.socks);
         if position > 0 {
-            let mut snapshot = lock(&inner.snapshot);
-            snapshot.status_message = Some(format!(
+            let progress = format!(
                 "{} is up; starting {} through it",
                 kinds[position - 1].label(),
                 kind.label()
-            ));
-            mark_snapshot_dirty(inner);
+            );
+            {
+                let mut snapshot = lock(&inner.snapshot);
+                snapshot.status_message = Some(progress.clone());
+                mark_snapshot_dirty(inner);
+            }
+            // Logged as well as shown. A second hop that never finishes left
+            // no trace at all otherwise: the log ended with hop 1 listening,
+            // which reads exactly like a chain that was never asked for.
+            supervisor_log(inner, "info", progress);
         }
 
         let hop = start_hop(app, inner, profile, kind, upstream, generation)?;
         if !inner.is_current(generation) {
-            stop_carriers(app);
+            stop_all_hops(app, inner);
             return Err("the connection was stopped while it was starting".into());
         }
         // The last hop that says where it leaves from wins, because that is
@@ -914,6 +967,17 @@ fn start_carrier_blocking(
     };
 
     if let Some(address) = chain_listener {
+        // What the screen tells people to point applications at, and what
+        // "This app only" names. Until this it kept the last hop's own port,
+        // which under a chain is a listener that bypasses mihomo entirely --
+        // and with it the datagram rejection and the Iranian-sites bypass that
+        // only mihomo applies. Anything sent there would leave by a route the
+        // app had just promised it would not use.
+        {
+            let mut snapshot = lock(&inner.snapshot);
+            snapshot.socks_address = address.to_string();
+            mark_snapshot_dirty(inner);
+        }
         app.state::<LanDoor>().retarget(address);
         if profile.lan_share.enabled {
             match app.state::<LanDoor>().open(address, &profile.lan_share) {
@@ -1348,7 +1412,12 @@ pub async fn set_full_tunnel(
         return Ok(false);
     };
 
-    if !enabled && !chain_settings.enabled {
+    // Was the engine only running to hold the device up? `!chain_settings.enabled`
+    // answered that as though a device and an exit chain were its only two
+    // reasons -- so turning full tunnel off under a lone Psiphon or Tor, or
+    // under any chain, stopped the very process that *was* the route. The
+    // chain's own rule knows better.
+    if !enabled && !engine_is_wanted(chain_settings.enabled, false, Some(&carriers)) {
         // The engine was only running to hold the device up.
         chain.stop();
         supervisor_log(inner, "info", "full tunnel stopped".into());
@@ -1427,7 +1496,7 @@ pub async fn set_chain(
     // The engine also runs to hold up a full-tunnel device, so "is a second hop
     // wanted" is no longer the same question as "should it be running".
     let tun = tun_is_possible(inner, full_tunnel);
-    let started = if engine_is_wanted(settings.enabled, tun, carriers.as_ref().map(|chain| *chain.last())) {
+    let started = if engine_is_wanted(settings.enabled, tun, carriers.as_ref()) {
         let address = chain.start(
             &app,
             &ChainRequest {
@@ -1567,6 +1636,12 @@ fn set_psiphon_region_blocking(
     // whatever the new run produces.
     app.state::<Chain>().stop();
     clear_system_proxy(app, inner);
+    // And every hop, before any of them is rebuilt. Restarting a chain by
+    // starting hop 1 again would pull the ground out from under hop 2 while it
+    // was still running -- and a hop 2 that is the engine responds to losing
+    // its upstream by dialling out on its own, which is the one thing it must
+    // not do on the network this feature exists for.
+    stop_all_hops(app, inner);
 
     start_carrier_blocking(app, inner, &profile, generation)
 }
@@ -2306,6 +2381,15 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
     let message = message.trim().to_string();
     push_log(inner, stream, log_level(&message), message.clone());
 
+    // Whether the engine's own listener is the address the app hands out. In a
+    // chain it is not: mihomo owns that, and the engine's listener is an
+    // internal hop address that bypasses it. Read before the snapshot lock,
+    // because every path here takes session-then-snapshot and never the other
+    // way round.
+    let engine_owns_route = lock(&inner.session)
+        .as_ref()
+        .is_none_or(|session| session.profile.carriers.is_lone_aether());
+
     let connected = {
         let mut snapshot = lock(&inner.snapshot);
         // Once the core is gone, buffered lines still draining from the pipe must
@@ -2317,7 +2401,7 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
             false
         } else {
             let before = snapshot.clone();
-            apply_log_to_snapshot(&message, &mut snapshot);
+            apply_log_to_snapshot(&message, &mut snapshot, engine_owns_route);
             let connected = snapshot.state == "connected";
             if connected {
                 snapshot.attempt = 0;
@@ -2398,13 +2482,15 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
         // Full tunnel needs the engine running whether or not a second hop was
         // asked for, because the device it holds up is the engine's.
         let full_tunnel = tun_is_possible(inner, full_tunnel);
-        let carrier = current_carrier(app, inner);
-        let engine_wanted = engine_is_wanted(chain_settings.enabled, full_tunnel, carrier);
+        // Only ever reached for a lone Aether -- `orchestrates_here` above --
+        // so one hop is the whole chain here by construction.
+        let carriers = current_carrier(app, inner).map(RunningChain::single);
+        let engine_wanted = engine_is_wanted(chain_settings.enabled, full_tunnel, carriers.as_ref());
         let chain_listener = if engine_wanted && !chain.is_running() {
             match chain.start(
                 app,
                 &ChainRequest {
-                    carriers: carrier.map(RunningChain::single),
+                    carriers: carriers.clone(),
                     settings: &chain_settings,
                     bypass_iran_sites,
                     tun: full_tunnel,
@@ -2525,21 +2611,29 @@ fn spawn_carrier_watch(app: &AppHandle, inner: &Arc<SupervisorInner>, generation
         if !inner.is_current(generation) {
             return;
         }
-        let kind = {
+        // Every hop, in the order traffic travels -- not just the exit. This
+        // read `carriers.last()` and returned outright when that was Aether,
+        // so `Psiphon -> Aether` and `Tor -> Aether` had no watcher at all,
+        // and in the other orderings the death of hop 1 went unnoticed while
+        // the screen still read connected. A hop that dies takes the chain
+        // with it; that is the rule, and this is the only thing enforcing it.
+        let kinds = {
             let session = lock(&inner.session);
             match session.as_ref() {
-                Some(session) => session.profile.carriers.last(),
+                Some(session) => session.profile.carriers.kinds(),
                 None => return,
             }
         };
-        let alive = match kind {
-            CarrierKind::Psiphon => app.state::<crate::psiphon::Psiphon>().is_alive(),
-            CarrierKind::Tor => app.state::<crate::tor::Tor>().is_alive(),
-            CarrierKind::Aether => return,
-        };
-        if alive {
+        let dead = kinds.into_iter().find(|kind| match kind {
+            CarrierKind::Psiphon => !app.state::<crate::psiphon::Psiphon>().is_alive(),
+            CarrierKind::Tor => !app.state::<crate::tor::Tor>().is_alive(),
+            // The engine's child, which is where a chained Aether lives. A
+            // lone Aether has its own exit monitor and never reaches here.
+            CarrierKind::Aether => !aether_hop_is_alive(&inner),
+        });
+        let Some(kind) = dead else {
             continue;
-        }
+        };
         carrier_died(&app, &inner, generation, kind);
         return;
     });
@@ -2552,12 +2646,26 @@ fn carrier_died(
     generation: u64,
     kind: CarrierKind,
 ) {
-    let holding = {
+    let (holding, chained) = {
         let session = lock(&inner.session);
-        session
+        let holding = session
             .as_ref()
             .is_some_and(|current| current.profile.kill_switch)
-            && proxy_is_applied(inner)
+            && proxy_is_applied(inner);
+        // Which chain, so the message can say what went down as well as which
+        // hop took it down. "Psiphon stopped" on its own reads as though the
+        // whole connection was Psiphon, which under a chain it was not.
+        let chained = session
+            .as_ref()
+            .filter(|current| current.profile.carriers.is_chained())
+            .map(|current| current.profile.carriers.label());
+        (holding, chained)
+    };
+    // The subject of every sentence below: one hop of a chain, or the lone
+    // carrier that was the whole connection.
+    let what = match &chained {
+        Some(label) => format!("{}, carrying {label},", kind.label()),
+        None => kind.label().to_string(),
     };
 
     {
@@ -2571,22 +2679,38 @@ fn carrier_died(
         snapshot.blocking = holding;
         snapshot.last_error = Some(if holding {
             format!(
-                "{} stopped. Traffic is being held rather than sent in the clear -- disconnect to \
-                 put your system proxy back.",
-                kind.label()
+                "{what} stopped. Traffic is being held rather than sent in the clear -- \
+                 disconnect to put your system proxy back."
             )
         } else {
-            format!("{} stopped.", kind.label())
+            format!("{what} stopped.")
         });
         mark_snapshot_dirty(inner);
     }
-    supervisor_log(inner, "error", format!("{} stopped unexpectedly", kind.label()));
+    supervisor_log(inner, "error", format!("{what} stopped unexpectedly"));
 
     // The chain exists only to carry this carrier's traffic; without it, it
     // would sit there dialling a port nothing answers on. The door other
     // devices come in through goes for the same reason.
     app.state::<Chain>().stop();
     app.state::<LanDoor>().close();
+
+    // And the hops that are still up. One dead hop makes the whole chain
+    // useless -- the survivors cannot reach anything through a hop that is
+    // gone -- so leaving them running means a process holding a tunnel nothing
+    // is routed into, and, where the survivor is the engine, one that will
+    // happily start dialling out on its own with no hop in front of it. No
+    // independent restarts: a hop that dies takes the chain with it.
+    stop_all_hops(app, inner);
+
+    // And the session goes, exactly as `decide_exit` releases it before giving
+    // up on the engine path. Without this the connection is over but the claim
+    // on it is not, so the next Connect is refused with "Aether core is already
+    // running" and the only way back is to press Stop on something that already
+    // stopped. The generation moves with it, so nothing still in flight for the
+    // dead session can act after this point.
+    inner.generation.fetch_add(1, Ordering::SeqCst);
+    *lock(&inner.session) = None;
 
     // The kill switch bites here exactly as it does on the engine path: the
     // proxy is left pointing at a listener that is gone, so applications fail
@@ -2614,6 +2738,44 @@ fn carrier_died(
 fn stop_carriers(app: &AppHandle) {
     app.state::<crate::psiphon::Psiphon>().stop();
     app.state::<crate::tor::Tor>().stop();
+}
+
+/// Whether a chained Aether's process is still running.
+///
+/// Asked of the process rather than of the handle. A hop is launched
+/// unsupervised -- the chain owns its lifecycle, not the engine's own exit
+/// monitor -- so nothing clears the handle when the process dies, and testing
+/// the handle for presence would report a dead engine as alive forever.
+///
+/// An error from `try_wait` counts as dead. It should not happen, and if it
+/// does, "carrying traffic but we cannot confirm the hop exists" is precisely
+/// the silent disagreement between the screen and the router that this whole
+/// watcher exists to prevent.
+fn aether_hop_is_alive(inner: &SupervisorInner) -> bool {
+    let mut guard = lock(&inner.child);
+    match guard.as_mut() {
+        Some(child) => matches!(child.try_wait(), Ok(None)),
+        None => false,
+    }
+}
+
+/// Stops every hop a chain may have started, the engine included.
+///
+/// [`stop_carriers`] knows only about the two carriers that are separate
+/// programs. Aether is a hop like any other now, and its child lives in the
+/// supervisor rather than in a carrier -- so the error paths, which called
+/// `stop_carriers` alone, left a chained engine running with the hop in front
+/// of it killed underneath. Measured: after one failed `Psiphon -> Aether` the
+/// engine lost its upstream, went hunting for a Cloudflare gateway *directly*,
+/// and was still sweeping two minutes later with the screen reading Stopped.
+/// On a network that filters, that is the one thing this must never do.
+fn stop_all_hops(app: &AppHandle, inner: &SupervisorInner) {
+    stop_carriers(app);
+    let mut child = lock(&inner.child).take();
+    if let Some(child) = child.as_mut() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
 }
 
 /// The engine as a carrier, read from one snapshot.
@@ -2711,7 +2873,10 @@ fn start_aether_hop(
         if !inner.is_current(generation) {
             return Err("the connection was stopped while it was starting".into());
         }
-        if let Some(carrier) = current_carrier(app, inner) {
+        // `aether_carrier`, not `current_carrier`: this hop is Aether whatever
+        // position it holds, and the session's exit may be a hop that does not
+        // exist yet because it is started through this one.
+        if let Some(carrier) = aether_carrier(inner) {
             return Ok(carrier);
         }
         // A core that died before connecting leaves no child; noticing turns a
@@ -2777,20 +2942,16 @@ fn current_chain(app: &AppHandle, inner: &SupervisorInner) -> Option<RunningChai
     current_carrier(app, inner).map(RunningChain::single)
 }
 
-fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> {
-    // Whose listener this is depends on what the session chose. Reading the
-    // engine's snapshot regardless is what would put `aether` in a config that
-    // is actually routing into Psiphon -- a chain pointed at a proxy name
-    // nothing declares, which fails every node with no clue why.
-    let kind = lock(&inner.session)
-        .as_ref()
-        .map_or(CarrierKind::Aether, |session| session.profile.carriers.last());
-    match kind {
-        CarrierKind::Psiphon => return app.state::<crate::psiphon::Psiphon>().carrier(),
-        CarrierKind::Tor => return app.state::<crate::tor::Tor>().carrier(),
-        CarrierKind::Aether => {}
-    }
-
+/// The Aether engine's own listener, asked for by name.
+///
+/// [`current_carrier`] answers "what is this session's exit", which is the last
+/// hop -- so asking it about Aether while Aether is the *first* hop of a chain
+/// returns the second hop's carrier, which does not exist yet because it is
+/// started through this one. `Aether -> Psiphon` and `Aether -> Tor` therefore
+/// never got past hop 1: the poll waited the full hop timeout for a listener it
+/// was looking for in the wrong place, and the log ended with Aether listening
+/// and nothing after it.
+fn aether_carrier(inner: &SupervisorInner) -> Option<Carrier> {
     let snapshot = lock(&inner.snapshot);
     if snapshot.state != "connected" {
         return None;
@@ -2831,6 +2992,23 @@ fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> 
     })
 }
 
+fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> {
+    // Whose listener this is depends on what the session chose. Reading the
+    // engine's snapshot regardless is what would put `aether` in a config that
+    // is actually routing into Psiphon -- a chain pointed at a proxy name
+    // nothing declares, which fails every node with no clue why.
+    let kind = lock(&inner.session)
+        .as_ref()
+        .map_or(CarrierKind::Aether, |session| session.profile.carriers.last());
+    match kind {
+        CarrierKind::Psiphon => return app.state::<crate::psiphon::Psiphon>().carrier(),
+        CarrierKind::Tor => return app.state::<crate::tor::Tor>().carrier(),
+        CarrierKind::Aether => {}
+    }
+
+    aether_carrier(inner)
+}
+
 /// Whether mihomo should be running at all.
 ///
 /// Three separate reasons, and it used to know two. A carrier that is not
@@ -2838,8 +3016,12 @@ fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> 
 /// what owns the interface and routes it into the carrier's listener, so
 /// stopping it when the user turns the exit chain off would leave Psiphon or
 /// Tor connected and carrying nothing at all.
-fn engine_is_wanted(chain_enabled: bool, tun: bool, carrier: Option<Carrier>) -> bool {
-    chain_enabled || tun || carrier.is_some_and(|carrier| carrier.kind != CarrierKind::Aether)
+fn engine_is_wanted(chain_enabled: bool, tun: bool, carriers: Option<&RunningChain>) -> bool {
+    // The carrier half is the chain's own rule, not a second copy of it. This
+    // took `Option<Carrier>` and was called with the chain's last hop, which
+    // meant toggling the exit chain off under a live `Psiphon -> Aether` shut
+    // down the very thing enforcing that the chain carries no datagrams.
+    chain_enabled || tun || carriers.is_some_and(RunningChain::needs_routing_engine)
 }
 
 /// Whether a second hop is what traffic should be following right now.
@@ -3030,7 +3212,17 @@ fn end_fruitless_sweep(inner: &SupervisorInner) {
     );
 }
 
-fn apply_log_to_snapshot(message: &str, snapshot: &mut CoreSnapshot) {
+/// Turns one line of the engine's output into snapshot state.
+///
+/// `engine_owns_route` says whether the engine's own SOCKS listener is the
+/// address applications are told to use. It is, for a lone engine. Inside a
+/// chain it is not -- mihomo owns that address -- and taking the engine's
+/// listener from this line regardless is what put the *bypass* listener back on
+/// screen every time a chained engine reconnected internally, which the
+/// measured `connection reset` makes a routine event rather than a rare one.
+/// The state still follows the line: a hop that came back is a chain that is
+/// carrying again.
+fn apply_log_to_snapshot(message: &str, snapshot: &mut CoreSnapshot, engine_owns_route: bool) {
     if message.contains("hunting for a working") || message.contains("verifying cached") {
         snapshot.state = "scanning".into();
     }
@@ -3068,7 +3260,9 @@ fn apply_log_to_snapshot(message: &str, snapshot: &mut CoreSnapshot) {
             };
             if let Some(candidate) = rest.split_whitespace().next() {
                 if candidate.parse::<SocketAddr>().is_ok() {
-                    snapshot.socks_address = candidate.to_string();
+                    if engine_owns_route {
+                        snapshot.socks_address = candidate.to_string();
+                    }
                     snapshot.state = "connected".into();
                     // A route is up, so nothing is being held any more.
                     snapshot.blocking = false;
@@ -3545,6 +3739,7 @@ mod tests {
         apply_log_to_snapshot(
             "[+] selected MASQUE gateway 162.159.192.18:443 (rtt 84.5ms)",
             &mut snapshot,
+            true,
         );
         assert_eq!(snapshot.endpoint.as_deref(), Some("162.159.192.18:443"));
         assert_eq!(snapshot.latency_ms, Some(84.5));
@@ -3552,6 +3747,7 @@ mod tests {
         apply_log_to_snapshot(
             "[+] socks5 server listening on 127.0.0.1:1819",
             &mut snapshot,
+            true,
         );
         assert_eq!(snapshot.state, "connected");
     }
@@ -3879,7 +4075,7 @@ mod tests {
             "WARN peer sent banner: \"socks5 server listening on 0.0.0.0:9\"",
         ] {
             let mut snapshot = CoreSnapshot::default();
-            apply_log_to_snapshot(line, &mut snapshot);
+            apply_log_to_snapshot(line, &mut snapshot, true);
             assert_ne!(snapshot.state, "connected", "line must not connect: {line}");
         }
     }
@@ -3911,7 +4107,7 @@ mod tests {
         // Garbage after the gate leaves the configured value untouched.
         let mut snapshot = CoreSnapshot::default();
         let configured = snapshot.socks_address.clone();
-        apply_log_to_snapshot("socks5 server listening on not-an-address", &mut snapshot);
+        apply_log_to_snapshot("socks5 server listening on not-an-address", &mut snapshot, true);
         assert_eq!(snapshot.socks_address, configured);
 
         // A different listener earlier in the line must not be mistaken for the SOCKS one.
@@ -3919,6 +4115,7 @@ mod tests {
         apply_log_to_snapshot(
             "http proxy listening on 198.51.100.9:8080; socks5 server listening on 127.0.0.1:1819",
             &mut snapshot,
+            true,
         );
         assert_eq!(snapshot.socks_address, "127.0.0.1:1819");
         assert_eq!(snapshot.state, "connected");
@@ -3930,6 +4127,7 @@ mod tests {
         apply_log_to_snapshot(
             "2026-01-01 ERROR aether - TLS certificate verification FAILED, reconnecting",
             &mut snapshot,
+            true,
         );
         assert_eq!(snapshot.state, "reconnecting");
         assert_eq!(
@@ -3953,6 +4151,14 @@ mod tests {
             endpoint: None,
             carries_quic: false,
         })
+    }
+
+    fn lone(kind: CarrierKind) -> RunningChain {
+        RunningChain::single(carrier(kind).unwrap())
+    }
+
+    fn pair(first: CarrierKind, second: CarrierKind) -> RunningChain {
+        RunningChain::pair(carrier(first).unwrap(), carrier(second).unwrap())
     }
 
     #[test]
@@ -4009,6 +4215,66 @@ mod tests {
     }
 
     #[test]
+    fn a_chained_engine_does_not_reclaim_the_address_applications_are_given() {
+        // Measured: `Psiphon -> Aether` and `Tor -> Aether` both come up, carry
+        // traffic, and then reset within seconds -- the engine reconnects
+        // internally and logs its listener again. Taking the address from that
+        // line would put mihomo's port back to the engine's own, which is the
+        // listener that bypasses the datagram rejection and the Iranian-sites
+        // bypass. So the state follows the line and the address does not.
+        let mut snapshot = CoreSnapshot {
+            socks_address: "127.0.0.1:1820".into(),
+            state: "reconnecting".into(),
+            ..CoreSnapshot::default()
+        };
+        apply_log_to_snapshot("[+] socks5 server listening on 127.0.0.1:1819", &mut snapshot, false);
+        assert_eq!(
+            snapshot.socks_address, "127.0.0.1:1820",
+            "mihomo owns the address a chain hands out"
+        );
+        assert_eq!(snapshot.state, "connected", "the hop is carrying again");
+
+        // A lone engine does own it, and must still be believed.
+        let mut alone = CoreSnapshot::default();
+        apply_log_to_snapshot("[+] socks5 server listening on 127.0.0.1:1819", &mut alone, true);
+        assert_eq!(alone.socks_address, "127.0.0.1:1819");
+        assert_eq!(alone.state, "connected");
+    }
+
+    #[test]
+    fn a_connection_without_aether_does_not_need_the_engine_binary() {
+        // The screen refuses to connect when the probe says unavailable, so
+        // gating it on the engine's binary blocked `Psiphon -> Tor` -- which
+        // never runs the engine -- whenever the engine could not be resolved.
+        let chains = [
+            CarrierChain { first: CarrierKind::Psiphon, second: None },
+            CarrierChain { first: CarrierKind::Tor, second: None },
+            CarrierChain { first: CarrierKind::Psiphon, second: Some(CarrierKind::Tor) },
+            CarrierChain { first: CarrierKind::Tor, second: Some(CarrierKind::Psiphon) },
+        ];
+        for carriers in chains {
+            assert!(
+                !carriers.contains(CarrierKind::Aether),
+                "{} was meant to exclude the engine",
+                carriers.label()
+            );
+        }
+        // And every chain that does contain it still asks for it, in either
+        // position, so the check cannot be loosened into never asking.
+        for carriers in [
+            CarrierChain { first: CarrierKind::Aether, second: None },
+            CarrierChain { first: CarrierKind::Aether, second: Some(CarrierKind::Tor) },
+            CarrierChain { first: CarrierKind::Psiphon, second: Some(CarrierKind::Aether) },
+        ] {
+            assert!(
+                carriers.contains(CarrierKind::Aether),
+                "{} runs the engine and must be gated on it",
+                carriers.label()
+            );
+        }
+    }
+
+    #[test]
     fn the_engine_runs_for_a_carrier_with_no_second_hop_and_no_device() {
         // The arrangement a carrier depends on: mihomo owns the interface and
         // routes it into whichever carrier is up. Asking only "is an exit chain
@@ -4016,7 +4282,7 @@ mod tests {
         // hop off, leaving Psiphon or Tor connected and carrying nothing.
         for kind in [CarrierKind::Psiphon, CarrierKind::Tor] {
             assert!(
-                engine_is_wanted(false, false, carrier(kind)),
+                engine_is_wanted(false, false, Some(&lone(kind))),
                 "{kind:?} needs the engine to carry anything at all"
             );
         }
@@ -4028,11 +4294,38 @@ mod tests {
         // device there is nothing for mihomo to do. Starting it regardless
         // would put a second process and a second port in the path of every
         // connection that did not ask for one.
-        assert!(!engine_is_wanted(false, false, carrier(CarrierKind::Aether)));
+        assert!(!engine_is_wanted(false, false, Some(&lone(CarrierKind::Aether))));
         assert!(!engine_is_wanted(false, false, None));
         // The two reasons it did already know about still hold.
-        assert!(engine_is_wanted(true, false, carrier(CarrierKind::Aether)));
-        assert!(engine_is_wanted(false, true, carrier(CarrierKind::Aether)));
+        assert!(engine_is_wanted(true, false, Some(&lone(CarrierKind::Aether))));
+        assert!(engine_is_wanted(false, true, Some(&lone(CarrierKind::Aether))));
+    }
+
+    #[test]
+    fn every_chain_of_two_hops_needs_the_engine_whatever_it_ends_at() {
+        // The fault that made `Psiphon -> Aether` report "the chain has nothing
+        // to carry". Aether's listener is directly usable, so keyed on the last
+        // hop this looked like the lone-Aether case -- but the chain behind that
+        // listener carries only what its weakest hop carries, and mihomo is the
+        // only thing that can declare `udp: false` and refuse datagrams at the
+        // edge instead of letting them die in the middle.
+        let kinds = [CarrierKind::Aether, CarrierKind::Psiphon, CarrierKind::Tor];
+        for first in kinds {
+            for second in kinds {
+                if first == second {
+                    continue;
+                }
+                let chain = pair(first, second);
+                assert!(
+                    engine_is_wanted(false, false, Some(&chain)),
+                    "{first:?} -> {second:?} needs the engine to enforce the weakest hop"
+                );
+                assert!(
+                    chain.needs_routing_engine(),
+                    "{first:?} -> {second:?}: the chain's own rule must agree"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -12,7 +12,7 @@ use std::{
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
-use crate::carrier::{Carrier, CarrierKind};
+use crate::carrier::{Carrier, CarrierChain, CarrierKind, RunningChain};
 use crate::chain::{Chain, ChainRequest, ChainSettings};
 use crate::http_bridge::{self, HttpBridge};
 use crate::lan_share::{LanDoor, LanSettings, LanStatus};
@@ -36,13 +36,15 @@ const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 #[serde(default, rename_all = "camelCase")]
 pub struct CoreProfile {
     pub name: String,
-    /// Which way out of the network to use.
+    /// Which way out of the network to use, and in what order.
     ///
     /// Everything below it describes the Aether engine and applies only when
-    /// this is `Aether`. A profile saved before carriers existed names none,
-    /// which reads as `Aether` -- see [`CarrierKind`].
+    /// the chain ends there. A profile saved before carriers existed names
+    /// none, which reads as Aether alone; one saved by 1.8.x carries a bare
+    /// `carrier` string, which [`migrate_carrier_chain`] turns into a
+    /// single-hop chain. See [`CarrierChain`].
     #[serde(default)]
-    pub carrier: CarrierKind,
+    pub carriers: CarrierChain,
     pub protocol: String,
     pub masque_transport: String,
     pub scan_mode: String,
@@ -162,7 +164,7 @@ impl Default for CoreProfile {
     fn default() -> Self {
         Self {
             name: "Adaptive · Iran".into(),
-            carrier: CarrierKind::Aether,
+            carriers: CarrierChain::default(),
             protocol: "masque".into(),
             masque_transport: "h2".into(),
             scan_mode: "balanced".into(),
@@ -736,7 +738,7 @@ fn start_core_blocking(
     // is no gateway to hunt, no transport to alternate, and nothing to read out
     // of log prose. The session above is still claimed first, so a stop and a
     // second connect behave the same way whichever carrier is running.
-    if profile.carrier != CarrierKind::Aether {
+    if !profile.carriers.is_lone_aether() {
         return match start_carrier_blocking(app, inner, &profile, generation) {
             Ok(snapshot) => Ok(snapshot),
             Err(error) => {
@@ -781,8 +783,8 @@ fn start_carrier_blocking(
         let mut snapshot = lock(&inner.snapshot);
         *snapshot = CoreSnapshot {
             state: "connecting".into(),
-            transport: Some(profile.carrier.proxy_name().into()),
-            status_message: Some(format!("Starting {}", profile.carrier.label())),
+            transport: Some(profile.carriers.last().proxy_name().into()),
+            status_message: Some(format!("Starting {}", profile.carriers.label())),
             started_at: Some(now_millis()),
             ..CoreSnapshot::default()
         };
@@ -791,13 +793,13 @@ fn start_carrier_blocking(
     supervisor_log(
         inner,
         "info",
-        format!("carrier {} is starting", profile.carrier.label()),
+        format!("carrier {} is starting", profile.carriers.label()),
     );
 
     // Each carrier brings itself up its own way and they share nothing but the
     // shape of the answer: a listener, and something to say about where traffic
     // is leaving from.
-    let (listener, leaving_from) = match profile.carrier {
+    let (listener, leaving_from) = match profile.carriers.last() {
         CarrierKind::Psiphon => {
             let psiphon = app.state::<crate::psiphon::Psiphon>();
             let listener = psiphon.start(app, &profile.psiphon)?;
@@ -847,7 +849,7 @@ fn start_carrier_blocking(
     let chain_listener = match chain.start(
         app,
         &ChainRequest {
-            carrier: Some(carrier),
+            carriers: Some(RunningChain::single(carrier)),
             settings: &profile.chain,
             bypass_iran_sites: profile.bypass_iran_sites,
             tun,
@@ -864,7 +866,7 @@ fn start_carrier_blocking(
             // report connected with nothing carrying anything.
             return Err(format!(
                 "{} is up but the routing engine did not start: {error}",
-                profile.carrier.label()
+                profile.carriers.label()
             ));
         }
     };
@@ -1303,7 +1305,7 @@ pub async fn set_full_tunnel(
     let address = chain.start(
         &app,
         &ChainRequest {
-            carrier: Some(carrier),
+            carriers: Some(RunningChain::single(carrier)),
             settings: &chain_settings,
             bypass_iran_sites,
             tun: enabled,
@@ -1376,7 +1378,7 @@ pub async fn set_chain(
         let address = chain.start(
             &app,
             &ChainRequest {
-                carrier,
+                carriers: carrier.map(RunningChain::single),
                 settings: &settings,
                 bypass_iran_sites,
                 tun,
@@ -1478,8 +1480,14 @@ fn set_psiphon_region_blocking(
     let Some(profile) = profile else {
         return Ok(lock(&inner.snapshot).clone());
     };
-    if profile.carrier == CarrierKind::Aether {
-        return Err("the exit country is a Psiphon setting; this connection is using Aether".into());
+    // Named after what is actually running rather than assuming Aether: a
+    // Tor-only connection reaches this too, and being told it is "using Aether"
+    // would send someone looking for a setting that is not the problem.
+    if !profile.carriers.contains(CarrierKind::Psiphon) {
+        return Err(format!(
+            "the exit country is a Psiphon setting, and this connection is using {}",
+            profile.carriers.label()
+        ));
     }
 
     let generation = inner.generation.load(Ordering::SeqCst);
@@ -1555,6 +1563,7 @@ fn load_profile_blocking(app: AppHandle) -> Result<CoreProfile, String> {
     let mut stored: serde_json::Value =
         serde_json::from_slice(&bytes).map_err(|error| format!("profile is invalid: {error}"))?;
     migrate_endpoint_mode(&mut stored);
+    migrate_carrier_chain(&mut stored);
     migrate_keepalive(&mut stored);
     let profile: CoreProfile =
         serde_json::from_value(stored).map_err(|error| format!("profile is invalid: {error}"))?;
@@ -1580,6 +1589,32 @@ fn migrate_keepalive(stored: &mut serde_json::Value) {
     if object.get("keepaliveSecs").and_then(serde_json::Value::as_u64) == Some(OLD_DEFAULT) {
         object.insert("keepaliveSecs".into(), serde_json::json!(25));
     }
+}
+
+/// Turns the single `carrier` that 1.8.x saved into a one-hop chain.
+///
+/// The field went from a bare string to an ordered pair, and a profile written
+/// by 1.8.0 or 1.8.1 carries `"carrier": "psiphon"`. Left alone it would be
+/// ignored and the chain would default to Aether -- moving someone off the
+/// carrier they chose, silently, at the next launch.
+///
+/// Only fills in what is absent: a profile that already has `carriers` is left
+/// exactly as it is, so this runs harmlessly forever rather than needing to
+/// know whether it has run before.
+fn migrate_carrier_chain(stored: &mut serde_json::Value) {
+    let Some(object) = stored.as_object_mut() else {
+        return;
+    };
+    if object.contains_key("carriers") {
+        return;
+    }
+    let Some(kind) = object.get("carrier").cloned() else {
+        return;
+    };
+    object.insert(
+        "carriers".into(),
+        serde_json::json!({ "first": kind, "second": serde_json::Value::Null }),
+    );
 }
 
 /// Keeps a profile saved before endpoint modes existed behaving as it did.
@@ -2306,7 +2341,7 @@ fn record_log(app: &AppHandle, inner: &SupervisorInner, stream: &str, message: S
             match chain.start(
                 app,
                 &ChainRequest {
-                    carrier,
+                    carriers: carrier.map(RunningChain::single),
                     settings: &chain_settings,
                     bypass_iran_sites,
                     tun: full_tunnel,
@@ -2430,7 +2465,7 @@ fn spawn_carrier_watch(app: &AppHandle, inner: &Arc<SupervisorInner>, generation
         let kind = {
             let session = lock(&inner.session);
             match session.as_ref() {
-                Some(session) => session.profile.carrier,
+                Some(session) => session.profile.carriers.last(),
                 None => return,
             }
         };
@@ -2531,7 +2566,7 @@ fn current_carrier(app: &AppHandle, inner: &SupervisorInner) -> Option<Carrier> 
     // nothing declares, which fails every node with no clue why.
     let kind = lock(&inner.session)
         .as_ref()
-        .map_or(CarrierKind::Aether, |session| session.profile.carrier);
+        .map_or(CarrierKind::Aether, |session| session.profile.carriers.last());
     match kind {
         CarrierKind::Psiphon => return app.state::<crate::psiphon::Psiphon>().carrier(),
         CarrierKind::Tor => return app.state::<crate::tor::Tor>().carrier(),
@@ -3722,12 +3757,37 @@ mod tests {
 
     #[test]
     fn a_profile_saved_before_carriers_reads_as_aether() {
-        // Every profile on disk predates the field. Reading a missing carrier
-        // as anything else would move existing users onto a way out of the
-        // network they never chose, silently, at the next launch.
+        // Reading a missing carrier as anything else would move existing users
+        // onto a way out of the network they never chose, silently, at the next
+        // launch.
         let stored = serde_json::json!({ "name": "Adaptive · Iran" });
         let profile: CoreProfile = serde_json::from_value(stored).unwrap();
-        assert_eq!(profile.carrier, CarrierKind::Aether);
+        assert!(profile.carriers.is_lone_aether());
+    }
+
+    #[test]
+    fn a_profile_saved_by_1_8_keeps_the_carrier_it_chose() {
+        // 1.8.0 and 1.8.1 saved a bare string. The field is an ordered pair
+        // now, and left alone the old key would be ignored -- moving someone
+        // off Psiphon and back to Aether without saying so.
+        let mut stored = serde_json::json!({ "name": "x", "carrier": "psiphon" });
+        migrate_carrier_chain(&mut stored);
+        let profile: CoreProfile = serde_json::from_value(stored).unwrap();
+        assert_eq!(profile.carriers.first, CarrierKind::Psiphon);
+        assert_eq!(profile.carriers.second, None);
+        assert!(!profile.carriers.is_chained());
+
+        // A profile that already carries a chain is left exactly as it is, so
+        // the migration is safe to run on every load rather than needing to
+        // know whether it has run before.
+        let mut chained = serde_json::json!({
+            "carrier": "aether",
+            "carriers": { "first": "aether", "second": "tor" },
+        });
+        migrate_carrier_chain(&mut chained);
+        let profile: CoreProfile = serde_json::from_value(chained).unwrap();
+        assert_eq!(profile.carriers.second, Some(CarrierKind::Tor));
+        assert_eq!(profile.carriers.label(), "Aether → Tor");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,12 +131,14 @@ async fn fetch_bridges(
 /// Every node the chain knows about, with the delay each last recorded.
 #[tauri::command]
 async fn chain_nodes(
+    app: AppHandle,
     chain: tauri::State<'_, Chain>,
     supervisor: tauri::State<'_, CoreSupervisor>,
 ) -> Result<Vec<chain::ChainNode>, String> {
-    // Which transport came up decides whether a QUIC node behind the tunnel can
-    // work at all, and only the supervisor knows that.
-    chain.nodes(supervisor.carries_quic())
+    // Whether a QUIC node behind the tunnel can work at all is a property of
+    // the whole chain, not of one transport: one hop that refuses datagrams
+    // settles it for every hop behind it.
+    chain.nodes(supervisor.carries_quic(&app))
 }
 
 /// Measures one node through the tunnel.

--- a/src-tauri/src/psiphon.rs
+++ b/src-tauri/src/psiphon.rs
@@ -260,7 +260,12 @@ impl Psiphon {
     /// reason there is not. The caller is about to point an interface at this:
     /// a listener with no tunnel behind it swallows packets instead of refusing
     /// them, which is worse for the person using it than an honest failure.
-    pub fn start(&self, app: &AppHandle, settings: &PsiphonSettings) -> Result<SocketAddr, String> {
+    pub fn start(
+        &self,
+        app: &AppHandle,
+        settings: &PsiphonSettings,
+        upstream: Option<SocketAddr>,
+    ) -> Result<SocketAddr, String> {
         settings.validate()?;
         self.stop();
 
@@ -278,7 +283,7 @@ impl Psiphon {
             .map_err(|error| format!("cannot prepare the Psiphon directory: {error}"))?;
 
         let config_path = home.join("config.json");
-        std::fs::write(&config_path, render_config(settings, &home))
+        std::fs::write(&config_path, render_config(settings, &home, upstream))
             .map_err(|error| format!("cannot write the Psiphon config: {error}"))?;
 
         {
@@ -568,8 +573,12 @@ fn apply_notice_to_snapshot(snapshot: &mut PsiphonSnapshot, notice: &Notice) -> 
 /// tunnel-core has dozens more whose defaults are chosen against live censored
 /// networks by people who measure them, which is not something to second-guess
 /// from here.
-fn render_config(settings: &PsiphonSettings, home: &Path) -> String {
-    serde_json::json!({
+fn render_config(
+    settings: &PsiphonSettings,
+    home: &Path,
+    upstream: Option<SocketAddr>,
+) -> String {
+    let mut config = serde_json::json!({
         "PropagationChannelId": PROPAGATION_CHANNEL_ID,
         "SponsorId": SPONSOR_ID,
         // Our own version, as a string, which is what tunnel-core's sample says
@@ -592,8 +601,25 @@ fn render_config(settings: &PsiphonSettings, home: &Path) -> String {
         // machine unless the user sends a report.
         "EmitDiagnosticNotices": true,
         "EmitDiagnosticNetworkParameters": false,
-    })
-    .to_string()
+        // The hop in front, when there is one. Measured honouring this: with a
+        // proxy under our own control in front, 15 of tunnel-core's own
+        // connections arrived there and the tunnel established through it.
+        //
+        // Measured refusing to go round it, too. Pointed at a proxy that
+        // refused every connection it made 1340 attempts and never once
+        // connected directly, which is what makes a chain worth trusting: a
+        // first hop that drops does not leak the second.
+        //
+    });
+
+    // Inserted only when there is one, rather than sent as null: tunnel-core
+    // declares this `omitempty`, and a config that always carries the key --
+    // even empty -- is a config that says something about a proxy in the case
+    // where there is none.
+    if let Some(address) = upstream {
+        config["UpstreamProxyURL"] = serde_json::json!(format!("socks5://{address}"));
+    }
+    config.to_string()
 }
 
 fn locate(app: &AppHandle) -> Result<PathBuf, String> {
@@ -764,6 +790,7 @@ mod tests {
         let rendered = render_config(
             &PsiphonSettings { egress_region: "JP".into() },
             Path::new("/tmp/psiphon"),
+            None,
         );
         let config: serde_json::Value = serde_json::from_str(&rendered).unwrap();
         // Zero is "pick one and tell me". A fixed port is one more thing that
@@ -781,11 +808,32 @@ mod tests {
     }
 
     #[test]
+    fn a_hop_in_front_is_named_and_its_absence_is_silence() {
+        // Measured honouring this: with a proxy under our own control in front,
+        // 15 of tunnel-core's own connections arrived there and the tunnel
+        // established through it.
+        let chained = render_config(
+            &PsiphonSettings::default(),
+            Path::new("/tmp/psiphon"),
+            Some("127.0.0.1:1819".parse().unwrap()),
+        );
+        let config: serde_json::Value = serde_json::from_str(&chained).unwrap();
+        assert_eq!(config["UpstreamProxyURL"], "socks5://127.0.0.1:1819");
+
+        // Absent, not null and not empty. tunnel-core declares the field
+        // `omitempty`, and a config that always carries the key says something
+        // about a proxy in the case where there is none.
+        let alone = render_config(&PsiphonSettings::default(), Path::new("/tmp/psiphon"), None);
+        let config: serde_json::Value = serde_json::from_str(&alone).unwrap();
+        assert!(config.get("UpstreamProxyURL").is_none(), "{alone}");
+    }
+
+    #[test]
     fn no_exit_country_is_sent_as_empty_rather_than_omitted() {
         // tunnel-core reads a missing EgressRegion and an empty one the same
         // way, but writing it explicitly keeps the config self-describing for
         // anyone reading it out of the data directory during a support call.
-        let rendered = render_config(&PsiphonSettings::default(), Path::new("/tmp/psiphon"));
+        let rendered = render_config(&PsiphonSettings::default(), Path::new("/tmp/psiphon"), None);
         let config: serde_json::Value = serde_json::from_str(&rendered).unwrap();
         assert_eq!(config["EgressRegion"], "");
     }

--- a/src-tauri/src/tor.rs
+++ b/src-tauri/src/tor.rs
@@ -238,7 +238,12 @@ impl Tor {
     }
 
     /// Starts tor and waits for a circuit.
-    pub fn start(&self, app: &AppHandle, settings: &TorSettings) -> Result<SocketAddr, String> {
+    pub fn start(
+        &self,
+        app: &AppHandle,
+        settings: &TorSettings,
+        upstream: Option<SocketAddr>,
+    ) -> Result<SocketAddr, String> {
         settings.validate()?;
         self.stop();
 
@@ -271,7 +276,7 @@ impl Tor {
         let torrc = home.join("torrc");
         std::fs::write(
             &torrc,
-            render_torrc(settings, &home, &support, &control_port_file, &cookie_file)?,
+            render_torrc(settings, &home, &support, &control_port_file, &cookie_file, upstream)?,
         )
         .map_err(|error| format!("cannot write the Tor configuration: {error}"))?;
 
@@ -521,6 +526,7 @@ fn render_torrc(
     support: &Path,
     control_port_file: &Path,
     cookie_file: &Path,
+    upstream: Option<SocketAddr>,
 ) -> Result<String, String> {
     let mut config = String::new();
     // Both auto: a fixed port is one more thing that can already be taken on a
@@ -544,6 +550,16 @@ fn render_torrc(
     config.push_str("__OwningControllerProcess ");
     config.push_str(&std::process::id().to_string());
     config.push('\n');
+
+    // The hop in front, when there is one. Measured honouring this: with a
+    // proxy under our own control in front, tor's guard connections arrived
+    // there and it bootstrapped through them.
+    //
+    // Not quoted, and not a URL: unlike the paths above, tor takes this as a
+    // bare `host:port`.
+    if let Some(address) = upstream {
+        config.push_str(&format!("Socks5Proxy {address}\n"));
+    }
 
     if settings.bridges != BridgeMode::None {
         let lyrebird = support.join(LYREBIRD_FILENAME);
@@ -906,6 +922,7 @@ mod tests {
             &support,
             Path::new("/tmp/tor/control-port"),
             Path::new("/tmp/tor/cookie"),
+            None,
         )
         .unwrap();
 
@@ -925,6 +942,37 @@ mod tests {
     }
 
     #[test]
+    fn a_hop_in_front_becomes_a_socks5_proxy_line() {
+        // Measured honouring this: tor's guard connections arrived at a proxy
+        // under our own control and it bootstrapped through them.
+        //
+        // A bare host:port, and unquoted -- unlike every path in this file. tor
+        // takes this one as an address rather than as a filename or a URL.
+        let chained = render_torrc(
+            &TorSettings::default(),
+            Path::new("/tmp/tor"),
+            Path::new("/tmp/support"),
+            Path::new("/tmp/tor/control-port"),
+            Path::new("/tmp/tor/cookie"),
+            Some("127.0.0.1:64347".parse().unwrap()),
+        )
+        .unwrap();
+        assert!(chained.contains("\nSocks5Proxy 127.0.0.1:64347\n"), "{chained}");
+        assert!(!chained.contains("Socks5Proxy \""), "not a quoted path: {chained}");
+
+        let alone = render_torrc(
+            &TorSettings::default(),
+            Path::new("/tmp/tor"),
+            Path::new("/tmp/support"),
+            Path::new("/tmp/tor/control-port"),
+            Path::new("/tmp/tor/cookie"),
+            None,
+        )
+        .unwrap();
+        assert!(!alone.contains("Socks5Proxy"), "{alone}");
+    }
+
+    #[test]
     fn no_bridges_means_no_transport_plugin_line() {
         // A ClientTransportPlugin naming a binary we did not ship would stop
         // tor from starting at all, so it appears only when bridges do.
@@ -936,6 +984,7 @@ mod tests {
             support,
             Path::new("/tmp/tor/control-port"),
             Path::new("/tmp/tor/cookie"),
+            None,
         )
         .unwrap();
         assert!(!config.contains("ClientTransportPlugin"), "{config}");

--- a/src-tauri/src/tor.rs
+++ b/src-tauri/src/tor.rs
@@ -561,7 +561,20 @@ fn render_torrc(
         config.push_str(&format!("Socks5Proxy {address}\n"));
     }
 
-    if settings.bridges != BridgeMode::None {
+    // Bridges exist to reach tor where tor itself is blocked. Behind another
+    // carrier that question is already answered -- the hop in front is what got
+    // us out -- so a chained tor takes the direct relays and leaves the
+    // transports alone.
+    //
+    // This is also the one combination `CARRIER-CHAINING.md` forbids shipping
+    // on the strength of a config check (finding 7): tor accepts `Socks5Proxy`
+    // and `ClientTransportPlugin` together, but whether lyrebird then dials its
+    // bridge *through* that proxy was never observed, and a pluggable transport
+    // that ignores it would reach for the bridge directly -- the one address on
+    // a censored network that must not be dialled in the clear. Not shipped
+    // unproven, and not refused either: dropped, because it has nothing to do.
+    let bridges_wanted = settings.bridges != BridgeMode::None && upstream.is_none();
+    if bridges_wanted {
         let lyrebird = support.join(LYREBIRD_FILENAME);
         if !lyrebird.is_file() {
             return Err("the pluggable transports are missing from this installation".into());
@@ -939,6 +952,36 @@ mod tests {
         assert!(config.contains("CookieAuthFile \""), "{config}");
 
         let _ = std::fs::remove_dir_all(&support);
+    }
+
+    #[test]
+    fn a_chained_tor_takes_the_direct_relays_and_no_transports() {
+        // The one combination `CARRIER-CHAINING.md` forbids shipping on a
+        // config check alone (finding 7). Bridges exist to reach tor where tor
+        // is blocked; behind another carrier the hop in front already answered
+        // that, so there is nothing for a transport to do -- and whether
+        // lyrebird would dial its bridge *through* the proxy or reach for it
+        // directly was never observed. Dropped rather than risked: reaching for
+        // a bridge address in the clear is the one thing this must not do.
+        //
+        // No lyrebird is staged in this test, so a chained tor that still
+        // wanted bridges would fail outright here rather than render.
+        let chained = render_torrc(
+            &TorSettings { bridges: BridgeMode::BuiltIn, ..TorSettings::default() },
+            Path::new("/tmp/tor"),
+            Path::new("/tmp/support-absent"),
+            Path::new("/tmp/tor/control-port"),
+            Path::new("/tmp/tor/cookie"),
+            Some("127.0.0.1:64347".parse().unwrap()),
+        )
+        .expect("a chained tor renders without needing the transports");
+        assert!(chained.contains("
+Socks5Proxy 127.0.0.1:64347
+"), "{chained}");
+        assert!(!chained.contains("UseBridges"), "{chained}");
+        assert!(!chained.contains("ClientTransportPlugin"), "{chained}");
+        assert!(!chained.contains("
+Bridge "), "{chained}");
     }
 
     #[test]

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -297,8 +297,33 @@ const FA: Record<string, string> = {
   // asks the question the screen actually answers instead of naming a concept
   // the user has no reason to hold.
   "Way out": "راه خروج",
-  "What carries your traffic off this network. Everything below applies to Aether only.":
-    "چه چیزی ترافیک شما را از این شبکه بیرون می‌برد. هر چه پایین‌تر است فقط به Aether مربوط می‌شود.",
+  "What carries your traffic off this network. Add a second hop to change where it comes out.":
+    "چه چیزی ترافیک شما را از این شبکه بیرون می‌برد. برای عوض کردن محل خروج، یک پرش دوم اضافه کنید.",
+  // The two pickers are one sentence broken in half, so the halves have to
+  // read as a sentence in Persian too rather than as two labels.
+  "Leaves this network through": "خروج از این شبکه با",
+  "Then out through": "و سپس خروج از",
+  "Nothing further": "هیچ‌چیز دیگر",
+  "One hop. Traffic comes out wherever the carrier above puts it.":
+    "یک پرش. ترافیک همان‌جایی بیرون می‌آید که کریر بالا می‌گذارد.",
+  // Reached through AS_EXIT and EXIT_NOTE rather than as literals, so the
+  // check that scans for literal t() arguments cannot see them. Translated
+  // here on purpose: without these lines the whole panel falls back to English.
+  "Needs an Aether identity already on this machine — it cannot register a new one through another carrier.":
+    "به یک شناسهٔ Aether که از قبل روی این دستگاه باشد نیاز دارد — نمی‌تواند از راه کریر دیگری شناسهٔ تازه ثبت کند.",
+  "Can be pinned to a country below. Slower to connect.":
+    "می‌توان کشورش را پایین ثابت کرد. کندتر وصل می‌شود.",
+  "A Tor exit relay, in a country nobody here chooses. No UDP.":
+    "یک بازپخش خروجی تور، در کشوری که هیچ‌کس اینجا انتخابش نمی‌کند. UDP ندارد.",
+  "Comes out on Cloudflare's network, close to you. This does not change your country.":
+    "روی شبکهٔ کلادفلر، نزدیک خودتان بیرون می‌آید. این کشور شما را عوض نمی‌کند.",
+  "Comes out wherever Psiphon has capacity, and can be pinned to a country below.":
+    "هرجا که سایفون ظرفیت داشته باشد بیرون می‌آید، و می‌توان کشورش را پایین ثابت کرد.",
+  "Comes out at a Tor exit relay.": "در یک بازپخش خروجی تور بیرون می‌آید.",
+  "Aether cannot register a new device through another carrier, so this ordering only works if Aether has connected on this machine before. It also comes out near you rather than abroad.":
+    "Aether نمی‌تواند از راه کریر دیگری دستگاه تازه ثبت کند؛ پس این ترتیب فقط وقتی کار می‌کند که Aether پیش‌تر روی این دستگاه وصل شده باشد. خروجش هم نزدیک خودتان است، نه خارج.",
+  "No UDP through this chain: QUIC and plain DNS are refused rather than left to hang. Pages still load and names still resolve.":
+    "این زنجیره UDP را عبور نمی‌دهد: QUIC و DNS ساده رد می‌شوند تا معلق نمانند. صفحه‌ها باز می‌شوند و نام‌ها هم ترجمه می‌شوند.",
   "Cloudflare's network. Fast, and exits near you — it does not change your country.":
     "شبکهٔ کلادفلر. سریع است و نزدیک خودتان خارج می‌شود — کشور شما را عوض نمی‌کند.",
   "Psiphon": "سایفون",
@@ -325,6 +350,8 @@ const FA: Record<string, string> = {
   "Three relays. The strongest against being identified, and the slowest. No UDP.":
     "سه بازپخش. قوی‌ترین گزینه در برابر شناسایی، و کندترین. UDP ندارد.",
   "Bridges": "پل‌ها",
+  "Bridges are not used when Tor is the second hop: the carrier in front is what got out of this network, so Tor takes the direct relays.":
+    "وقتی تور هپ دوم است پل‌ها استفاده نمی‌شوند: کریر جلویی همان چیزی است که از این شبکه بیرون رفته، پس تور از بازپخش‌های مستقیم استفاده می‌کند.",
   "Only needed where Tor itself is blocked. Off is faster and works on an ordinary network.":
     "فقط جایی لازم است که خود تور مسدود باشد. خاموش سریع‌تر است و روی شبکهٔ معمولی کار می‌کند.",
   "Off": "خاموش",

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -349,6 +349,17 @@ const FA: Record<string, string> = {
   "Tor": "تور",
   "Three relays. The strongest against being identified, and the slowest. No UDP.":
     "سه بازپخش. قوی‌ترین گزینه در برابر شناسایی، و کندترین. UDP ندارد.",
+  // -- the search that tries every way out ------------------------------
+  "Find one that works": "یکی که کار می‌کند را پیدا کن",
+  "Stop searching": "توقف جستجو",
+  "Tries each way out in turn and keeps the first that carries traffic. Singles first, pairs only if none of them get out.":
+    "هر راه خروج را به‌ترتیب امتحان می‌کند و اولی که ترافیک حمل کند نگه می‌دارد. اول تک‌ها، و جفت‌ها فقط اگر هیچ‌کدام بیرون نرفت.",
+  "Each one gets up to 90 seconds. Stopping takes effect after the current attempt.":
+    "به هرکدام تا ۹۰ ثانیه فرصت داده می‌شود. توقف بعد از تلاش فعلی اعمال می‌شود.",
+  "carrying traffic": "در حال حمل ترافیک",
+  "Nothing got out. Every way out was tried; the list above says how each one failed.":
+    "هیچ‌چیز بیرون نرفت. همهٔ راه‌های خروج امتحان شد؛ فهرست بالا می‌گوید هرکدام چطور شکست خورد.",
+
   "Bridges": "پل‌ها",
   "Bridges are not used when Tor is the second hop: the carrier in front is what got out of this network, so Tor takes the direct relays.":
     "وقتی تور هپ دوم است پل‌ها استفاده نمی‌شوند: کریر جلویی همان چیزی است که از این شبکه بیرون رفته، پس تور از بازپخش‌های مستقیم استفاده می‌کند.",

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -350,6 +350,7 @@ const FA: Record<string, string> = {
   "Three relays. The strongest against being identified, and the slowest. No UDP.":
     "سه بازپخش. قوی‌ترین گزینه در برابر شناسایی، و کندترین. UDP ندارد.",
   // -- the search that tries every way out ------------------------------
+  "Not sure which one works?": "نمی‌دانید کدام کار می‌کند؟",
   "Find one that works": "یکی که کار می‌کند را پیدا کن",
   "Stop searching": "توقف جستجو",
   "Tries each way out in turn and keeps the first that carries traffic. Singles first, pairs only if none of them get out.":

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -640,7 +640,7 @@ function CarrierPanel({
     setSearchFailure(null);
     cancelled.current = false;
     const order = searchOrder(available);
-    setAttempts(order.map((candidate) => ({ chain: candidate, outcome: "skipped" })));
+    setAttempts(order.map((candidate) => ({ chain: candidate, outcome: "pending" })));
 
     // Whatever is up now is in the way: the supervisor refuses a second
     // connection while one is claimed.
@@ -851,12 +851,14 @@ function CarrierPanel({
             {attempts.map((entry) => {
               const name = carrierChainLabel(entry.chain, (kind) => t(CARRIER_NAME[kind]));
               const mark = {
+                pending: "·",
                 trying: "…",
                 connected: "✓",
                 failed: "✕",
                 skipped: "–",
               }[entry.outcome];
               const tone = {
+                pending: "text-muted-foreground/60",
                 trying: "text-foreground",
                 connected: "text-primary font-medium",
                 failed: "text-muted-foreground",

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -596,25 +596,20 @@ function BridgeFetch({ onFetched }: { onFetched: (lines: string[]) => void }) {
  * is empty until the first successful connect — the field says "best available"
  * until then instead of offering countries it cannot promise.
  */
-function CarrierPanel({
+/**
+ * The one action for someone who does not know which way out works.
+ *
+ * Its own card, and a filled button. As a `secondary` button tucked under the
+ * pickers it read as a caption beside them and was missed entirely -- which for
+ * the single control aimed at the person with no idea what to choose is the
+ * whole feature failing quietly.
+ */
+function WayOutSearch({
   profile,
   onChange,
-}: Pick<AdvancedProps, "profile" | "onChange">) {
+  available,
+}: Pick<AdvancedProps, "profile" | "onChange"> & { available: CarrierKind[] | null }) {
   const t = useT();
-  const set = (patch: Partial<ConnectionProfile>) => onChange({ ...profile, ...patch });
-  const [regions, setRegions] = useState<string[]>([]);
-  const [moving, setMoving] = useState(false);
-  const [failure, setFailure] = useState<string | null>(null);
-  // Everything until the backend answers. A picker that starts empty and fills
-  // in would flicker; one that starts full and removes a carrier is worse,
-  // because someone may have clicked it already.
-  const [available, setAvailable] = useState<CarrierKind[] | null>(null);
-
-  const chain = profile.carriers;
-  const offered = CARRIERS.filter((option) => !available || available.includes(option.id));
-  // Weakest link: a chain passes datagrams only if every hop does.
-  const carriesUdp = CARRIES_UDP[chain.first] && (chain.second === null || CARRIES_UDP[chain.second]);
-
   const [attempts, setAttempts] = useState<SearchAttempt[]>([]);
   const [searching, setSearching] = useState(false);
   // Its own state rather than the exit country's `failure`: sharing one would
@@ -673,7 +668,7 @@ function CarrierPanel({
         // Say what it settled on, and leave the profile holding it. Ending on
         // one ordering while the screen still shows another is the whole
         // failure this feature could introduce.
-        set({ carriers: candidate });
+        onChange({ ...profile, carriers: candidate });
         settled = true;
         break;
       }
@@ -695,6 +690,96 @@ function CarrierPanel({
     }
     setSearching(false);
   };
+  return (
+    <Card className="border-primary/40 bg-primary/[0.06]">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-[15px]">{t("Not sure which one works?")}</CardTitle>
+        <CardDescription>
+          {t("Tries each way out in turn and keeps the first that carries traffic. Singles first, pairs only if none of them get out.")}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3 pt-0">
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            variant={searching ? "outline" : "default"}
+            onClick={() => {
+              if (searching) {
+                cancelled.current = true;
+                void stopCore().catch(() => {});
+                return;
+              }
+              void search();
+            }}
+          >
+            {searching ? t("Stop searching") : t("Find one that works")}
+          </Button>
+          {searching ? (
+            <p className="text-[12.5px] leading-snug text-muted-foreground">
+              {t("Each one gets up to 90 seconds. Stopping takes effect after the current attempt.")}
+            </p>
+          ) : null}
+        </div>
+
+        {searchFailure ? (
+          <p className="text-[12.5px] leading-snug text-destructive">{searchFailure}</p>
+        ) : null}
+
+        {attempts.length > 0 ? (
+          <ul className="flex flex-col gap-1">
+            {attempts.map((entry) => {
+              const name = carrierChainLabel(entry.chain, (kind) => t(CARRIER_NAME[kind]));
+              const mark = {
+                pending: "·",
+                trying: "…",
+                connected: "✓",
+                failed: "✕",
+                skipped: "–",
+              }[entry.outcome];
+              const tone = {
+                pending: "text-muted-foreground/60",
+                trying: "text-foreground",
+                connected: "text-primary font-medium",
+                failed: "text-muted-foreground",
+                skipped: "text-muted-foreground/70",
+              }[entry.outcome];
+              return (
+                <li key={name} className={`text-[12.5px] leading-snug ${tone}`}>
+                  <span className="inline-block w-4">{mark}</span>
+                  {name}
+                  {entry.outcome === "connected" ? ` — ${t("carrying traffic")}` : null}
+                  {/* The backend's own words. A search that says "failed" and
+                      nothing else is a search nobody can act on. */}
+                  {entry.detail && entry.outcome !== "connected" ? (
+                    <span className="text-muted-foreground/70"> — {entry.detail}</span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function CarrierPanel({
+  profile,
+  onChange,
+}: Pick<AdvancedProps, "profile" | "onChange">) {
+  const t = useT();
+  const set = (patch: Partial<ConnectionProfile>) => onChange({ ...profile, ...patch });
+  const [regions, setRegions] = useState<string[]>([]);
+  const [moving, setMoving] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  // Everything until the backend answers. A picker that starts empty and fills
+  // in would flicker; one that starts full and removes a carrier is worse,
+  // because someone may have clicked it already.
+  const [available, setAvailable] = useState<CarrierKind[] | null>(null);
+
+  const chain = profile.carriers;
+  const offered = CARRIERS.filter((option) => !available || available.includes(option.id));
+  // Weakest link: a chain passes datagrams only if every hop does.
+  const carriesUdp = CARRIES_UDP[chain.first] && (chain.second === null || CARRIES_UDP[chain.second]);
 
   useEffect(() => {
     if (!isDesktopRuntime()) return;
@@ -746,7 +831,8 @@ function CarrierPanel({
   };
 
   return (
-    <Card>
+    <>
+      <Card>
       <CardHeader className="pb-3">
         <CardTitle className="text-[15px]">{t("Way out")}</CardTitle>
         <CardDescription>
@@ -817,69 +903,6 @@ function CarrierPanel({
           ) : null}
         </div>
 
-        {/* For the network where the answer is not knowable in advance. Tries
-            the cheap ways out first and the pairs only after every single has
-            failed -- see `carrierSearch.ts` for why that order. */}
-        <div className="mt-4 flex items-center gap-2.5">
-          <Button
-            variant={searching ? "outline" : "secondary"}
-            size="sm"
-            onClick={() => {
-              if (searching) {
-                cancelled.current = true;
-                void stopCore().catch(() => {});
-                return;
-              }
-              void search();
-            }}
-          >
-            {searching ? t("Stop searching") : t("Find one that works")}
-          </Button>
-          <p className="text-[12.5px] leading-snug text-muted-foreground">
-            {searching
-              ? t("Each one gets up to 90 seconds. Stopping takes effect after the current attempt.")
-              : t("Tries each way out in turn and keeps the first that carries traffic. Singles first, pairs only if none of them get out.")}
-          </p>
-        </div>
-
-        {searchFailure ? (
-          <p className="mt-2 text-[12.5px] leading-snug text-destructive">{searchFailure}</p>
-        ) : null}
-
-        {attempts.length > 0 ? (
-          <ul className="mt-3 flex flex-col gap-1">
-            {attempts.map((entry) => {
-              const name = carrierChainLabel(entry.chain, (kind) => t(CARRIER_NAME[kind]));
-              const mark = {
-                pending: "·",
-                trying: "…",
-                connected: "✓",
-                failed: "✕",
-                skipped: "–",
-              }[entry.outcome];
-              const tone = {
-                pending: "text-muted-foreground/60",
-                trying: "text-foreground",
-                connected: "text-primary font-medium",
-                failed: "text-muted-foreground",
-                skipped: "text-muted-foreground/70",
-              }[entry.outcome];
-              return (
-                <li key={name} className={`text-[12.5px] leading-snug ${tone}`}>
-                  <span className="inline-block w-4">{mark}</span>
-                  {name}
-                  {entry.outcome === "connected" ? ` — ${t("carrying traffic")}` : null}
-                  {/* The backend's own words. A search that says "failed" and
-                      nothing else is a search nobody can act on. */}
-                  {entry.detail && entry.outcome !== "connected" ? (
-                    <span className="text-muted-foreground/70"> — {entry.detail}</span>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        ) : null}
-
         {carrierChainHas(profile.carriers, "psiphon") ? (
           <>
             <Row title="Exit country" help="A preference, not a guarantee. Psiphon keeps trying rather than substituting, so a country with no capacity is a slow connect.">
@@ -934,7 +957,10 @@ function CarrierPanel({
           </>
         ) : null}
       </CardContent>
-    </Card>
+      </Card>
+
+      <WayOutSearch profile={profile} onChange={onChange} available={available} />
+    </>
   );
 }
 

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useT } from "@/core/useT";
 import {
   Activity, FileText, Globe, Link2, Route as RouteIcon, Scale, ShieldCheck, Wifi, type LucideIcon,
@@ -22,7 +22,12 @@ import {
   saveReport,
   setLanShare,
   setPsiphonRegion,
+  startCore,
+  stopCore,
 } from "@/core/api";
+import {
+  ATTEMPT_CAP_MS, isImpossible, searchOrder, type SearchAttempt,
+} from "./carrierSearch";
 import { NumberField, Row, RulesField, Seg, TextField } from "./panels";
 import { Chain } from "./Chain";
 import { Scanner } from "./Scanner";
@@ -610,6 +615,87 @@ function CarrierPanel({
   // Weakest link: a chain passes datagrams only if every hop does.
   const carriesUdp = CARRIES_UDP[chain.first] && (chain.second === null || CARRIES_UDP[chain.second]);
 
+  const [attempts, setAttempts] = useState<SearchAttempt[]>([]);
+  const [searching, setSearching] = useState(false);
+  // Its own state rather than the exit country's `failure`: sharing one would
+  // let a stale region error read as a search result, and the region error is
+  // only rendered where Psiphon is in the chain, so a search that found
+  // nothing would have had nowhere to say so.
+  const [searchFailure, setSearchFailure] = useState<string | null>(null);
+  // Read by the loop between attempts, so Stop takes effect on the next one
+  // rather than after all nine. Held in a ref because the running loop closes
+  // over its own render's state and would never see a change to it.
+  const cancelled = useRef(false);
+
+  /**
+   * Tries each way out in turn and keeps the first that carries traffic.
+   *
+   * Drives the same `start_core` the Connect button does rather than
+   * orchestrating hops itself. Two orchestrators would be two copies of the
+   * startup order, and a second copy of a rule is what put seven faults in the
+   * chain path at once.
+   */
+  const search = async () => {
+    setSearching(true);
+    setSearchFailure(null);
+    cancelled.current = false;
+    const order = searchOrder(available);
+    setAttempts(order.map((candidate) => ({ chain: candidate, outcome: "skipped" })));
+
+    // Whatever is up now is in the way: the supervisor refuses a second
+    // connection while one is claimed.
+    await stopCore().catch(() => {});
+
+    let settled = false;
+    for (const [index, candidate] of order.entries()) {
+      if (cancelled.current) break;
+      setAttempts((current) =>
+        current.map((entry, at) => (at === index ? { ...entry, outcome: "trying" } : entry)),
+      );
+
+      // The cap is enforced by stopping rather than by walking away: the
+      // supervisor checks between hops and unwinds, so a timed-out attempt
+      // leaves no process behind.
+      const timer = window.setTimeout(() => void stopCore().catch(() => {}), ATTEMPT_CAP_MS);
+      let failure: string | null = null;
+      try {
+        await startCore({ ...profile, carriers: candidate });
+      } catch (error) {
+        failure = error instanceof Error ? error.message : String(error);
+      } finally {
+        window.clearTimeout(timer);
+      }
+
+      if (!failure) {
+        setAttempts((current) =>
+          current.map((entry, at) => (at === index ? { ...entry, outcome: "connected" } : entry)),
+        );
+        // Say what it settled on, and leave the profile holding it. Ending on
+        // one ordering while the screen still shows another is the whole
+        // failure this feature could introduce.
+        set({ carriers: candidate });
+        settled = true;
+        break;
+      }
+
+      setAttempts((current) =>
+        current.map((entry, at) =>
+          at === index
+            ? { ...entry, outcome: isImpossible(failure) ? "skipped" : "failed", detail: failure }
+            : entry,
+        ),
+      );
+      await stopCore().catch(() => {});
+    }
+
+    if (!settled && !cancelled.current) {
+      setSearchFailure(
+        t("Nothing got out. Every way out was tried; the list above says how each one failed."),
+      );
+    }
+    setSearching(false);
+  };
+
   useEffect(() => {
     if (!isDesktopRuntime()) return;
     let cancelled = false;
@@ -730,6 +816,67 @@ function CarrierPanel({
             </div>
           ) : null}
         </div>
+
+        {/* For the network where the answer is not knowable in advance. Tries
+            the cheap ways out first and the pairs only after every single has
+            failed -- see `carrierSearch.ts` for why that order. */}
+        <div className="mt-4 flex items-center gap-2.5">
+          <Button
+            variant={searching ? "outline" : "secondary"}
+            size="sm"
+            onClick={() => {
+              if (searching) {
+                cancelled.current = true;
+                void stopCore().catch(() => {});
+                return;
+              }
+              void search();
+            }}
+          >
+            {searching ? t("Stop searching") : t("Find one that works")}
+          </Button>
+          <p className="text-[12.5px] leading-snug text-muted-foreground">
+            {searching
+              ? t("Each one gets up to 90 seconds. Stopping takes effect after the current attempt.")
+              : t("Tries each way out in turn and keeps the first that carries traffic. Singles first, pairs only if none of them get out.")}
+          </p>
+        </div>
+
+        {searchFailure ? (
+          <p className="mt-2 text-[12.5px] leading-snug text-destructive">{searchFailure}</p>
+        ) : null}
+
+        {attempts.length > 0 ? (
+          <ul className="mt-3 flex flex-col gap-1">
+            {attempts.map((entry) => {
+              const name = carrierChainLabel(entry.chain, (kind) => t(CARRIER_NAME[kind]));
+              const mark = {
+                trying: "…",
+                connected: "✓",
+                failed: "✕",
+                skipped: "–",
+              }[entry.outcome];
+              const tone = {
+                trying: "text-foreground",
+                connected: "text-primary font-medium",
+                failed: "text-muted-foreground",
+                skipped: "text-muted-foreground/70",
+              }[entry.outcome];
+              return (
+                <li key={name} className={`text-[12.5px] leading-snug ${tone}`}>
+                  <span className="inline-block w-4">{mark}</span>
+                  {name}
+                  {entry.outcome === "connected" ? ` — ${t("carrying traffic")}` : null}
+                  {/* The backend's own words. A search that says "failed" and
+                      nothing else is a search nobody can act on. */}
+                  {entry.detail && entry.outcome !== "connected" ? (
+                    <span className="text-muted-foreground/70"> — {entry.detail}</span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
 
         {carrierChainHas(profile.carriers, "psiphon") ? (
           <>

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -32,7 +32,7 @@ import { transportName } from "./Simple";
 // that. The same text is installed beside the executable under licences/.
 import notices from "../../THIRD_PARTY_NOTICES.md?raw";
 import {
-  ENDPOINT_MODES, carrierChainHas, isLoneAether, type CarrierKind,
+  ENDPOINT_MODES, carrierChainHas, carrierChainLabel, carrierChainLast, isLoneAether, type CarrierKind,
   type ConnectionProfile, type LanSettings, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
 } from "@/types";
 
@@ -372,6 +372,69 @@ const CARRIERS: Array<{ id: CarrierKind; label: string; detail: string }> = [
   },
 ];
 
+const CARRIER_NAME: Record<CarrierKind, string> = {
+  aether: "Aether",
+  psiphon: "Psiphon",
+  tor: "Tor",
+};
+
+/**
+ * What each carrier means in the second position, where it decides the exit.
+ *
+ * Different text from the first position on purpose: the same carrier answers a
+ * different question there, and Aether in particular carries a condition that
+ * only applies when it is second.
+ */
+const AS_EXIT: Record<CarrierKind, string> = {
+  aether: "Needs an Aether identity already on this machine — it cannot register a new one through another carrier.",
+  psiphon: "Can be pinned to a country below. Slower to connect.",
+  tor: "A Tor exit relay, in a country nobody here chooses. No UDP.",
+};
+
+/** Where the traffic comes out, given the hop that ends the chain. */
+const EXIT_NOTE: Record<CarrierKind, string> = {
+  aether: "Comes out on Cloudflare's network, close to you. This does not change your country.",
+  psiphon: "Comes out wherever Psiphon has capacity, and can be pinned to a country below.",
+  tor: "Comes out at a Tor exit relay.",
+};
+
+/**
+ * Whether a carrier passes datagrams.
+ *
+ * Measured rather than assumed — Psiphon answers a SOCKS5 UDP ASSOCIATE with
+ * "command not supported", which is why it reads false here despite having
+ * shipped as true once. A chain carries UDP only if every hop does.
+ */
+const CARRIES_UDP: Record<CarrierKind, boolean> = { aether: true, psiphon: false, tor: false };
+
+/** One choice in either hop picker. */
+function CarrierButton({
+  label,
+  detail,
+  on,
+  onClick,
+}: {
+  label: string;
+  detail: string;
+  on: boolean;
+  onClick: () => void;
+}) {
+  const t = useT();
+  return (
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={onClick}
+      className={`rounded-lg border p-3 text-left transition ${
+        on ? "border-primary bg-primary/5" : "border-border hover:border-primary/40"
+      }`}
+    >
+      <div className="text-[13.5px] font-medium">{t(label)}</div>
+      <div className="mt-1 text-[12.5px] leading-snug text-muted-foreground">{t(detail)}</div>
+    </button>
+  );
+}
+
 /**
  * Where Tor's bridges come from.
  *
@@ -395,8 +458,21 @@ function TorPanel({
   profile,
   onChange,
 }: Pick<AdvancedProps, "profile" | "onChange">) {
+  const t = useT();
   const set = (patch: Partial<ConnectionProfile["tor"]>) =>
     onChange({ ...profile, tor: { ...profile.tor, ...patch } });
+
+  // Bridges reach Tor where Tor is blocked. As the second hop that question is
+  // already answered by the carrier in front, so the backend renders a torrc
+  // with no transports at all -- and controls that quietly do nothing are worse
+  // than controls that are not there.
+  if (profile.carriers.second === "tor") {
+    return (
+      <p className="pt-2 text-[12.5px] leading-snug text-muted-foreground">
+        {t("Bridges are not used when Tor is the second hop: the carrier in front is what got out of this network, so Tor takes the direct relays.")}
+      </p>
+    );
+  }
 
   return (
     <>
@@ -529,6 +605,11 @@ function CarrierPanel({
   // because someone may have clicked it already.
   const [available, setAvailable] = useState<CarrierKind[] | null>(null);
 
+  const chain = profile.carriers;
+  const offered = CARRIERS.filter((option) => !available || available.includes(option.id));
+  // Weakest link: a chain passes datagrams only if every hop does.
+  const carriesUdp = CARRIES_UDP[chain.first] && (chain.second === null || CARRIES_UDP[chain.second]);
+
   useEffect(() => {
     if (!isDesktopRuntime()) return;
     let cancelled = false;
@@ -583,30 +664,71 @@ function CarrierPanel({
       <CardHeader className="pb-3">
         <CardTitle className="text-[15px]">{t("Way out")}</CardTitle>
         <CardDescription>
-          {t("What carries your traffic off this network. Everything below applies to Aether only.")}
+          {t("What carries your traffic off this network. Add a second hop to change where it comes out.")}
         </CardDescription>
       </CardHeader>
       <CardContent className="pt-0">
+        <p className="pb-2 text-[12.5px] font-medium">{t("Leaves this network through")}</p>
         <div className="grid grid-cols-2 gap-2.5">
-          {CARRIERS.filter((option) => !available || available.includes(option.id)).map((option) => {
-            const on = profile.carriers.first === option.id;
-            return (
-              <button
+          {offered.map((option) => (
+            <CarrierButton
+              key={option.id}
+              label={option.label}
+              detail={option.detail}
+              on={chain.first === option.id}
+              // Keep the second hop across a change of the first unless that
+              // would chain a carrier to itself, which reaches the same
+              // network through itself for twice the delay.
+              onClick={() =>
+                set({
+                  carriers: { first: option.id, second: chain.second === option.id ? null : chain.second },
+                })
+              }
+            />
+          ))}
+        </div>
+
+        <p className="pb-2 pt-4 text-[12.5px] font-medium">{t("Then out through")}</p>
+        <div className="grid grid-cols-2 gap-2.5">
+          <CarrierButton
+            label="Nothing further"
+            detail="One hop. Traffic comes out wherever the carrier above puts it."
+            on={chain.second === null}
+            onClick={() => set({ carriers: { first: chain.first, second: null } })}
+          />
+          {offered
+            .filter((option) => option.id !== chain.first)
+            .map((option) => (
+              <CarrierButton
                 key={option.id}
-                type="button"
-                aria-pressed={on}
-                onClick={() => set({ carriers: { first: option.id, second: null } })}
-                className={`rounded-lg border p-3 text-left transition ${
-                  on ? "border-primary bg-primary/5" : "border-border hover:border-primary/40"
-                }`}
-              >
-                <div className="text-[13.5px] font-medium">{t(option.label)}</div>
-                <div className="mt-1 text-[12.5px] leading-snug text-muted-foreground">
-                  {t(option.detail)}
-                </div>
-              </button>
-            );
-          })}
+                label={option.label}
+                detail={AS_EXIT[option.id]}
+                on={chain.second === option.id}
+                onClick={() => set({ carriers: { first: chain.first, second: option.id } })}
+              />
+            ))}
+        </div>
+
+        {/* The chain said back, in the order traffic travels, with what this
+            particular ordering does and does not get you. Two orderings look
+            alike in the pickers and differ entirely here. */}
+        <div className="mt-4 rounded-lg border border-border bg-muted/40 p-3">
+          <div className="text-[13.5px] font-medium">
+            {carrierChainLabel(chain, (kind) => t(CARRIER_NAME[kind]))}
+          </div>
+          <div className="mt-1 text-[12.5px] leading-snug text-muted-foreground">
+            {t(EXIT_NOTE[carrierChainLast(chain)])}
+          </div>
+          {chain.second === "aether" ? (
+            <div className="mt-1.5 text-[12.5px] leading-snug text-amber-600 dark:text-amber-500">
+              {t("Aether cannot register a new device through another carrier, so this ordering only works if Aether has connected on this machine before. It also comes out near you rather than abroad.")}
+            </div>
+          ) : null}
+          {chain.second && !carriesUdp ? (
+            <div className="mt-1.5 text-[12.5px] leading-snug text-muted-foreground">
+              {t("No UDP through this chain: QUIC and plain DNS are refused rather than left to hang. Pages still load and names still resolve.")}
+            </div>
+          ) : null}
         </div>
 
         {carrierChainHas(profile.carriers, "psiphon") ? (

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -32,7 +32,8 @@ import { transportName } from "./Simple";
 // that. The same text is installed beside the executable under licences/.
 import notices from "../../THIRD_PARTY_NOTICES.md?raw";
 import {
-  ENDPOINT_MODES, type ConnectionProfile, type LanSettings, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
+  ENDPOINT_MODES, carrierChainHas, isLoneAether, type CarrierKind,
+  type ConnectionProfile, type LanSettings, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
 } from "@/types";
 
 type SectionId =
@@ -103,7 +104,7 @@ const AETHER_ONLY_SECTIONS: SectionId[] = ["endpoint"];
 export function Advanced(props: AdvancedProps) {
   const t = useT();
   const [section, setSection] = useState<SectionId>("status");
-  const aetherOnly = props.profile.carrier === "aether";
+  const aetherOnly = isLoneAether(props.profile.carriers);
 
   // Someone who was reading Endpoint and then switched carrier would otherwise
   // be left looking at a section that is no longer in the list.
@@ -353,7 +354,7 @@ const PROTOCOLS: Array<{ id: string; label: string; detail: string; protocol: Co
  * Tor is deliberately absent until it exists: an option that saves and does
  * nothing is worse than one that is not offered.
  */
-const CARRIERS: Array<{ id: ConnectionProfile["carrier"]; label: string; detail: string }> = [
+const CARRIERS: Array<{ id: CarrierKind; label: string; detail: string }> = [
   {
     id: "aether",
     label: "Aether",
@@ -526,7 +527,7 @@ function CarrierPanel({
   // Everything until the backend answers. A picker that starts empty and fills
   // in would flicker; one that starts full and removes a carrier is worse,
   // because someone may have clicked it already.
-  const [available, setAvailable] = useState<ConnectionProfile["carrier"][] | null>(null);
+  const [available, setAvailable] = useState<CarrierKind[] | null>(null);
 
   useEffect(() => {
     if (!isDesktopRuntime()) return;
@@ -542,7 +543,7 @@ function CarrierPanel({
   }, []);
 
   useEffect(() => {
-    if (profile.carrier !== "psiphon" || !isDesktopRuntime()) return;
+    if (!carrierChainHas(profile.carriers, "psiphon") || !isDesktopRuntime()) return;
     let cancelled = false;
     const read = () =>
       psiphonStatus()
@@ -559,7 +560,7 @@ function CarrierPanel({
       cancelled = true;
       window.clearInterval(timer);
     };
-  }, [profile.carrier]);
+  }, [profile.carriers.first, profile.carriers.second]);
 
   const chooseRegion = async (region: string) => {
     set({ psiphon: { ...profile.psiphon, egressRegion: region } });
@@ -588,13 +589,13 @@ function CarrierPanel({
       <CardContent className="pt-0">
         <div className="grid grid-cols-2 gap-2.5">
           {CARRIERS.filter((option) => !available || available.includes(option.id)).map((option) => {
-            const on = profile.carrier === option.id;
+            const on = profile.carriers.first === option.id;
             return (
               <button
                 key={option.id}
                 type="button"
                 aria-pressed={on}
-                onClick={() => set({ carrier: option.id })}
+                onClick={() => set({ carriers: { first: option.id, second: null } })}
                 className={`rounded-lg border p-3 text-left transition ${
                   on ? "border-primary bg-primary/5" : "border-border hover:border-primary/40"
                 }`}
@@ -608,7 +609,7 @@ function CarrierPanel({
           })}
         </div>
 
-        {profile.carrier === "psiphon" ? (
+        {carrierChainHas(profile.carriers, "psiphon") ? (
           <>
             <Row title="Exit country" help="A preference, not a guarantee. Psiphon keeps trying rather than substituting, so a country with no capacity is a slow connect.">
               <select
@@ -646,7 +647,7 @@ function CarrierPanel({
           </>
         ) : null}
 
-        {profile.carrier === "tor" ? (
+        {carrierChainHas(profile.carriers, "tor") ? (
           <>
             <TorPanel profile={profile} onChange={onChange} />
             {/* Said plainly rather than left to be met as a fault. Tor carries
@@ -683,7 +684,7 @@ function Routes({ profile, onChange }: AdvancedProps) {
   // work with Psiphon?" — with MASQUE H2 still highlighted as though it were
   // the answer. A control that saves and does nothing is worse than one that is
   // absent, so they are absent.
-  const aetherOnly = profile.carrier === "aether";
+  const aetherOnly = isLoneAether(profile.carriers);
 
   return (
     <>

--- a/src/features/carrierSearch.test.ts
+++ b/src/features/carrierSearch.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isImpossible, searchOrder } from "./carrierSearch.ts";
+import { carrierChainLabel, type CarrierKind } from "../types.ts";
+
+const label = (chain: { first: CarrierKind; second: CarrierKind | null }) =>
+  carrierChainLabel(chain, (kind) => kind);
+
+test("every single is tried before any chain", () => {
+  // Nine attempts at up to ninety seconds is a quarter of an hour, so the
+  // cheap answer has to come first. Chains exist for the network where no
+  // single answers at all.
+  const order = searchOrder(null);
+  const firstChain = order.findIndex((chain) => chain.second !== null);
+  const lastSingle = order.reduce((last, chain, index) => (chain.second === null ? index : last), -1);
+  assert.ok(firstChain > lastSingle, order.map(label).join(" | "));
+});
+
+test("the singles come in measured order of how long they take", () => {
+  const singles = searchOrder(null).filter((chain) => chain.second === null);
+  assert.deepEqual(singles.map(label), ["aether", "psiphon", "tor"]);
+});
+
+test("all six orderings are offered, and none is a carrier chained to itself", () => {
+  const pairs = searchOrder(null).filter((chain) => chain.second !== null);
+  assert.equal(pairs.length, 6, pairs.map(label).join(" | "));
+  assert.equal(new Set(pairs.map(label)).size, 6, "no ordering is offered twice");
+  for (const chain of pairs) {
+    assert.notEqual(chain.first, chain.second, label(chain));
+  }
+});
+
+test("a carrier that is not installed is left out of both halves", () => {
+  // Attempting it would spend an attempt on a certainty.
+  const order = searchOrder(["aether", "psiphon"]);
+  assert.ok(
+    order.every((chain) => chain.first !== "tor" && chain.second !== "tor"),
+    order.map(label).join(" | "),
+  );
+  // And what is left is still complete: two singles and both of their pairings.
+  assert.deepEqual(order.map(label), ["aether", "psiphon", "aether → psiphon", "psiphon → aether"]);
+});
+
+test("one carrier on its own leaves exactly one attempt", () => {
+  assert.deepEqual(searchOrder(["tor"]).map(label), ["tor"]);
+});
+
+test("nothing installed is an empty sweep rather than a wasted one", () => {
+  assert.deepEqual(searchOrder([]), []);
+});
+
+test("the refusals that mean never are told apart from the ones that mean not now", () => {
+  // The backend owns these rules; the search reads its words rather than
+  // keeping a second copy that could drift from the one being enforced.
+  assert.ok(
+    isImpossible(
+      "Aether has not registered a device yet, and it cannot register from inside another carrier.",
+    ),
+  );
+  assert.ok(
+    isImpossible("this profile already dials through a proxy of your own, so Aether cannot also"),
+  );
+  assert.ok(!isImpossible("Aether did not connect in 30s"));
+  assert.ok(!isImpossible("Psiphon reported a listener and then stopped carrying"));
+});

--- a/src/features/carrierSearch.ts
+++ b/src/features/carrierSearch.ts
@@ -1,0 +1,90 @@
+import type { CarrierChain, CarrierKind } from "../types.ts";
+
+/**
+ * What order to try ways out in, when the user does not know which works.
+ *
+ * Nine possibilities at up to a minute and a half each is a quarter of an hour,
+ * so the order is the whole design: the cheap answer has to come first, and the
+ * expensive ones only exist for the network where nothing cheap answers.
+ */
+
+/**
+ * The single carriers, in measured order of how long they take to connect --
+ * Aether around 25s, Psiphon around 40s, Tor around 60s. On most networks the
+ * first one answers and the search is over in half a minute.
+ */
+const SINGLES: CarrierKind[] = ["aether", "psiphon", "tor"];
+
+/**
+ * The pairs, tried only once every single has failed -- which is the situation
+ * the search exists for.
+ *
+ * Grouped by first hop in the same measured order, because the first hop is
+ * what has to reach the physical network and so decides most of the wait.
+ *
+ * Chains are worth trying at all only because a single failing does not mean
+ * its carrier cannot be reached *through* something else: measured here,
+ * Aether reaches Cloudflare perfectly well through Psiphon or Tor on a network
+ * where it cannot reach it directly. That is why the orderings ending at
+ * Aether are in this list despite not changing the exit country.
+ */
+const PAIRS: Array<[CarrierKind, CarrierKind]> = [
+  ["aether", "psiphon"],
+  ["aether", "tor"],
+  ["psiphon", "aether"],
+  ["psiphon", "tor"],
+  ["tor", "aether"],
+  ["tor", "psiphon"],
+];
+
+/**
+ * Every chain to try, in order.
+ *
+ * `available` is what the backend reports as installed; null means it has not
+ * answered yet, and everything is offered rather than nothing. A carrier that
+ * is not installed is left out of both halves -- attempting it would spend an
+ * attempt on a certainty.
+ */
+export function searchOrder(available: CarrierKind[] | null): CarrierChain[] {
+  const has = (kind: CarrierKind) => !available || available.includes(kind);
+  const singles: CarrierChain[] = SINGLES.filter(has).map((first) => ({ first, second: null }));
+  const pairs: CarrierChain[] = PAIRS.filter(([first, second]) => has(first) && has(second)).map(
+    ([first, second]) => ({ first, second }),
+  );
+  return [...singles, ...pairs];
+}
+
+/**
+ * How long to give one attempt before moving on.
+ *
+ * Long enough for a legitimately slow Psiphon behind a slow Tor, short enough
+ * that the whole sweep stays bounded. Enforced by stopping the connection
+ * rather than by abandoning it: the supervisor checks between hops and unwinds,
+ * so a timed-out attempt leaves nothing running.
+ */
+export const ATTEMPT_CAP_MS = 90_000;
+
+/** What happened to one attempt, for the list the user watches. */
+export interface SearchAttempt {
+  chain: CarrierChain;
+  outcome: "trying" | "connected" | "failed" | "skipped";
+  /** The backend's own words, when it refused or failed. */
+  detail?: string;
+}
+
+/**
+ * Whether a failure means "this can never work here" rather than "this did not
+ * work just now".
+ *
+ * The backend refuses the impossible combinations immediately and by name --
+ * no Aether identity to chain behind another carrier, or a manual upstream
+ * proxy that a chain would have to overwrite. Those cost no time, so the search
+ * attempts them and reads the refusal, rather than keeping a second copy of the
+ * rule that could drift from the one the supervisor enforces.
+ */
+export function isImpossible(detail: string): boolean {
+  return (
+    detail.includes("cannot register from inside") ||
+    detail.includes("already dials through a proxy of your own")
+  );
+}

--- a/src/features/carrierSearch.ts
+++ b/src/features/carrierSearch.ts
@@ -64,10 +64,16 @@ export function searchOrder(available: CarrierKind[] | null): CarrierChain[] {
  */
 export const ATTEMPT_CAP_MS = 90_000;
 
-/** What happened to one attempt, for the list the user watches. */
+/** What happened to one attempt, for the list the user watches.
+ *
+ * "pending" and "skipped" are different facts and are shown differently:
+ * the first is "not reached yet", the second is "reached and refused as
+ * impossible here". Collapsing them would make a search that stopped early
+ * look like one that ruled everything out.
+ */
 export interface SearchAttempt {
   chain: CarrierChain;
-  outcome: "trying" | "connected" | "failed" | "skipped";
+  outcome: "pending" | "trying" | "connected" | "failed" | "skipped";
   /** The backend's own words, when it refused or failed. */
   detail?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,43 @@ export const ENDPOINT_MODES: Array<{ id: EndpointMode; label: string; detail: st
  */
 export type CarrierKind = "aether" | "psiphon" | "tor";
 
+/**
+ * An ordered pair of carriers.
+ *
+ * `first` leaves the local network; `second` decides the exit address.
+ * `second: null` is the single-carrier case — every session before chaining,
+ * and still the default.
+ */
+export interface CarrierChain {
+  first: CarrierKind;
+  second: CarrierKind | null;
+}
+
+/** What to call a chain on screen: the order traffic travels. */
+export function carrierChainLabel(chain: CarrierChain, name: (kind: CarrierKind) => string): string {
+  return chain.second ? `${name(chain.first)} → ${name(chain.second)}` : name(chain.first);
+}
+
+/** The hop that decides the exit address, and whose listener is dialled. */
+export function carrierChainLast(chain: CarrierChain): CarrierKind {
+  return chain.second ?? chain.first;
+}
+
+/**
+ * Whether a carrier appears anywhere in the chain.
+ *
+ * Settings belong to a carrier rather than to a position: an exit country is
+ * Psiphon's whether Psiphon is the first hop or the second.
+ */
+export function carrierChainHas(chain: CarrierChain, kind: CarrierKind): boolean {
+  return chain.first === kind || chain.second === kind;
+}
+
+/** The Aether engine on its own — the only case its own settings apply to. */
+export function isLoneAether(chain: CarrierChain): boolean {
+  return chain.first === "aether" && chain.second === null;
+}
+
 export interface PsiphonSettings {
   /**
    * A two-letter country to exit from, or empty for whichever Psiphon
@@ -189,10 +226,11 @@ export interface ConnectionProfile {
    * Which way out of the network to use.
    *
    * Everything else in this profile describes the Aether engine and applies
-   * only when this is "aether". A profile saved before carriers existed names
-   * none, which the backend reads as "aether".
+   * only when the chain ends at "aether". A profile saved before carriers
+   * existed names none, and one saved by 1.8.x carries a bare `carrier` string
+   * the backend migrates into a single-hop chain.
    */
-  carrier: CarrierKind;
+  carriers: CarrierChain;
   /** How the Psiphon carrier runs. Ignored unless `carrier` selects it. */
   psiphon: PsiphonSettings;
   /** How the Tor carrier runs. Ignored unless `carrier` selects it. */
@@ -283,7 +321,7 @@ export const DEFAULT_PROFILE: ConnectionProfile = {
   gateway: false,
   systemProxy: false,
   autoReconnect: true,
-  carrier: "aether",
+  carriers: { first: "aether", second: null },
   psiphon: { egressRegion: "" },
   tor: { bridges: "none", transport: "obfs4", customBridges: "" },
   chain: { enabled: false, throughTunnel: true, sources: [], manual: "", node: null },


### PR DESCRIPTION
Lets Aether, Psiphon and Tor be chained two at a time in any of the six orderings, so the second hop decides the exit address and the first decides how you get off the local network. Also adds a button that tries every way out in turn and keeps the first one that works. No version bump: merging this doesn't release anything, because `v1.8.1` already exists and the gate skips.

The design and what was measured are in `CARRIER-CHAINING.md`.

## What changed

**Startup, hop by hop.** Each hop has to be carrying traffic, not just listening, before the next one starts, and the next one is told to dial out through it: Psiphon via `UpstreamProxyURL`, Tor via `Socks5Proxy`, Aether via `AETHER_UPSTREAM`. No hop knows it's in a chain. It just has an upstream.

**The last hop was standing in for the whole chain** (finding 10). The first real run turned up faults that all came from one cause: code asking a chain-wide question of the last hop only.
- `Aether → X` never got past hop 1, because the readiness poll looked for the second hop's listener.
- mihomo refused to start for `X → Aether` with "nothing to carry".
- `carries_quic` said yes for every chain.
- The watcher returned immediately whenever the last hop was Aether.
- The QUIC advice named Aether's fix for Psiphon's limit.

These rules now live on `RunningChain`, the only type that can see every hop: `needs_routing_engine`, `carries_udp`, `carries_quic`, `datagram_blocker`, `process_names`.

**Teardown.** The error paths used to leave a chained Aether running. Measured: after a failed `Psiphon → Aether`, the engine lost its upstream and spent two minutes sweeping for a Cloudflare gateway *directly*, while the screen said Stopped. Every hop now goes down together, the session is released so Connect works again, and one dead hop takes the whole chain with it.

**The screen.** Two ordered pickers replace the single-carrier one, which could only ever write `second: null`. Under them, a card says what the chosen ordering gets you and what it doesn't. Orderings that end at Aether are never presented as a foreign exit. The search button has its own card.

**Two deliberate decisions.** When Tor is chained it drops its bridges: finding 7 was never proven at runtime, and bridges have nothing to do once the hop in front has already got out. `probe_core` also no longer blocks connections that never run the engine.

## Measured, from outside the app

- Five of the six orderings carried real traffic through mihomo. `Psiphon → Tor` hasn't been run.
- On `Aether → Tor`, `curl` through mihomo's port got `{"IsTor":true,"IP":"203.55.81.2"}` from check.torproject.org, so the exit belongs to the last hop.
- The rendered config declared `udp: false` and `NETWORK,udp,REJECT` for a chain with a TCP-only hop.
- Killing hop 1 brought the whole chain down in 623 ms.

## Not done

- **`Psiphon → Tor`**: never run.
- **The kill switch under a chain**: untested.
- **Chains ending at Aether reset within seconds**: `h2 body: connection reset; reconnecting`, three times out of three. A lone Aether stays up, so this points at the engine's SOCKS upstream path, not at the chain wiring. The engine recovers and the app reports `reconnecting` honestly, so the connection degrades rather than breaks.

## Tests

- Rust: 174 passed.
- Frontend: 52 passed, including 7 for the search order.
- `tsc` clean.
- No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
