### PR TITLE
Give the search a verdict worth reading, and a chained engine the framing it needs

### DIFF
--- a/CARRIER-CHAINING.md
+++ b/CARRIER-CHAINING.md
@@ -65,6 +65,30 @@ second hop, and say so plainly when it cannot — a fresh install whose first
 action is `Psiphon → Aether` will otherwise fail with a message about
 registration that names nothing the user can act on.
 
+**Read afterwards in the pinned engine source, and it makes the guard more
+important than it looked.** `account.rs::http_client` does honour
+`AETHER_UPSTREAM` — it asks `upstream::configured()` for a proxy and attaches
+it. But `aether/Cargo.toml` builds reqwest without the `socks` feature, so a
+`socks5://` proxy cannot be constructed; the error is caught, logged as `the api
+calls could not be sent through the proxy`, and **the client is then built
+without a proxy at all**. The registration request goes out *directly*.
+
+That is not a failure to register. It is a fresh install, with a carrier in
+front of it precisely because the network is hostile, making an unproxied
+request to Cloudflare's API at the moment it is trying not to be seen. The
+`aether_identity_exists` refusal is what stands between a user and that, so it
+stays until the engine either gains the feature or refuses the dial itself.
+
+Two more facts from the same reading, both about `AETHER_UPSTREAM`:
+
+- `upstream.rs` caches it in a `OnceLock`, so it is read once per process. This
+  costs us nothing only because every connect spawns a fresh engine — the value
+  is set on the `Command` and never mutated under a running one. It would bite
+  immediately if a long-lived engine were ever reused across carrier restarts.
+- `--startup-secs` becomes `AETHER_MASQUE_STARTUP_SECS`, which wraps `ready_rx`
+  — the tunnel handshake *after* a gateway has been chosen. It does not bound
+  the gateway scan ahead of it. See `scan_deadline`.
+
 ### 2. Any chain containing Psiphon or Tor is TCP-only — measured
 
 Psiphon's SOCKS5 refuses `UDP ASSOCIATE` with `0x07 COMMAND NOT SUPPORTED`. Tor
@@ -77,6 +101,17 @@ and both must reach the screen rather than being discovered:
 - Aether in such a chain can only use **MASQUE H2**. H3 rides QUIC and WireGuard
   is UDP; both die at the TCP-only hop. Those options must be disabled, not
   merely annotated.
+
+  Disabling them on the screen turned out not to be enough, and the reason is
+  worth keeping: `Routes` hides the transport picker whenever the engine is not
+  alone, but hiding a control does not clear what it last stored. Someone who
+  chose WireGuard while Aether was on its own and then put Psiphon in front of
+  it still had `wg` in the profile, and `start_aether_hop` launched the engine
+  with it — so the hop did not fail over to something slower, it dialled the
+  gateway directly, past the carrier the chain existed for. The search made it
+  routine rather than rare: it tries six chained orderings with whatever the
+  profile holds. Pinned in `pin_to_masque_h2`, in the supervisor, where the
+  chain is actually built.
 - The `udp: false` declaration and the `NETWORK,udp,REJECT` rule already written
   for Tor now apply to any chain with a TCP-only hop.
 
@@ -256,15 +291,58 @@ from a hang.
 
 ## The "find one that works" button
 
-Six orderings plus three single carriers is nine attempts, and at three minutes
-each that is half an hour. That is not a button, it is abandoning the app.
+Six orderings plus three single carriers is nine attempts, and giving each
+carrier the time it actually needs makes a sweep where nothing answers run for
+the better part of an hour. That is the honest cost of not cutting a search that
+was about to succeed, so the screen says the number before anyone commits to it
+and counts a clock while it runs — minutes of silence is what people give up on.
+Ordering is what keeps the usual case to seconds.
 
 - **Singles first, in order of measured speed:** Aether (~25s), Psiphon (~40s),
   Tor (~60s). On most networks the first one answers and the search ends.
 - **Chains only after every single has failed**, which is the situation the
   search exists for.
-- **A hard cap per attempt**, around 90 seconds — long enough for a legitimately
-  slow Psiphon, short enough that nine of them stay bounded.
+- **A cap per attempt, taken from the deadline the carrier already enforces on
+  itself** — `AETHER_HOP_TIMEOUT` (150s), `ESTABLISH_TIMEOUT` (315s),
+  `BOOTSTRAP_TIMEOUT` (180s), added up across the hops of a chain.
+
+  Aether's share is not one number: it scans to `prober.rs`'s own deadline,
+  which runs from 45s in `turbo` to 330s in `thorough`, and only then starts the
+  handshake `--startup-secs` bounds. `aether_hop_timeout` adds those rather than
+  assuming either contains the other — the flat 150s it replaced was below the
+  *default* mode's own window, so a chained engine that was still scanning came
+  back as "did not connect".
+
+  This was one flat 90 seconds, which was shorter than all three. A cap below a
+  carrier's own deadline does not bound the search, it *replaces* that deadline
+  and always wins: every attempt was cut before the thing it was waiting for
+  could answer. Psiphon was the worst of it — a first run has no tactics, so
+  in-proxy is not available yet and reaching it can take tunnel-core's full 300s
+  window, which is the whole reason `ESTABLISH_TIMEOUT` is what it is. The one
+  feature aimed at someone who does not know what works could never find it.
+
+  The cap is a safety net, not the deadline. Each carrier fails its own attempt
+  at its own deadline and says why, and that reason is what the list shows.
+
+- **A route counts only once a request has made the round trip through it.**
+  Reaching `connected` says the processes are up and the handshakes finished. It
+  does not say anything went through. A carrier that completes its handshake and
+  then carries nothing is the worst thing a search can settle on: it looks like
+  success on every screen and fails everything the person tries next. `settle`
+  asks `probe_latency` — a real SOCKS5 CONNECT and a byte back — and treats a
+  connected route that never answers as a failure, named as one so it is not
+  confused with never connecting.
+
+- **Wait for the snapshot, not for `start_core` to return.** That call answers
+  at two different moments: on the chained path it has already waited for a hop
+  to be carrying traffic, and on the engine path it returns the instant the
+  process is spawned, with the state reading `starting`. Taking the return as
+  the verdict settled every sweep on Aether alone on the strength of a process
+  having started — the six chained orderings below it were never reached on any
+  machine where the engine binary exists, which is all of them. `verdictFor`
+  reads the state instead: `connected` is the answer, `error` and `idle` are
+  failures, and `reconnecting` is the engine between its own attempts and not
+  yet either.
 - **Skip what cannot work:** with no Aether identity, every `X → Aether` is
   skipped rather than attempted (finding 1). With a manual `upstreamProxy` set,
   chains are skipped (finding 8).

