### PR TITLE
Give Psiphon the key it signs its servers with

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -91,13 +91,11 @@ third-party mirror (`mbm110/MSN-GUARD`) pinned to a revision and verified agains
 it is staged. The digest guarantees the file cannot change under us; it does not guarantee the
 entries are Psiphon's.
 
-An earlier version of this notice said every entry is signed and verified by tunnel-core. That holds
-only when the client is configured with Psiphon's `ServerEntrySignaturePublicKey`, and ours is not:
-Psiphon does not publish that key outside its own clients, and tunnel-core's default is empty.
-Without it tunnel-core skips verification of stored entries (`psiphon/dataStore.go`), so the list is
-trusted as far as the mirror and the pinned revision are and no further. For the same reason the
-list is never refreshed: the in-tunnel discovery that would replace it rejects every entry it
-receives with "missing public key".
+What guarantees the entries are Psiphon's is the signature on each one: tunnel-core verifies it
+against `ServerEntrySignaturePublicKey`, which WhiteAesther now configures. Psiphon ships that key
+only inside its own clients; ours is the value used by open-source clients with the same placeholder
+IDs (Oblivion, MSN-GUARD, Aether_Desktop), and it is checked rather than trusted: it validates all 430
+entries in this list, and `scripts/stage-psiphon.mjs` refuses to stage a list it does not validate.
 
 ## Tor, and the lyrebird pluggable transport
 

--- a/scripts/psiphon-verify/main.go
+++ b/scripts/psiphon-verify/main.go
@@ -1,0 +1,64 @@
+// Copied into the psiphon-tunnel-core checkout by scripts/stage-psiphon.mjs,
+// run there, and removed. It is kept as a real Go file rather than as a string
+// inside the script, where its escape sequences did not survive intact.
+//
+// It borrows tunnel-core's own DecodeServerEntryFields and VerifySignature
+// rather than reimplementing Ed25519 over Psiphon's field encoding: the
+// question is whether tunnel-core will accept these entries, so tunnel-core is
+// what answers it.
+//
+// Usage: go run . <server-list> <signature-key-file>
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Psiphon-Labs/psiphon-tunnel-core/psiphon/common/protocol"
+)
+
+func main() {
+	key, err := os.ReadFile(os.Args[2])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(2)
+	}
+	publicKey := strings.TrimSpace(string(key))
+
+	f, err := os.Open(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(2)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 1<<22)
+	total, verified, reported := 0, 0, 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		total++
+		fields, err := protocol.DecodeServerEntryFields(line, "", protocol.SERVER_ENTRY_SOURCE_TARGET)
+		if err == nil {
+			err = fields.VerifySignature(publicKey)
+		}
+		if err != nil {
+			// A handful is enough to see why; a rotated key fails every entry.
+			if reported < 3 {
+				fmt.Printf("entry %d: %v\n", total, err)
+				reported++
+			}
+			continue
+		}
+		verified++
+	}
+	fmt.Printf("%d/%d server entries verify against the signature key\n", verified, total)
+	if total == 0 || verified != total {
+		os.Exit(1)
+	}
+}

