### PR TITLE
1.9.1 — the search waits for an answer, and a chained engine keeps its cover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whiteaesther",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "prerelease": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "whiteaesther"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "getrandom 0.3.4",
  "rustls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whiteaesther"
-version = "1.9.0"
+version = "1.9.1"
 description = "Cross-platform desktop client for the Aether connection core"
 authors = ["WhiteDNS"]
 # WhiteAesther links the Aether engine, which is AGPL-3.0, so it is a derivative

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "WhiteAesther",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "identifier": "com.whitedns.whiteaesther",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump only — four lines across `package.json`, `tauri.conf.json`,
`Cargo.toml` and `Cargo.lock`. The work itself landed in #42.

**Merging this publishes `v1.9.1` as a pre-release.** `prerelease` stays `true`
in package.json, so GitHub keeps it out of `releases/latest`, which is what the
in-app update check reads — nobody on 1.9.0 is offered it until it is promoted
with `gh release edit v1.9.1 --prerelease=false`.

## What is in it

All five fixes from #42, each verified against a live network on Windows and not
only by tests:

- **The search never got past its first candidate.** Rigged Aether to be
  impossible; the sweep now spends that candidate's full budget, gives up at the
  second it should (170s: 140s scan + 15s startup + 15s overhead) and goes on to
  Psiphon. On 1.9.0 it reports that candidate connected one second after the
  click and stops there.
- **A chained engine is pinned to MASQUE H2.** Chose WireGuard while Aether was
  alone, then put Psiphon in front — the engine dialled out through Psiphon's
  SOCKS5 over TCP, where before it would have gone straight to the gateway past
  the hop the chain exists for.
- **Per-carrier attempt caps**, taken from the deadline each carrier already
  enforces on itself, instead of one flat 90s that was shorter than all of them.
- **The engine's hop timeout follows its scan mode**, which runs from 45s in
  turbo to 330s in thorough.
- **A route counts only after a round trip through it** — confirmed in the
  routing log as the probe left via Psiphon.

Plus a clock and an honest worst-case figure on the search, a note that
Psiphon's first connect on a hard network takes minutes, and a debug-only
diagnostics log file.

## Checks

178 backend and 58 frontend tests; five-platform CI green on #42; `--locked`
build verified after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