--- a/src-tauri/src/core_supervisor.rs
+++ b/src-tauri/src/core_supervisor.rs
@@ -2347,6 +2347,62 @@ fn retry_delay(attempt: u32) -> Duration {
     Duration::from_secs((BASE_RETRY_SECS << shift).min(MAX_RETRY_SECS))
 }
 
+/// Mirrors the diagnostics stream to a file, in debug builds only.
+///
+/// The log lives in memory and is shown in the window, which is enough while
+/// someone is looking at the window. It is not enough for the two cases that
+/// matter most: a crash or a freeze takes the buffer with it, and a run that
+/// has to be watched while something else is being done cannot be watched at
+/// all. A file survives the first and can be tailed for the second.
+///
+/// Debug builds only, and deliberately: these lines carry gateway addresses,
+/// listener ports and the shape of someone's chain. In a release build that is
+/// a file on disk describing how a person gets out of their network, written
+/// whether or not they ever ask for a diagnostics report -- which is the
+/// opposite of what keeping it in memory is for. The report they *do* ask for
+/// is composed and redacted in the window before it is ever saved.
+///
+/// Truncated once per run, so the file answers "what happened this time"
+/// rather than growing without limit. Every failure here is swallowed: a
+/// diagnostic aid that can break the thing it is diagnosing is worse than none.
+#[cfg(debug_assertions)]
+fn mirror_to_debug_file(event: &CoreLogEvent) {
+    use std::io::Write;
+    use std::sync::OnceLock;
+
+    static FILE: OnceLock<Option<Mutex<std::fs::File>>> = OnceLock::new();
+
+    let handle = FILE.get_or_init(|| {
+        let path = std::env::temp_dir().join("whiteaesther-debug.log");
+        match std::fs::File::create(&path) {
+            Ok(file) => {
+                // Printed rather than logged: this runs from inside `push_log`,
+                // and logging it here would be the first thing it recursed on.
+                eprintln!("[whiteaesther] diagnostics are mirrored to {}", path.display());
+                Some(Mutex::new(file))
+            }
+            Err(error) => {
+                eprintln!("[whiteaesther] no debug log file ({error})");
+                None
+            }
+        }
+    });
+
+    if let Some(file) = handle {
+        let mut file = lock(file);
+        let _ = writeln!(
+            file,
+            "{} {:>5} {:<10} {}",
+            event.timestamp, event.level, event.stream, event.message
+        );
+        let _ = file.flush();
+    }
+}
+
+/// Release builds keep the diagnostics log in memory and nowhere else.
+#[cfg(not(debug_assertions))]
+fn mirror_to_debug_file(_event: &CoreLogEvent) {}
+
 fn push_log(inner: &SupervisorInner, stream: &str, level: &str, message: String) {
     let event = CoreLogEvent {
         timestamp: now_millis(),
@@ -2354,6 +2410,7 @@ fn push_log(inner: &SupervisorInner, stream: &str, level: &str, message: String)
         level: level.into(),
         message,
     };
+    mirror_to_debug_file(&event);
     {
         let mut logs = lock(&inner.logs);
         if logs.len() == MAX_LOGS {
@@ -2816,11 +2873,56 @@ fn start_hop(
     }
 }
 
+/// The engine's own deadline for finding a gateway, per scan mode.
+///
+/// Read out of `prober.rs` in the pinned engine revision: `overall_deadline`
+/// plus `quiet_after_first`, which is the extra it spends after its first hit
+/// before settling. These are the numbers the engine enforces on itself, and
+/// this table is a mirror of them.
+///
+/// | mode     | deadline | quiet |
+/// | ---      | ---      | ---   |
+/// | turbo    | 45s      | 0s    |
+/// | balanced | 120s     | 20s   |
+/// | thorough | 300s     | 30s   |
+/// | stealth  | 180s     | 25s   |
+/// | ironclad | 180s     | 15s   |
+fn scan_deadline(scan_mode: &str) -> Duration {
+    let secs = match scan_mode {
+        "turbo" => 45,
+        "thorough" => 300 + 30,
+        "stealth" => 180 + 25,
+        "ironclad" => 180 + 15,
+        // Balanced is the default here and in the engine, so it is also what an
+        // unknown mode gets rather than the shortest window.
+        _ => 120 + 20,
+    };
+    Duration::from_secs(secs)
+}
+
+/// Work that happens either side of the scan: spawning the process, reading the
+/// identity, the registration and API calls that the doc comment in `prober.rs`
+/// notes come on top of the scan deadline.
+const AETHER_HOP_OVERHEAD: Duration = Duration::from_secs(20);
+
 /// How long to wait for the engine to come up as one hop of a chain.
 ///
-/// Its own `startup_secs` governs the scan; this bounds the whole thing so a
-/// chain reports failure rather than sitting on "connecting" forever.
-const AETHER_HOP_TIMEOUT: Duration = Duration::from_secs(150);
+/// Derived from what the engine was actually asked to do, rather than one
+/// number for every scan mode. This was a flat 150s, on the belief -- stated in
+/// the comment that used to be here -- that `startup_secs` governed the scan.
+/// It does not: `--startup-secs` becomes `AETHER_MASQUE_STARTUP_SECS`, which
+/// wraps only the tunnel handshake *after* a gateway has been chosen. The scan
+/// ahead of it runs to `prober.rs`'s own deadline and knows nothing about it.
+///
+/// So 150s cut the default `balanced` mode short -- 140s of scanning plus a 30s
+/// handshake is 170s -- and cut `thorough` almost in half. Both failed as "did
+/// not connect" while the engine was still working, which is the one thing
+/// finding 4 of the Android notes says never to do to a search.
+fn aether_hop_timeout(profile: &CoreProfile) -> Duration {
+    scan_deadline(&profile.scan_mode)
+        + Duration::from_secs(profile.startup_secs)
+        + AETHER_HOP_OVERHEAD
+}
 
 /// The engine as one hop, brought up and waited for.
 ///
@@ -2850,6 +2952,19 @@ fn start_aether_hop(
             );
         }
         hop.upstream_proxy = format!("socks5://{address}");
+
+        if let Some(was) = pin_to_masque_h2(&mut hop) {
+            supervisor_log(
+                inner,
+                "info",
+                format!(
+                    "Aether runs as {was} on its own; behind another carrier it is pinned to \
+                     MASQUE H2, because QUIC and WireGuard would dial straight past the hop \
+                     in front of it"
+                ),
+            );
+        }
+
         // Measured: the engine never resolves Cloudflare's API by name, it
         // dials raw edge addresses with a spoofed SNI so DNS cannot be
         // blocked -- and that fails through a SOCKS proxy. Registration
@@ -2868,7 +2983,10 @@ fn start_aether_hop(
 
     launch(app, inner, &hop, 0, generation, false)?;
 
-    let deadline = Instant::now() + AETHER_HOP_TIMEOUT;
+    // Taken from the hop's own profile, which is what the engine was told to
+    // do -- not from the session's, which a retry may have moved on from.
+    let budget = aether_hop_timeout(&hop);
+    let deadline = Instant::now() + budget;
     while Instant::now() < deadline {
         if !inner.is_current(generation) {
             return Err("the connection was stopped while it was starting".into());
@@ -2889,8 +3007,34 @@ fn start_aether_hop(
     }
     Err(format!(
         "Aether did not connect in {}s",
-        AETHER_HOP_TIMEOUT.as_secs()
+        budget.as_secs()
     ))
+}
+
+/// Forces a chained engine onto the one framing a SOCKS5 hop can carry.
+///
+/// Returns what it was, when it had to change anything, so the caller can say
+/// so -- and `None` when the profile already asked for MASQUE H2.
+///
+/// H3 rides QUIC and WireGuard is UDP. A hop in front carries neither, so the
+/// engine does not fall back to something slower: it dials the gateway
+/// *directly*, and the session leaves by the address the chain exists to hide.
+/// That is the one failure here that is worse than not connecting at all.
+///
+/// Pinned in the supervisor rather than in the screen. `Routes` hides the
+/// transport picker whenever the engine is not alone, but hiding a control does
+/// not change what it last stored: someone who chose WireGuard while Aether was
+/// on its own and then put Psiphon in front of it still has `wg` in the
+/// profile, and the way-out search tries six chained orderings with whatever
+/// the profile holds. See finding 2 in `CARRIER-CHAINING.md`.
+fn pin_to_masque_h2(hop: &mut CoreProfile) -> Option<&'static str> {
+    let was = transport_label(hop);
+    if was == "masque-h2" {
+        return None;
+    }
+    hop.protocol = "masque".into();
+    hop.masque_transport = "h2".into();
+    Some(was)
 }
 
 /// Whether the engine already has a device identity on disk.
@@ -3804,6 +3948,86 @@ mod tests {
             assert_eq!(attempted.protocol, "wg");
             assert_eq!(attempted.masque_transport, profile.masque_transport);
         }
+    }
+
+    #[test]
+    fn a_chained_engine_is_pinned_to_the_framing_the_hop_can_carry() {
+        // Both of these leave by UDP, which a SOCKS5 hop does not carry -- so
+        // the engine would reach the gateway directly, past the carrier the
+        // chain exists for.
+        for leaves_by_udp in ["wg", "gool"] {
+            let mut hop = CoreProfile::default();
+            hop.protocol = leaves_by_udp.into();
+            assert!(pin_to_masque_h2(&mut hop).is_some(), "{leaves_by_udp}");
+            assert_eq!(transport_label(&hop), "masque-h2");
+        }
+
+        let mut h3 = CoreProfile::default();
+        h3.masque_transport = "h3".into();
+        assert_eq!(pin_to_masque_h2(&mut h3), Some("masque-h3"));
+        assert_eq!(transport_label(&h3), "masque-h2");
+
+        // And the arguments follow, which is the whole point: `--h2` is what
+        // the engine reads, and it is only pushed for MASQUE H2.
+        let args = h3.args(Path::new("identity.toml"));
+        assert!(args.contains(&"--masque".to_string()), "{args:?}");
+        assert!(args.contains(&"--h2".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn a_chained_engine_is_given_the_time_its_own_scan_mode_takes() {
+        // The engine's `overall_deadline` plus `quiet_after_first`, from
+        // `prober.rs`. A hop timeout below these fails an engine that is still
+        // working, which is the one thing a search must not do.
+        for (mode, scan_secs) in [
+            ("turbo", 45),
+            ("balanced", 140),
+            ("thorough", 330),
+            ("stealth", 205),
+            ("ironclad", 195),
+        ] {
+            let mut profile = CoreProfile::default();
+            profile.scan_mode = mode.into();
+            let budget = aether_hop_timeout(&profile);
+            assert!(
+                budget >= Duration::from_secs(scan_secs + profile.startup_secs),
+                "{mode} gets {budget:?}, which cuts its own scan short"
+            );
+        }
+
+        // The flat 150s this replaced was below the default mode's own window,
+        // which is how an engine that was still scanning came back as "did not
+        // connect".
+        let balanced = aether_hop_timeout(&CoreProfile::default());
+        assert!(balanced > Duration::from_secs(150), "{balanced:?}");
+
+        // A longer handshake deadline is the user asking for more patience, and
+        // it has to reach the wait rather than only the engine.
+        let mut patient = CoreProfile::default();
+        patient.startup_secs = 120;
+        assert!(aether_hop_timeout(&patient) > balanced);
+    }
+
+    #[test]
+    fn an_unknown_scan_mode_gets_the_default_window_rather_than_the_shortest() {
+        // A profile saved by a newer build, or a mode added to the engine
+        // first. Falling to `turbo`'s 45s would fail it before it had looked.
+        let mut future = CoreProfile::default();
+        future.scan_mode = "something-new".into();
+        assert_eq!(
+            aether_hop_timeout(&future),
+            aether_hop_timeout(&CoreProfile::default())
+        );
+    }
+
+    #[test]
+    fn pinning_a_profile_that_already_asked_for_h2_says_nothing() {
+        // The log line exists to explain a choice being overridden. Saying it
+        // where nothing was overridden would read as a fault on every ordinary
+        // chained connect.
+        let mut hop = CoreProfile::default();
+        assert_eq!(transport_label(&hop), "masque-h2");
+        assert_eq!(pin_to_masque_h2(&mut hop), None);
     }
 
     #[test]

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -339,6 +339,8 @@ const FA: Record<string, string> = {
     "فهرست کشورها را خود سایفون می‌دهد و پس از نخستین اتصال می‌رسد.",
   "The transport, search and anti-blocking settings belong to the Aether engine. Choose Aether above to see them.":
     "تنظیمات ترابرد، جستجو و ضدمسدودسازی به موتور Aether مربوط‌اند. برای دیدنشان بالا Aether را انتخاب کنید.",
+  "The first connect on a hard network can take several minutes: Psiphon has to fetch its own settings before it can use the routes that work there. Later connects are much faster.":
+    "اولین اتصال روی یک شبکهٔ سخت می‌تواند چند دقیقه طول بکشد: سایفون باید اول تنظیمات خودش را بگیرد تا بتواند از مسیرهایی که آنجا کار می‌کنند استفاده کند. اتصال‌های بعدی خیلی سریع‌ترند.",
   "Under Psiphon the endpoint scanner, the pinned endpoint and the transport choice do nothing — Psiphon finds its own route.":
     "زیر سایفون، پویشگر نقطهٔ پایانی، نقطهٔ پایانی ثابت‌شده و انتخاب ترابرد هیچ کاری نمی‌کنند — سایفون مسیر خودش را پیدا می‌کند.",
 
@@ -355,9 +357,17 @@ const FA: Record<string, string> = {
   "Stop searching": "توقف جستجو",
   "Tries each way out in turn and keeps the first that carries traffic. Singles first, pairs only if none of them get out.":
     "هر راه خروج را به‌ترتیب امتحان می‌کند و اولی که ترافیک حمل کند نگه می‌دارد. اول تک‌ها، و جفت‌ها فقط اگر هیچ‌کدام بیرون نرفت.",
-  "Each one gets up to 90 seconds. Stopping takes effect after the current attempt.":
-    "به هرکدام تا ۹۰ ثانیه فرصت داده می‌شود. توقف بعد از تلاش فعلی اعمال می‌شود.",
+  "each carrier is given the time it needs. Stopping takes effect after the current attempt.":
+    "به هر حامل همان‌قدر که لازم دارد وقت داده می‌شود. توقف بعد از تلاش فعلی اعمال می‌شود.",
+  "Worst case": "بدترین حالت",
+  "minutes, if nothing gets out at all — and seconds when the first one does.":
+    "دقیقه، اگر هیچ راهی بیرون نرود — و چند ثانیه، وقتی اولی جواب بدهد.",
   "carrying traffic": "در حال حمل ترافیک",
+  "did not connect within its own deadline": "در مهلت خودش وصل نشد",
+  "connected, but nothing made the round trip through it":
+    "وصل شد، ولی هیچ درخواستی از آن رد نشد و برنگشت",
+  "stopped without saying why": "بدون گفتن دلیل متوقف شد",
+  "the search was stopped": "جستجو متوقف شد",
   "Nothing got out. Every way out was tried; the list above says how each one failed.":
     "هیچ‌چیز بیرون نرفت. همهٔ راه‌های خروج امتحان شد؛ فهرست بالا می‌گوید هرکدام چطور شکست خورد.",
 

--- a/src/features/Advanced.tsx
+++ b/src/features/Advanced.tsx
@@ -17,7 +17,9 @@ import {
   carriersAvailable,
   fetchBridges,
   isDesktopRuntime,
+  getCoreStatus,
   lanShareStatus,
+  probeLatency,
   psiphonStatus,
   saveReport,
   setLanShare,
@@ -26,7 +28,8 @@ import {
   stopCore,
 } from "@/core/api";
 import {
-  ATTEMPT_CAP_MS, isImpossible, searchOrder, type SearchAttempt,
+  SETTLE_POLL_MS, attemptCapMs, isImpossible, searchBudgetMs, searchOrder, verdictFor,
+  type SearchAttempt,
 } from "./carrierSearch";
 import { NumberField, Row, RulesField, Seg, TextField } from "./panels";
 import { Chain } from "./Chain";
@@ -37,7 +40,8 @@ import { transportName } from "./Simple";
 // that. The same text is installed beside the executable under licences/.
 import notices from "../../THIRD_PARTY_NOTICES.md?raw";
 import {
-  ENDPOINT_MODES, carrierChainHas, carrierChainLabel, carrierChainLast, isLoneAether, type CarrierKind,
+  ENDPOINT_MODES, carrierChainHas, carrierChainLabel, carrierChainLast, isLoneAether,
+  type CarrierKind,
   type ConnectionProfile, type LanSettings, type CoreLogEvent, type CoreProbe, type CoreSnapshot,
 } from "@/types";
 
@@ -604,6 +608,76 @@ function BridgeFetch({ onFetched }: { onFetched: (lines: string[]) => void }) {
  * the single control aimed at the person with no idea what to choose is the
  * whole feature failing quietly.
  */
+/**
+ * Waits for one attempt to reach an answer, and says what the answer was.
+ *
+ * `null` means it is carrying traffic; a string is the reason it is not.
+ *
+ * Asked of the supervisor rather than inferred from `start_core` returning.
+ * That call answers at two different moments — after a hop is carrying traffic
+ * on the chained path, and the instant the process is spawned on the engine
+ * path — so treating it as the verdict settled the whole sweep on Aether alone
+ * wherever the engine binary merely existed, and the chained orderings below it
+ * were never tried at all.
+ *
+ * The cap is a safety net and not the deadline: each carrier fails its own
+ * attempt at its own deadline and says why, which is the answer worth showing.
+ * It is enforced by stopping rather than by walking away — the supervisor
+ * checks between hops and unwinds, so a timed-out attempt leaves nothing
+ * running.
+ */
+async function settle(
+  cap: number,
+  deadline: number,
+  cancelled: () => boolean,
+  t: (key: string) => string,
+): Promise<string | null> {
+  // Remembered so the timeout can say which half of the wait ran out. "Did not
+  // connect" and "connected and then carried nothing" send someone to look in
+  // completely different places.
+  let everConnected = false;
+  while (!cancelled()) {
+    // A status call that fails says nothing about the attempt — the window is
+    // closing, or the backend is busy — so it waits rather than convicting.
+    const snapshot = await getCoreStatus().catch(() => null);
+    if (snapshot) {
+      const verdict = verdictFor(snapshot.state);
+      if (verdict === "connected") {
+        everConnected = true;
+        // The last question, and the only one that is asked of the route rather
+        // than of the processes making it: has a request been through it and
+        // come back? A carrier that finishes its handshake and then carries
+        // nothing is the worst thing a search can settle on — it looks like
+        // success on every screen and fails everything the person then tries.
+        //
+        // `null` is not yet a verdict. A route measured in its first moment is
+        // often still settling, so it goes round again until the cap.
+        if ((await probeLatency().catch(() => null)) !== null) return null;
+      } else if (verdict === "failed") {
+        // The backend's own words when it has them. Those arrive in English
+        // from the supervisor, as every other failure on this list does.
+        return snapshot.lastError ?? t("stopped without saying why");
+      }
+    }
+    if (Date.now() >= deadline) {
+      // The seconds go in brackets at the end rather than inside the sentence:
+      // there is no interpolation in the dictionary, and a number spliced into
+      // the middle of a Persian sentence would have to be a different sentence.
+      const spent = ` (${Math.round(cap / 1000)}s)`;
+      return everConnected
+        ? t("connected, but nothing made the round trip through it") + spent
+        : t("did not connect within its own deadline") + spent;
+    }
+    await new Promise((resume) => window.setTimeout(resume, SETTLE_POLL_MS));
+  }
+  return t("the search was stopped");
+}
+
+/** `m:ss`, for a wait measured in minutes rather than hours. */
+function formatDuration(seconds: number): string {
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
 function WayOutSearch({
   profile,
   onChange,
@@ -621,6 +695,18 @@ function WayOutSearch({
   // rather than after all nine. Held in a ref because the running loop closes
   // over its own render's state and would never see a change to it.
   const cancelled = useRef(false);
+  // A clock, because the waits are now as long as the carriers themselves need
+  // and minutes of silence is what people give up on. A screen that is visibly
+  // counting is a screen that is visibly working.
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt === null) return;
+    const tick = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(tick);
+  }, [startedAt]);
+
+  const order = useMemo(() => searchOrder(available), [available]);
 
   /**
    * Tries each way out in turn and keeps the first that carries traffic.
@@ -634,7 +720,8 @@ function WayOutSearch({
     setSearching(true);
     setSearchFailure(null);
     cancelled.current = false;
-    const order = searchOrder(available);
+    setStartedAt(Date.now());
+    setNow(Date.now());
     setAttempts(order.map((candidate) => ({ chain: candidate, outcome: "pending" })));
 
     // Whatever is up now is in the way: the supervisor refuses a second
@@ -648,18 +735,32 @@ function WayOutSearch({
         current.map((entry, at) => (at === index ? { ...entry, outcome: "trying" } : entry)),
       );
 
-      // The cap is enforced by stopping rather than by walking away: the
-      // supervisor checks between hops and unwinds, so a timed-out attempt
-      // leaves no process behind.
-      const timer = window.setTimeout(() => void stopCore().catch(() => {}), ATTEMPT_CAP_MS);
+      // One deadline for the whole attempt, armed before it starts. The two
+      // paths spend it in different places -- a chained `start_core` blocks
+      // inside the call while the engine path returns at once and does its
+      // waiting in `settle` -- so anchoring both to the same moment is what
+      // keeps an attempt from being given the budget twice.
+      const cap = attemptCapMs(candidate, profile);
+      const deadline = Date.now() + cap;
+      const net = window.setTimeout(() => void stopCore().catch(() => {}), cap);
       let failure: string | null = null;
       try {
         await startCore({ ...profile, carriers: candidate });
+        // And then wait for it to actually carry traffic. `start_core` answers
+        // at two different moments: on the chained path it has already waited
+        // for a hop to carry traffic, and on the engine path it returns the
+        // instant the process is spawned. Only the snapshot tells them apart.
+        failure = await settle(cap, deadline, () => cancelled.current, t);
       } catch (error) {
         failure = error instanceof Error ? error.message : String(error);
       } finally {
-        window.clearTimeout(timer);
+        window.clearTimeout(net);
       }
+
+      // Stopped part-way through this attempt. It has no verdict, so it keeps
+      // none: marking it failed would put a carrier on the list as ruled out
+      // here when all that happened is that nobody waited for it.
+      if (cancelled.current) break;
 
       if (!failure) {
         setAttempts((current) =>
@@ -689,7 +790,11 @@ function WayOutSearch({
       );
     }
     setSearching(false);
+    setStartedAt(null);
   };
+
+  const elapsed = startedAt === null ? 0 : Math.max(0, Math.round((now - startedAt) / 1000));
+  const budgetMinutes = Math.ceil(searchBudgetMs(order, profile) / 60_000);
   return (
     <Card className="border-primary/40 bg-primary/[0.06]">
       <CardHeader className="pb-3">
@@ -713,11 +818,22 @@ function WayOutSearch({
           >
             {searching ? t("Stop searching") : t("Find one that works")}
           </Button>
+          {/* The real number, before anyone commits to waiting for it. Each
+              carrier is given the time it actually needs to answer, which is
+              what makes the worst case long — and someone who was told that
+              waits, where someone who was not stops at two minutes believing
+              the app has hung. */}
           {searching ? (
             <p className="text-[12.5px] leading-snug text-muted-foreground">
-              {t("Each one gets up to 90 seconds. Stopping takes effect after the current attempt.")}
+              {t("Searching")} · {formatDuration(elapsed)} ·{" "}
+              {t("each carrier is given the time it needs. Stopping takes effect after the current attempt.")}
             </p>
-          ) : null}
+          ) : (
+            <p className="text-[12.5px] leading-snug text-muted-foreground">
+              {t("Worst case")} {budgetMinutes}{" "}
+              {t("minutes, if nothing gets out at all — and seconds when the first one does.")}
+            </p>
+          )}
         </div>
 
         {searchFailure ? (
@@ -937,6 +1053,16 @@ function CarrierPanel({
                 anything here. */}
             <p className="pt-2 text-[12.5px] leading-snug text-muted-foreground">
               {t("Under Psiphon the endpoint scanner, the pinned endpoint and the transport choice do nothing — Psiphon finds its own route.")}
+            </p>
+            {/* Said before it happens rather than left to be met as a hang. A
+                fresh Psiphon data directory has no tactics, so the path that
+                matters on a filtered network — in-proxy, which is brokered over
+                WebRTC before any tunnel exists — is not available yet, and
+                reaching it can take tunnel-core's full establish window. That
+                is minutes of a screen doing nothing visible, and minutes of
+                silence is what people stop. */}
+            <p className="pt-1 text-[12.5px] leading-snug text-muted-foreground">
+              {t("The first connect on a hard network can take several minutes: Psiphon has to fetch its own settings before it can use the routes that work there. Later connects are much faster.")}
             </p>
           </>
         ) : null}

--- a/src/features/carrierSearch.test.ts
+++ b/src/features/carrierSearch.test.ts
@@ -1,16 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isImpossible, searchOrder } from "./carrierSearch.ts";
+import { attemptCapMs, isImpossible, searchBudgetMs, searchOrder, verdictFor } from "./carrierSearch.ts";
 import { carrierChainLabel, type CarrierKind } from "../types.ts";
 
 const label = (chain: { first: CarrierKind; second: CarrierKind | null }) =>
   carrierChainLabel(chain, (kind) => kind);
 
 test("every single is tried before any chain", () => {
-  // Nine attempts at up to ninety seconds is a quarter of an hour, so the
-  // cheap answer has to come first. Chains exist for the network where no
-  // single answers at all.
+  // A sweep where nothing answers runs for the better part of an hour, because
+  // every carrier is given the time it actually needs -- so the cheap answer
+  // has to come first. Chains exist for the network where no single answers at
+  // all.
   const order = searchOrder(null);
   const firstChain = order.findIndex((chain) => chain.second !== null);
   const lastSingle = order.reduce((last, chain, index) => (chain.second === null ? index : last), -1);
@@ -63,4 +64,96 @@ test("the refusals that mean never are told apart from the ones that mean not no
   );
   assert.ok(!isImpossible("Aether did not connect in 30s"));
   assert.ok(!isImpossible("Psiphon reported a listener and then stopped carrying"));
+});
+
+test("no attempt is cut before the carrier it is waiting for can answer", () => {
+  // The deadlines each carrier already enforces on itself, in the backend.
+  // A cap below any of these does not bound the search, it replaces that
+  // deadline -- which is how a Psiphon that needed its first-run tactics fetch
+  // could never be found by the feature that exists to find it.
+  const profile = { scanMode: "balanced", startupSecs: 30 };
+  const OWN_DEADLINE_MS: Record<CarrierKind, number> = {
+    // The engine scans to prober.rs's own deadline (balanced: 120s + 20s
+    // quiet) and only then starts the handshake --startup-secs bounds.
+    aether: 140_000 + 30_000,
+    psiphon: 315_000, // ESTABLISH_TIMEOUT, psiphon.rs
+    tor: 180_000, // BOOTSTRAP_TIMEOUT, tor.rs
+  };
+  for (const chain of searchOrder(null)) {
+    const needed = (OWN_DEADLINE_MS[chain.first] ?? 0)
+      + (chain.second ? OWN_DEADLINE_MS[chain.second] : 0);
+    assert.ok(attemptCapMs(chain, profile) >= needed, `${label(chain)} is cut short`);
+  }
+});
+
+test("a chain waits for its hops added up, not for the longest of them", () => {
+  // They start one after another: each has to be carrying traffic before the
+  // next one begins.
+  const tor = attemptCapMs({ first: "tor", second: null });
+  const psiphon = attemptCapMs({ first: "psiphon", second: null });
+  assert.equal(attemptCapMs({ first: "tor", second: "psiphon" }), tor + psiphon);
+  assert.ok(attemptCapMs({ first: "tor", second: "psiphon" }) > Math.max(tor, psiphon));
+});
+
+test("the budget shown to the user is every attempt the sweep would make", () => {
+  const order = searchOrder(null);
+  assert.equal(
+    searchBudgetMs(order),
+    order.reduce((total, chain) => total + attemptCapMs(chain), 0),
+  );
+  // One carrier installed means one attempt, and the budget is that attempt.
+  assert.equal(searchBudgetMs(searchOrder(["tor"])), attemptCapMs({ first: "tor", second: null }));
+});
+
+test("a process that has started is not a carrier that is carrying traffic", () => {
+  // `start_core` returns the instant the engine is spawned, with the snapshot
+  // reading "starting" and the search still ahead of it. Reading that as
+  // success settled every sweep on Aether alone and never reached the chains.
+  assert.equal(verdictFor("starting"), "waiting");
+  assert.equal(verdictFor("scanning"), "waiting");
+  assert.equal(verdictFor("connecting"), "waiting");
+  // The engine between its own attempts is still trying, not yet an answer.
+  assert.equal(verdictFor("reconnecting"), "waiting");
+
+  assert.equal(verdictFor("connected"), "connected");
+  assert.equal(verdictFor("error"), "failed");
+  assert.equal(verdictFor("idle"), "failed");
+});
+
+test("how hard the engine was asked to look decides how long it is given", () => {
+  // `thorough` scans for more than seven times as long as `turbo`. A cap that
+  // ignores that fails the mode someone chose precisely because the network is
+  // hard.
+  const turbo = attemptCapMs({ first: "aether", second: null }, { scanMode: "turbo", startupSecs: 30 });
+  const balanced = attemptCapMs({ first: "aether", second: null }, { scanMode: "balanced", startupSecs: 30 });
+  const thorough = attemptCapMs({ first: "aether", second: null }, { scanMode: "thorough", startupSecs: 30 });
+  assert.ok(turbo < balanced, `${turbo} < ${balanced}`);
+  assert.ok(balanced < thorough, `${balanced} < ${thorough}`);
+
+  // `--startup-secs` wraps the handshake *after* a gateway is chosen, so it
+  // adds to the scan rather than containing it.
+  const patient = attemptCapMs({ first: "aether", second: null }, { scanMode: "balanced", startupSecs: 120 });
+  assert.equal(patient - balanced, 90_000);
+
+  // A mode this build has not heard of gets the default window, not the
+  // shortest one.
+  assert.equal(
+    attemptCapMs({ first: "aether", second: null }, { scanMode: "from-a-newer-build", startupSecs: 30 }),
+    balanced,
+  );
+});
+
+test("only the engine's share of a chain moves with the scan mode", () => {
+  // Psiphon and Tor do not scan for a Cloudflare gateway, so their deadlines
+  // are unaffected by how hard Aether was told to look.
+  const turbo = { scanMode: "turbo", startupSecs: 30 };
+  const thorough = { scanMode: "thorough", startupSecs: 30 };
+  assert.equal(
+    attemptCapMs({ first: "psiphon", second: null }, turbo),
+    attemptCapMs({ first: "psiphon", second: null }, thorough),
+  );
+  assert.ok(
+    attemptCapMs({ first: "psiphon", second: "aether" }, thorough)
+      > attemptCapMs({ first: "psiphon", second: "aether" }, turbo),
+  );
 });

--- a/src/features/carrierSearch.ts
+++ b/src/features/carrierSearch.ts
@@ -1,4 +1,4 @@
-import type { CarrierChain, CarrierKind } from "../types.ts";
+import type { CarrierChain, CarrierKind, CoreState } from "../types.ts";
 
 /**
  * What order to try ways out in, when the user does not know which works.
@@ -55,14 +55,146 @@ export function searchOrder(available: CarrierKind[] | null): CarrierChain[] {
 }
 
 /**
+ * How long each carrier is allowed to take, matching the deadline it already
+ * enforces on itself in the backend.
+ *
+ * These are mirrors, and the backend is the original:
+ *
+ * | carrier | constant                              | where                   |
+ * | ---     | ---                                   | ---                     |
+ * | aether  | `AETHER_HOP_TIMEOUT`                  | `core_supervisor.rs`    |
+ * | psiphon | `ESTABLISH_TIMEOUT`                   | `psiphon.rs`            |
+ * | tor     | `BOOTSTRAP_TIMEOUT`                   | `tor.rs`                |
+ *
+ * A cap shorter than these does not bound the search -- it *replaces* the
+ * deadline the carrier was given, and always wins. The single 90s cap this
+ * replaced was shorter than all three: every attempt was cut before the thing
+ * it was waiting for could answer, so a Psiphon that needed its first-run
+ * tactics fetch (up to tunnel-core's full 300s window, which is why
+ * `ESTABLISH_TIMEOUT` is what it is) could never be found by the one feature
+ * aimed at the person who does not know what works.
+ */
+const CARRIER_DEADLINE_MS: Record<CarrierKind, number> = {
+  // Replaced per attempt by `aetherDeadlineMs`, which knows how hard this
+  // profile asked the engine to look. This is the default mode's figure, for a
+  // caller that has no profile to ask.
+  aether: 190_000,
+  psiphon: 315_000,
+  tor: 180_000,
+};
+
+/**
+ * What the engine's own gateway scan is allowed to take, by scan mode.
+ *
+ * `overall_deadline` plus `quiet_after_first` from the engine's `prober.rs` --
+ * the second is the extra it spends after its first hit before settling. Not
+ * one number for every mode: `thorough` looks for more than seven times as long
+ * as `turbo`, and a cap that ignores that fails the mode chosen precisely
+ * because the network is hard.
+ */
+const SCAN_DEADLINE_MS: Record<string, number> = {
+  turbo: 45_000,
+  balanced: 140_000,
+  thorough: 330_000,
+  stealth: 205_000,
+  ironclad: 195_000,
+};
+
+/**
+ * How long the engine may take, for the profile it is actually being run with.
+ *
+ * `startupSecs` is added rather than assumed to bound the whole thing:
+ * `--startup-secs` wraps only the tunnel handshake *after* a gateway has been
+ * chosen, so it sits on top of the scan rather than containing it.
+ */
+export function aetherDeadlineMs(profile: SearchProfile): number {
+  const scan = SCAN_DEADLINE_MS[profile.scanMode] ?? SCAN_DEADLINE_MS.balanced;
+  return scan + profile.startupSecs * 1000;
+}
+
+/** What the search needs to know about a profile to size its waits. */
+export interface SearchProfile {
+  scanMode: string;
+  startupSecs: number;
+}
+
+/**
+ * Spawning the process, staging its files, reading Tor's control port: work
+ * that happens before any carrier's own deadline starts running.
+ */
+const HOP_OVERHEAD_MS = 15_000;
+
+/**
  * How long to give one attempt before moving on.
  *
- * Long enough for a legitimately slow Psiphon behind a slow Tor, short enough
- * that the whole sweep stays bounded. Enforced by stopping the connection
- * rather than by abandoning it: the supervisor checks between hops and unwinds,
- * so a timed-out attempt leaves nothing running.
+ * The hops of a chain start one after another -- each has to be carrying
+ * traffic before the next one begins -- so the wait is their deadlines added
+ * up, not the longest of them.
+ *
+ * A safety net rather than the deadline itself: the backend fails the attempt
+ * at its own deadline and returns a reason, which is the ordinary path. This
+ * only fires when nothing came back at all. Enforced by stopping the
+ * connection rather than by walking away: the supervisor checks between hops
+ * and unwinds, so a timed-out attempt leaves nothing running.
  */
-export const ATTEMPT_CAP_MS = 90_000;
+export function attemptCapMs(chain: CarrierChain, profile?: SearchProfile): number {
+  const hops: CarrierKind[] = chain.second ? [chain.first, chain.second] : [chain.first];
+  return hops.reduce((total, hop) => {
+    const own = hop === "aether" && profile
+      ? aetherDeadlineMs(profile)
+      : CARRIER_DEADLINE_MS[hop];
+    return total + own + HOP_OVERHEAD_MS;
+  }, 0);
+}
+
+/**
+ * The longest the whole sweep can take, for the sentence that says so before
+ * anyone starts one.
+ *
+ * Worth showing rather than hiding. It is long -- every carrier being given the
+ * time it actually needs is what makes it long -- and someone who knows that is
+ * someone who waits rather than someone who stops at two minutes believing the
+ * app has hung. See "Show a clock and ask for patience".
+ */
+export function searchBudgetMs(order: CarrierChain[], profile?: SearchProfile): number {
+  return order.reduce((total, chain) => total + attemptCapMs(chain, profile), 0);
+}
+
+/** How often to ask the supervisor what the current attempt is doing. */
+export const SETTLE_POLL_MS = 500;
+
+/**
+ * What one attempt's state means to the search.
+ *
+ * `start_core` returning is not the answer, and reading it as one is what this
+ * exists to fix. On the chained path it blocks until a hop is carrying traffic,
+ * so returning does mean connected -- but on the engine path it returns as soon
+ * as the process is spawned, with the snapshot reading "starting" and the
+ * search still ahead of it. Taking that as success meant the sweep settled on
+ * Aether alone on the strength of a process having started, and the six chained
+ * orderings below it were never reached on any machine where the engine binary
+ * exists.
+ *
+ * "reconnecting" is the engine between its own attempts, which is still trying
+ * and not yet an answer. "error" is where it stops for good -- `give_up` and
+ * the kill-switch hold both land there -- and "idle" is a session that was
+ * released underneath us, which is the Stop button or a supervisor that has let
+ * go either way.
+ */
+export type AttemptVerdict = "waiting" | "connected" | "failed";
+
+export function verdictFor(state: CoreState): AttemptVerdict {
+  switch (state) {
+    case "connected":
+      return "connected";
+    case "error":
+    case "idle":
+    case "stopped":
+      return "failed";
+    default:
+      return "waiting";
+  }
+}
 
 /** What happened to one attempt, for the list the user watches.
  *


### PR DESCRIPTION
Five faults, found by checking the Android client's 1.5.0–1.6.1 notes against
this tree, and then against the pinned engine source.

**Deliberately carries no version bump**, so merging this publishes nothing —
the gate finds `v1.9.0` already released and skips the build entirely. The bump
to `1.9.1` should follow the two smoke tests at the bottom, not precede them.

## What was wrong

**The search settled on Aether alone, always.** `start_core` answers at two
different moments: after a hop is carrying traffic on the chained path, and the
instant the process is spawned on the engine path. Reading the return as the
verdict meant the sweep stopped at its first candidate on the strength of a
process having started — the six chained orderings below it were never reached
on any machine where the engine binary exists, which is all of them.

**A chained engine ran with whatever framing the profile held.** `Routes` hides
the transport picker when the engine is not alone, but hiding a control does not
clear what it last stored. WireGuard chosen while Aether was on its own stayed
in the profile, and H3 and WireGuard are datagrams a SOCKS5 hop does not carry —
so the engine did not fall back to something slower, it dialled the gateway
directly, past the carrier the chain existed for. Now pinned in the supervisor,
where the chain is built.

**Every attempt was cut before its carrier could answer.** One flat 90s cap,
against deadlines of 150s, 315s and 180s that each carrier already enforces on
itself. Psiphon was the worst of it: a first run has no tactics, so reaching
in-proxy can take tunnel-core's full 300s window.

**The hop timeout was one number for five scan modes**, on the belief that
`startup_secs` governed the scan. It does not — `AETHER_MASQUE_STARTUP_SECS`
wraps only the handshake after a gateway is chosen. The scan runs to
`prober.rs`'s own deadline, 45s in turbo to 330s in thorough.

**A route counted as working before anything went through it.** `settle` now
asks `probe_latency` for a real round trip.

Also: the worst case is about an hour now, so the screen says the number up
front and counts a clock; Psiphon says the first connect can take minutes; and
debug builds mirror diagnostics to a file, since a crash takes the in-memory
buffer with it.

## Two engine facts worth knowing, read from `v1.8.0-whiteaesther.1`

Both recorded in `CARRIER-CHAINING.md`:

- `upstream.rs` caches `AETHER_UPSTREAM` in a `OnceLock`. Harmless here only
  because every connect spawns a fresh process.
- reqwest is built without the `socks` feature, so `account.rs::http_client`
  fails to attach the proxy, logs a warning, and **builds the client without
  one**. A registration inside a chain is not refused — it goes out unproxied.
  The `aether_identity_exists` guard is what stands between a user and that, so
  it stays until the engine gains the feature or refuses the dial itself.

## Verified

178 backend and 58 frontend tests; `tsc --noEmit` clean; release build clean
(the one `field socks is never read` warning predates this branch). In the
running UI: the budget tracks the scan mode (60 → 75 minutes on thorough), the
new Psiphon note renders, the transport panel collapses when chained, the search
loop completes without hanging, and both new strings render in Persian.

## Not verified — please run before bumping the version

Both need a live network, and both are the changes that matter most:

1. **Aether alone** → run the search. The clock should count, and it should
   settle on Aether *after* it actually connects, not immediately.
2. **Choose WireGuard, then put Psiphon in front** → connect. Diagnostics must
   contain: `Aether runs as wireguard on its own; behind another carrier it is
   pinned to MASQUE H2…`

If `settle` is wrong, the failure mode is that "find one that works" reports
nothing works on a network where something does — to the person least able to
tell. That is why this waits for a real connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
