### PR TITLE
1.9.0 (pre-release) — chain two carriers, and Psiphon reaches in-proxy

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -39,6 +39,7 @@ jobs:
     outputs:
       publish: ${{ steps.decide.outputs.publish }}
       version: ${{ steps.decide.outputs.version }}
+      prerelease: ${{ steps.decide.outputs.prerelease }}
       reuse: ${{ steps.decide.outputs.reuse }}
     steps:
       - uses: actions/checkout@v7
@@ -57,6 +58,14 @@ jobs:
           set -euo pipefail
           version="$(node -p "require('./package.json').version")"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+          # Set per release in package.json, beside the version it describes.
+          # A pre-release keeps a plain version number: a semver suffix such as
+          # "-beta.1" is the usual way to say it, but the bundle targets are
+          # "all", which includes the Windows MSI, and the MSI takes numeric
+          # versions only.
+          prerelease="$(node -p "require('./package.json').prerelease === true")"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
 
           publish=false
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
@@ -99,7 +108,7 @@ jobs:
             fi
           fi
           echo "reuse=${reuse}" >> "$GITHUB_OUTPUT"
-          echo "version ${version}, publish ${publish}, reuse ${reuse:-none}"
+          echo "version ${version}, prerelease ${prerelease}, publish ${publish}, reuse ${reuse:-none}"
 
   package:
     name: ${{ matrix.name }}
@@ -440,10 +449,20 @@ jobs:
           if gh release view "$tag" >/dev/null 2>&1; then
             gh release upload "$tag" release-assets/* --clobber
           else
+            # A pre-release is published and downloadable, but GitHub leaves it
+            # out of `releases/latest` -- which is what the in-app update check
+            # reads -- so nobody on a stable build is offered it. Promoting it
+            # later is `gh release edit <tag> --prerelease=false --latest`, with
+            # nothing rebuilt.
+            flags=()
+            if [[ "${{ needs.gate.outputs.prerelease }}" == "true" ]]; then
+              flags+=(--prerelease)
+            fi
             gh release create "$tag" release-assets/* \
               --target "${GITHUB_SHA}" \
               --generate-notes \
-              --title "WhiteAesther $tag"
+              --title "WhiteAesther $tag" \
+              ${flags[@]+"${flags[@]}"}
           fi
           echo "Released $tag from ${GITHUB_SHA}"
           gh release view "$tag" --json url --jq .url

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.9.0",
+  "prerelease": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "getrandom 0.3.4",
  "rustls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.8.1"
+version = "1.9.0"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/core/updates.ts
+++ b/src/core/updates.ts
@@ -12,7 +12,13 @@
  * connecting is the expected case, not an error worth showing anyone.
  */
 
-/** Where releases are published. Read-only, unauthenticated. */
+/**
+ * Where releases are published. Read-only, unauthenticated.
+ *
+ * `releases/latest` never returns a GitHub pre-release, and that is the point
+ * rather than a gap: a pre-release is published for the people who go and get
+ * it, and nobody on a stable build is offered one until it is promoted.
+ */
 const LATEST_RELEASE = "https://api.github.com/repos/WhiteDNS/WhiteAesther/releases/latest";
 
 /** How long to wait before asking again. */
@@ -41,9 +47,10 @@ export function compareVersions(a: string, b: string): number {
     value
       .trim()
       .replace(/^v/i, "")
-      // A prerelease suffix is dropped rather than ranked. We do not publish
-      // them, and guessing an order for something we never ship would be a rule
-      // written from nothing.
+      // A prerelease suffix is dropped rather than ranked. We never put one in
+      // a version number -- a pre-release is marked on GitHub instead, and
+      // `releases/latest` never returns it -- so guessing an order for
+      // something we never ship would be a rule written from nothing.
       .split("-")[0]
       .split(".")
       .map((piece) => Number.parseInt(piece, 10));


### PR DESCRIPTION
Merging this publishes **v1.9.0 as a GitHub pre-release**. It can be downloaded from the releases page, but the in-app update check reads `releases/latest`, which leaves pre-releases out, so nobody on 1.8.1 will be offered it.

## Why the workflow had to change

The publish step created every release as a full one. Bumping the version and merging would have made 1.9.0 the new latest for everyone.

- `package.json` has a `prerelease` flag next to the version it describes. The gate reads it and passes it on, and the publish step adds `--prerelease`.
- The version stays a plain `1.9.0`. A suffix such as `-beta.1` is the usual way to mark a pre-release, but our bundle targets include the Windows MSI, which only accepts numeric versions.
- **Promoting it to a stable release later** is `gh release edit v1.9.0 --prerelease=false --latest`. Nothing gets rebuilt.

## What 1.9.0 contains, since 1.8.1

- **#38**: chain any two carriers in any of the six orderings. It adds a two-hop picker, labels that say honestly where each ordering exits, and a "find one that works" search.
- **#39**: Psiphon waits its own 300 seconds instead of 120.
- **#40**: Psiphon gets the key it signs its servers with. Without it, in-proxy never connected (0 dials measured). With it, a tunnel came up through a volunteer proxy in 33 seconds, and the server list refreshes again. CI checks the list against the key on every build.

## Not done yet

- The `Psiphon → Tor` ordering and the kill switch under a chain haven't been run live.
- Chains that end at Aether reset within seconds. The evidence points at the engine's SOCKS path rather than the chain code, and the app reports `reconnecting` honestly.

## Checks

- **Workflow:** all 7 `run:` blocks pass `bash -n`.
- **Frontend:** 52 tests pass and `tsc` is clean.
- **Rust:** the only Rust change here is the version number. CI runs the full suite on all five platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