--- a/scripts/stage-psiphon.mjs
+++ b/scripts/stage-psiphon.mjs
@@ -16,7 +16,7 @@
  */
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { access, chmod, mkdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { access, chmod, copyFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { execFileSync } from "node:child_process";
 import { pipeline } from "node:stream/promises";
 import { dirname, join, resolve } from "node:path";
@@ -105,6 +105,7 @@ if (await isBuilt(destination)) {
 }
 
 await stageServerList();
+await verifyServerList();
 
 const size = (await stat(destination)).size;
 console.log(`Staged Psiphon ${REVISION} for ${target}`);
@@ -120,6 +121,63 @@ console.log(`  ${serverListDestination}`);
  * served with a 200, which tunnel-core would reject as a whole without saying
  * which line lost it.
  */
+/**
+ * Checks every entry in the staged list against the key the app ships with.
+ *
+ * The digest pin proves the file has not changed; it proves nothing about the
+ * entries. Their signatures do. A list that does not verify is either a rotated
+ * key -- every entry would then be rejected at runtime, and Psiphon would
+ * silently stop connecting -- or a list that is not Psiphon's, which is worse.
+ * Either way it must not ship, so this refuses rather than warns.
+ *
+ * Reads the same file the app compiles in, so the two cannot drift apart.
+ */
+async function verifyServerList() {
+  const keyPath =
+    option("--signature-key") ?? join(appRoot, "src-tauri", "src", "psiphon_server_entry_signature_key.txt");
+  // Verified once per list-and-key pair. Those two are what can change -- a
+  // new list, or a rotated key -- and neither changes between two ordinary
+  // builds, so checking every time would only make Go a requirement of every
+  // `desktop:dev` for nothing. CI stages from nothing, so it always checks.
+  const key = (await readFile(keyPath, "utf8")).trim();
+  const pair = `${await sha256(serverListDestination)} ${createHash("sha256").update(key).digest("hex")}`;
+  const marker = `${serverListDestination}.verified`;
+  if ((await readFile(marker, "utf8").catch(() => "")).trim() === pair) {
+    console.log("  server list already verified against this signature key");
+    return;
+  }
+  // Gone before the check rather than after it, so a failed or interrupted
+  // check can never leave a marker claiming this pair was verified.
+  await rm(marker, { force: true });
+  await ensureCheckout(checkout);
+  const dir = join(checkout, "zz_whiteaesther_verify");
+  await mkdir(dir, { recursive: true });
+  await copyFile(join(appRoot, "scripts", "psiphon-verify", "main.go"), join(dir, "main.go"));
+  // The host's own toolchain: this runs here, whatever the build target is.
+  const env = { ...process.env, CGO_ENABLED: "0" };
+  delete env.GOOS;
+  delete env.GOARCH;
+  try {
+    const out = execFileSync("go", ["run", "./zz_whiteaesther_verify", serverListDestination, keyPath], {
+      cwd: checkout,
+      encoding: "utf8",
+      env,
+    });
+    console.log(`  ${out.trim()}`);
+    await writeFile(marker, pair);
+  } catch (error) {
+    throw new Error(
+      `The Psiphon server list does not verify against the signature key the app ships with.
+` +
+        `Either Psiphon rotated the key or the list is not Psiphon's; refusing to stage it.
+` +
+        `${error.stdout ?? ""}${error.stderr ?? ""}`.trim(),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 async function stageServerList() {
   if (await matches(serverListDestination, SERVER_LIST.sha256)) {
     console.log("server list already present and matches the pin");

--- a/src-tauri/src/psiphon.rs
+++ b/src-tauri/src/psiphon.rs
@@ -88,6 +88,30 @@ const ESTABLISH_TUNNEL_TIMEOUT_SECONDS: u64 = 300;
 const PROPAGATION_CHANNEL_ID: &str = "FFFFFFFFFFFFFFFF";
 const SPONSOR_ID: &str = "1111111111111111";
 
+/// The key Psiphon signs its server entries with.
+///
+/// Without it tunnel-core cannot use in-proxy at all -- every in-proxy dial
+/// fails in `MakeDialParameters` on "missing public key" -- and in-tunnel
+/// discovery rejects every server it is sent. Measured with in-proxy forced:
+/// 0 dials and 10,116 failures without it; with it, 21 dials and a tunnel
+/// through a volunteer proxy in 33 seconds -- and in-tunnel discovery fetched
+/// fresh server entries in that same run, where without the key it had
+/// rejected every one, so the list refreshes itself again. In-proxy is how Psiphon gets
+/// through where its direct protocols are blocked, which is why users saw the
+/// official app connect where this one did not.
+///
+/// Psiphon ships it only inside its own clients, so it is the value used by the
+/// open-source clients that share our placeholder IDs -- Oblivion, MSN-GUARD
+/// and Aether_Desktop -- and it is *verified* rather than trusted: it validates
+/// the signature on all 430 entries of our bootstrap list, and two other keys
+/// from the same sources validate none. It is a verification key: it grants
+/// nothing and identifies no one. A rotation fails closed -- entries signed
+/// under a new key are rejected, not accepted -- and `scripts/stage-psiphon.mjs`
+/// re-checks the list against it every time it stages.
+///
+/// Kept in its own file so the app and that check read one copy of it.
+const SERVER_ENTRY_SIGNATURE_PUBLIC_KEY: &str = include_str!("psiphon_server_entry_signature_key.txt");
+
 #[cfg(windows)]
 const PSIPHON_FILENAME: &str = "psiphon-tunnel-core.exe";
 #[cfg(not(windows))]
@@ -586,30 +610,15 @@ fn render_config(
     home: &Path,
     upstream: Option<SocketAddr>,
 ) -> String {
-    // What is deliberately absent, and what its absence costs -- measured on
-    // 2026-09-10 against this exact config.
-    //
-    // No `ServerEntrySignaturePublicKey`. Psiphon publishes it only inside its
-    // own clients, and tunnel-core's default is empty. Without it:
-    //
-    //   - Every in-proxy dial fails in `MakeDialParameters`, before a packet is
-    //     sent: "missing public key", 10,116 times in a 70-second run with
-    //     in-proxy forced, zero dials, zero tunnels. 316 of the 430 bootstrap
-    //     servers offer in-proxy and none can be reached that way. In-proxy is
-    //     how Psiphon gets through where its direct protocols are blocked, so
-    //     this is the difference users report between the official app
-    //     connecting and this one not. The tactics that arrive *do* carry
-    //     broker specs; it is the key, not the IDs below, that closes it.
-    //   - The list is never refreshed: in-tunnel discovery rejects every entry
-    //     it receives for the same reason.
-    //   - The bootstrap list is used unverified: `dataStore.go` checks
-    //     signatures only when the key is set.
-    //
-    // No `RemoteServerListURLs` or their signing key either, for the same
-    // reason. What fixes all of it is Psiphon's own client configuration.
+    // Still absent: `RemoteServerListURLs` and their signing key. They have not
+    // been verified the way the signature key has, so they are left out rather
+    // than trusted -- and they are no longer what keeps the list fresh: with
+    // the signature key set, in-tunnel discovery does that once any tunnel is
+    // up. See `SERVER_ENTRY_SIGNATURE_PUBLIC_KEY`.
     let mut config = serde_json::json!({
         "PropagationChannelId": PROPAGATION_CHANNEL_ID,
         "SponsorId": SPONSOR_ID,
+        "ServerEntrySignaturePublicKey": SERVER_ENTRY_SIGNATURE_PUBLIC_KEY.trim(),
         // Our own version, as a string, which is what tunnel-core's sample says
         // and what it rejects the config for getting wrong. Reporting one of
         // Psiphon's own client versions would put our sessions in someone
@@ -834,6 +843,17 @@ mod tests {
             ESTABLISH_TUNNEL_TIMEOUT_SECONDS
         );
         assert_eq!(config["EmitDiagnosticNotices"], true);
+        // Without it in-proxy is dead and discovery rejects every server; see
+        // the constant for what that cost, measured.
+        assert_eq!(
+            config["ServerEntrySignaturePublicKey"],
+            SERVER_ENTRY_SIGNATURE_PUBLIC_KEY.trim()
+        );
+        assert_eq!(
+            SERVER_ENTRY_SIGNATURE_PUBLIC_KEY.trim().len(),
+            44,
+            "a base64 Ed25519 public key, with no stray whitespace from the file"
+        );
     }
 
     #[test]

--- a/src-tauri/src/psiphon_server_entry_signature_key.txt
+++ b/src-tauri/src/psiphon_server_entry_signature_key.txt
@@ -1,0 +1,1 @@
+sHuUVTWaRyh5pZwy4UguSgkwmBe0EHtJJkoF5WrxmvA=


### PR DESCRIPTION
Fixes the Psiphon carrier failing where the official app connects. Follows #39, which diagnosed the problem and raised the timeout.

## The cause

Our config had no `ServerEntrySignaturePublicKey`. Other projects that use the same placeholder IDs (Oblivion, MSN-GUARD, Aether_Desktop) connect because they set it.

Same config, with in-proxy forced, before and after:

| | without the key | with the key |
|---|---|---|
| in-proxy dials | 0 | **21** |
| tunnel | none | **`INPROXY-WEBRTC-OSSH`** in 32.8 s |
| "missing public key" | 10,116 | **0** |
| in-tunnel discovery | rejected every entry | **fetched server entries** |

In-proxy is how Psiphon gets through where its direct protocols are blocked. That's why this never showed up on an open network.

## The key

Psiphon ships this key only inside its own clients. Ours is the value those projects use, and it has been **verified, not just trusted**. tunnel-core's own `VerifySignature` accepts it on all 430 entries of our bootstrap list, and rejects two other keys from the same sources on every entry ("unexpected public key ID"). It's a public verification key: it grants nothing and identifies no one, and if Psiphon rotates it the failure is closed.

## Changes

- **`psiphon_server_entry_signature_key.txt`** is the single copy of the key. It's compiled into the app with `include_str!` and read by the staging script, so the two can't drift apart.
- **`render_config`** now sends the key. A test pins it and checks it's 44 characters with no stray whitespace.
- **`stage-psiphon.mjs` refuses to stage a list that doesn't verify.** Otherwise a rotated key would leave every entry rejected at runtime and Psiphon would quietly stop connecting. It runs tunnel-core's own verification through `scripts/psiphon-verify/main.go`, a real Go file copied into the checkout. The check runs once per list-and-key pair, so ordinary builds don't need Go. CI stages from nothing, so it always runs the check.
- **THIRD_PARTY_NOTICES** now says what actually verifies the bootstrap list.

`RemoteServerListURLs` are still left out. They haven't been verified the way the key has, and with the key set, discovery keeps the list fresh anyway.

## Tested

- Rust: 174 passed.
- Staging, run locally in sequence:
  1. With the shipped key: 430/430.
  2. Staged again: skipped, marker matches.
  3. With a wrong key: 0/430 and a refusal (exit 1), marker removed.
  4. Staged again: 430/430.
- The tunnel-core checkout was left clean.
- `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
